### PR TITLE
"Order Again" PPOM compatibility support has been added.

### DIFF
--- a/classes/plugin.class.php
+++ b/classes/plugin.class.php
@@ -319,6 +319,8 @@ class NM_PersonalizedProduct {
 		// delete_option('ppom_demo_meta_installed');
 
 		add_action( 'in_admin_header', 'ppom_hooks_remove_admin_notices', 99 );
+
+		add_filter( 'woocommerce_order_again_cart_item_data', 'ppom_wc_order_again_compatibility', 10, 3 );
 	}
 
 	/*

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -1355,3 +1355,22 @@ function ppom_woocommerce_rename_files( $order_id, $posted_data, $order ) {
 		do_action( 'ppom_after_files_moved', $all_moved_files, $order_id, $order );
 	}
 }
+
+/**
+ * Responsible from the adding a support for Order Again functionality in the WooCommerce My Account -> Order View page.
+ * The method adds PPOM Fields to the given order item from the provided order. (Clones the PPOM data of data order item to the new cart)
+ *
+ * @param  array $cart_item_data Current custom item data.
+ * @param  \WC_Order_Item_Product $item Order Item Product
+ * @param  \WC_Order $order
+ * @return void
+ */
+function ppom_wc_order_again_compatibility( $cart_item_data, $item, $order ) {
+	$ppom_data = $item->get_meta('_ppom_fields');
+
+    if( is_array($ppom_data) && array_key_exists( 'fields', $ppom_data ) ) {
+        $cart_item_data['ppom'] = $ppom_data;
+    }
+
+	return $cart_item_data;
+}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
WooCommerce has the Order Again feature, that allows to customers re-order their previous order easily. Customers can use it in their My Account -> Orders -> Order detail screen. (note for testing: to be able to see Order Again button in the order details, make sure the order status is completed)

Before this PR, PPOM plugin had not any support for the Order Again feature so, when you clicked the Order Again button, the PPOM fields of the Order item were not moving to the Cart page. (if more details needed: see #33 )

With this PR; the compatibility support has been added. From now on, if you clicked the Order Again button for an order that contains some products those has PPOM fields, the previous PPOM field data will be copied to the cart for the all items in the Order.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Make sure all PPOM field data is the same as the first order for all order items. (So, compare the data of the first Order and cloned order (the Order one that was created by using the Order Again feature) )
- Make sure the new order fields are inserted as expected (after you click the Order Again button; go head to the Checkout and complete the checkout, and check the Admin Order screen, make sure all PPOM fields look the same as the original Order.) 

<!-- Issues that this pull request closes. -->
Closes #33 .
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->