### PR TITLE
fix for null argument on an array_filter call

### DIFF
--- a/classes/ppom.class.php
+++ b/classes/ppom.class.php
@@ -208,7 +208,7 @@ class PPOM_Meta {
 		}
 
 		// Filter fields which are active only
-		$meta_fields = array_filter( $meta_fields, function ( $field ) {
+		$meta_fields = array_filter( (array) $meta_fields, function ( $field ) {
 			return ! isset( $field['status'] ) || $field['status'] == 'on';
 		} );
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
A fatal error / PHP warning was happening due to a null argument passing to array_filter. That has been fixed with array casting.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Install the plugin (v30.1.2) (that one does not contains the https://github.com/Codeinwp/woocommerce-product-addon/pull/21 PR)
2. Attach a few products to the demo PPOM Meta Group or create a new PPOM Meta Group and attach products to that.
3. Remove all fields of the PPOM Meta Group
4. Visit single product page of the attached products, should work well without fatal error or the PHP error that defined on the [issue](https://github.com/Codeinwp/woocommerce-product-addon/issues/5)

<!-- Issues that this pull request closes. -->
Closes #5 .
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->