### PR TITLE
themeisle-sdk namespace registration has been removed.

### DIFF
--- a/woocommerce-product-addon.php
+++ b/woocommerce-product-addon.php
@@ -44,7 +44,7 @@ add_filter(
 add_filter(
 	'themesle_sdk_namespace_' . md5( __FILE__ ),
 	function () {
-		return 'sparks';
+		return 'ppom';
 	}
 );
 

--- a/woocommerce-product-addon.php
+++ b/woocommerce-product-addon.php
@@ -41,13 +41,6 @@ add_filter(
 	}
 );
 
-add_filter(
-	'themesle_sdk_namespace_' . md5( __FILE__ ),
-	function () {
-		return 'ppom';
-	}
-);
-
 /*
  * plugin localization being initiated here
  */


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
I think we don't need namespace registration for themeisle-sdk since that's a free plugin.

I've reviewed Otter free and Neve Lite, both of them doesn't contains the name space. That's why I've removed that.