### PR TITLE
fix: autoload missing vendor/codeinwp/themeisle-sdk/load.php file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,11 @@
     "require": {
         "codeinwp/themeisle-sdk": "^3.2"
     },
+    "autoload": {
+        "files": [
+            "vendor/codeinwp/themeisle-sdk/load.php"
+        ]
+    },
     "require-dev": {
         "phpunit/phpunit": "^6.5",
         "yoast/phpunit-polyfills": "^1.0"


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Before the PR, `vendor/codeinwp/themeisle-sdk/load.php` file was not initialized as auto. That's added to composer.json

Thus, the fatal error caused by `Call to undefined function tsdk_utmify()` has been fixed.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
**Case 1:**
- Make sure the PPOM Fields dashboard works well (use different theme than Neve also make sure you don't use any Themeisle product during your test.)


**Case 2:**
- Make sure the PPOM Fields dashboard works well with using Neve theme (stable version)


<!-- Issues that this pull request closes. -->
Closes #24 .
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->