### PR TITLE
Fix for PPOM Pro [Image Cropper doesn't work with some AJAX add to cart plugins]

### DIFF
--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -13,8 +13,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Saving Cropped image when posted from product page.
 function ppom_hooks_save_cropped_image( $ppom_fields, $posted_data ) {
 
-	$product_id = $posted_data['add-to-cart'];
-	// var_dump($product_id);
+	if( ! isset( $posted_data['ppom_product_id'] ) ) {
+		return;
+	}
+
+	$product_id = intval( $posted_data['ppom_product_id'] );
+
 	$cropped_fields = ppom_has_field_by_type( $product_id, 'cropper' );
 	if ( empty( $cropped_fields ) ) {
 		return $ppom_fields;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Image Cropper was not working with some AJAX add to cart plugins; when you added a product to the cart, the cropped image was not shown in the cart. That's fixed.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Create a PPOM group and add the Image Cropper field to there and attach a simple product to the PPOM group.
- Visit the product on the front side, add an image, then crop it, then add to the cart.
- Make sure the cropped image also is shown on the cart with the featured product image (so; two images should be shown for the cart item.)
- Repeat the tests by changing the WooCommerce Product Type (attach a variable WC product to the PPOM group instead of a simple one.)
- Repeat the tests by activating some seamless(ajax) add to cart plugins. (https://wordpress.org/plugins/woo-ajax-add-to-cart/ or Neve Pro seamless add to cart feature etc.)

**Test Cases:**
* For the variable products make sure the correct variable is added to the cart. That's valid for the other WC product types. So, we should make sure the correct product added to the cart.
* Image cropper mechanism works as independent from Ajax add-to-cart plugins.
* No regression entire of the Image Cropper (frontend, admin order details page.)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/17.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->