### PR TITLE
fix: wrong apply_filter first argument has been fixed (with keeping t…

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1025,7 +1025,13 @@ function ppom_get_field_meta_by_dataname( $product_id, $original_data_name, $ppo
 		}
 	}
 
-	return apply_filters( 'ppom_get_field_by_dataname__field_meta', $ppom_fields, $field_meta, $original_data_name, $data_name );
+	// Keep the apply_filters call has wrong param (released with v32.0.0)
+	if( ppom_pro_is_installed() && ! ppom_check_pro_compatibility( 'pgfbdfm_wp_filter_param_fix' ) ) {
+		return apply_filters( 'ppom_get_field_by_dataname__field_meta', $ppom_fields, $field_meta, $original_data_name, $data_name );
+	}
+
+	// apply_filters call param fixed with PPOM v32.0.1
+	return apply_filters( 'ppom_get_field_by_dataname__field_meta', $field_meta, $ppom_fields, $original_data_name, $data_name );
 }
 
 // Is PPOM meta has field of specific type

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1026,7 +1026,7 @@ function ppom_get_field_meta_by_dataname( $product_id, $original_data_name, $ppo
 	}
 
 	// Keep the apply_filters call has wrong param (released with v32.0.0)
-	if( ppom_pro_is_installed() && ! ppom_check_pro_compatibility( 'pgfbdfm_wp_filter_param_fix' ) ) {
+	if( ppom_pro_is_installed() && ppom_check_pro_compatibility( 'cond_field_repeat' ) && ! ppom_check_pro_compatibility( 'pgfbdfm_wp_filter_param_fix' ) ) {
 		return apply_filters( 'ppom_get_field_by_dataname__field_meta', $ppom_fields, $field_meta, $original_data_name, $data_name );
 	}
 

--- a/woocommerce-product-addon.php
+++ b/woocommerce-product-addon.php
@@ -32,7 +32,8 @@ define( 'PPOM_TABLE_META', 'nm_personalized' );
 define( 'PPOM_UPLOAD_DIR_NAME', 'ppom_files' );
 define( 'PPOM_UPGRADE_URL', 'https://themeisle.com/plugins/ppom-pro/upgrade/' );
 define( 'PPOM_COMPATIBILITY_FEATURES', [
-	'pro_cond_field_repeat' => true // Compatibility for Conditional Field Repeater feature
+	'pro_cond_field_repeat' => true, // Compatibility for Conditional Field Repeater feature
+	'pgfbdfm_wp_filter_param_fix' => true // Fix for the wrong params of the ppom_get_field_by_dataname__field_meta WP filter.
 ] );
 
 require PPOM_PATH . '/vendor/autoload.php';


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

**technical cause**
before yesterday's PPOM Free release `ppom_get_field_meta_by_dataname` was returning $field_meta with the yesterday's release a new WP filter surrounded the return value of the function.

But I've made a fault on there, I passed wrong variable to the filter in terms of the order ($field_meta should be first but I passed it as the second argument.) On the pro side the logic is fine end returns $field_meta as expected.

**Therefore a regression was occurred:**
* If a website uses only PPOM Free (without Pro); field prices are not passed into cart. (since the WP filter returns the first argument as default if there is no attached add_filter call)
* If the website uses PPOM Free + Pro ; no issues on there since there is an add_filter call on the Pro and that returns $field_meta as expected.

**before the yesterday's release:**
<img width="1140" alt="Screen Shot 2022-10-19 at 14 29 07" src="https://user-images.githubusercontent.com/25361626/196678839-e3994c72-1232-42fe-b14e-4488280d3736.png">

**Once the yesterday's release**
The WP filter **ppom_get_field_by_dataname__field_meta** that released by PPOM Free v32.0.0 had the wrong first param, normally `$field_meta` should be returned from the function but `$field_meta` is not the first param of the function.

**PPOM Free released yesterday**
<img width="1147" alt="Screen Shot 2022-10-19 at 14 24 51" src="https://user-images.githubusercontent.com/25361626/196678355-f13a7a40-72bc-4b6e-a842-0c0f810d3d2d.png">

**Pro released yesterday**
<img width="1383" alt="Screen Shot 2022-10-19 at 14 25 42" src="https://user-images.githubusercontent.com/25361626/196678382-8813588f-1c68-404a-8a44-8dc862edafe0.png">



-----
I've fixed the function param orders with keeping the backward compatibility with the PPOM Pro v25.0.0 that released yesterday.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Conditional repeater feature (if the test matrix has Pro version) should be tested basically
2. Cart page (the field prices(provided by PPOM) should be same as the product page)
3. In the cart page; the field titles should be shown as human readable not as a slug.
4. In admin order page; the field prices should be shown as expected and field titles should be shown as human readable.

The cases in the above should be tested for the following version groups:

**Matrixes**
- PPOM Free (This PR Build) + PPOM Pro v25.0.0 (released yesterday)
- PPOM Free (This PR Build) + PPOM Pro (https://github.com/Codeinwp/ppom-pro/pull/66 PR Build)
- PPOM Free (This PR Build) without PPOM Pro
- PPOM Free (yesteday's release - v32.0.0) + PPOM Pro (https://github.com/Codeinwp/ppom-pro/pull/66 PR Build)

<!-- Issues that this pull request closes. -->
Closes #56, #57.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->