### PR TITLE
Fix/do not allow removing admin permission

### DIFF
--- a/backend/assets/settings.js
+++ b/backend/assets/settings.js
@@ -138,15 +138,24 @@ jQuery(function($) {
     **/
     $('.nmsf-multiselect-js').select2();
 
-    $('#ppom_permission_mfields').on('select2:unselecting', function(e){
-        if( typeof e.params.args === 'undefined' ) {
-            return;
+    const permissionField = $('#ppom_permission_mfields');
+
+    $(document).ready(function(){
+        if( permissionField.val().length === 0 ) {
+            permissionField.val(['administrator']);
+            permissionField.trigger('change');
         }
 
-        const element = $(e.params.args.data.element);
-        if( element.prop('value') === 'administrator' ) {
-            alert(nmsf_vars.administrator_role_cannot_be_removed);
-            e.preventDefault();
-        }
+        permissionField.on('select2:unselecting', function(e){
+            if( typeof e.params.args === 'undefined' ) {
+                return;
+            }
+
+            const element = $(e.params.args.data.element);
+            if( element.prop('value') === 'administrator' ) {
+                alert(nmsf_vars.administrator_role_cannot_be_removed);
+                e.preventDefault();
+            }
+        });
     });
 });

--- a/backend/assets/settings.js
+++ b/backend/assets/settings.js
@@ -137,4 +137,16 @@ jQuery(function($) {
         Select2 Init
     **/
     $('.nmsf-multiselect-js').select2();
+
+    $('#ppom_permission_mfields').on('select2:unselecting', function(e){
+        if( typeof e.params.args === 'undefined' ) {
+            return;
+        }
+
+        const element = $(e.params.args.data.element);
+        if( element.prop('value') === 'administrator' ) {
+            alert(nmsf_vars.administrator_role_cannot_be_removed);
+            e.preventDefault();
+        }
+    });
 });

--- a/backend/settings-panel.class.php
+++ b/backend/settings-panel.class.php
@@ -812,7 +812,8 @@ class PPOM_SettingsFramework {
 			case 'nmsf-settings-panel':
 
 				$localize_data = [
-					'migrate_back_msg' => __( 'Are you sure?', $this->get_config( 'ppom' ) )
+					'migrate_back_msg' => __( 'Are you sure?', $this->get_config( 'ppom' ) ),
+					'administrator_role_cannot_be_removed' => esc_html__( 'The administrator role cannot be removed.', $this->get_config( 'ppom' ) )
 				];
 
 				break;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Before this PR, removing "administrator" role from **PPOM Permissions** was possible. I've restricted that with that PR.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Vist PPOM Settings on WP Admin -> WooCommerce -> Settings -> PPOM Settings -> PPOM -> General Settings
- Try to remove "Administrator" from **PPOM Permissions**, make sure that role is not removable but others should be removable.
- Also should not be any regression around the settings panel.

<!-- Issues that this pull request closes. -->
Closes #9.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->