### PR TITLE
Fix for issue that occurs conditionally during saving/updating PPOM Group

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -203,7 +203,7 @@ function ppom_admin_save_form_meta() {
     $enable_ajax_validation = "";
 
     $ppom_meta    = isset( $_REQUEST['ppom_meta'] ) ? $_REQUEST['ppom_meta'] : $_REQUEST['ppom'];
-    $product_meta = apply_filters( 'ppom_meta_data_saving', $ppom_meta, $productmeta_id );
+    $product_meta = apply_filters( 'ppom_meta_data_saving', (array)$ppom_meta, $productmeta_id );
     $product_meta = ppom_sanitize_array_data( $product_meta );
     $product_meta = json_encode( $product_meta );
 
@@ -262,7 +262,7 @@ function ppom_admin_save_form_meta() {
 
     $ppom_id = $wpdb->insert_id;
 
-    $product_meta = apply_filters( 'ppom_meta_data_saving', $ppom, $ppom_id );
+    $product_meta = apply_filters( 'ppom_meta_data_saving', (array)$ppom, $ppom_id );
     // Updating PPOM Meta with ppom_id in each meta array
     ppom_admin_update_ppom_meta_only( $ppom_id, $product_meta );
 
@@ -342,7 +342,7 @@ function ppom_admin_update_form_meta() {
     global $wpdb;
 
     $ppom_meta    = isset( $_REQUEST['ppom_meta'] ) ? $_REQUEST['ppom_meta'] : $_REQUEST['ppom'];
-    $product_meta = apply_filters( 'ppom_meta_data_saving', $ppom_meta, $productmeta_id );
+    $product_meta = apply_filters( 'ppom_meta_data_saving', (array)$ppom_meta, $productmeta_id );
     $product_meta = ppom_sanitize_array_data( $product_meta );
     $product_meta = json_encode( $product_meta );
     // ppom_pa($product_meta); exit;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
If PPOM Pro is enabled; removing all fields of the group or creating a new group without having fields was not possible. That's fixed.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

**Case 1 (create PPOM group without any field)**
- Create a new PPOM group
- Do not add any field
- Try to save, make sure it's saved as successfully.

**Case 2 (make sure to able to remove all fields of a group)**
- Try to edit a PPOM group that has some fields
- Try to remove all fields and save the group.
- Make sure the PPOM Group is updated and all fields could be deleted as successfully.

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/2
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->