### PR TITLE
[ppom pro] fix price matrix does not work if the field is shown conditionally by the two other fields

### DIFF
--- a/js/ppom-conditions-v2.js
+++ b/js/ppom-conditions-v2.js
@@ -288,6 +288,7 @@ function ppom_check_conditions(data_name, callback) {
 
         let matched = 0;
         var matched_conditions = [];
+        let cond_elements = [];
         for (var t = 1; t <= total_cond; t++) {
 
             const cond_element = jQuery(this).data(`cond-input${t}`);
@@ -300,7 +301,12 @@ function ppom_check_conditions(data_name, callback) {
             // if (cond_element !== data_name) continue;
             is_matched = ppom_compare_values(field_val, cond_val, operator);
             // console.log(`${data_name} TRIGGERS :: ${t} ***** ${element_data_name} ==> field value ${field_val} || cond_valu ${cond_val} || operator ${operator} || Binding ${binding} is_matched=>${is_matched}`);
-            matched = is_matched ? ++matched : matched;
+
+            if(is_matched) {
+                matched = ++matched;
+                cond_elements.push(cond_element);
+            }
+
             matched_conditions[element_data_name] = matched;
             
             event_type = visibility === 'hide' ? 'ppom_field_hidden' : 'ppom_field_shown';
@@ -310,16 +316,18 @@ function ppom_check_conditions(data_name, callback) {
                  (matched_conditions[element_data_name] == total_cond && binding === 'All')
                 ) {
                 
-                if( visibility === 'hide' ){
-                    jQuery(this).addClass(`ppom-locked-${data_name} ppom-c-hide`).removeClass('ppom-c-show');
-                }else{
-                    jQuery(this).removeClass(`ppom-locked-${data_name} ppom-c-hide`);   
-                }
+                // remove/add locked classes for all dependent fields
+                cond_elements.forEach(cond_dataname => {
+                    if( visibility === 'hide' ){
+                        jQuery(this).addClass(`ppom-locked-${cond_dataname} ppom-c-hide`).removeClass('ppom-c-show');
+                    }else{
+                        jQuery(this).removeClass(`ppom-locked-${cond_dataname} ppom-c-hide`);
+                    }
+                });
+
                 if (typeof callback == "function")
                     callback(element_data_name, event_type);
                 // return is_matched;
-
-                
             }
             else if ( ! is_matched || matched_conditions[element_data_name] !== total_cond) {
                 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Before this PR; on the PPOM Pro; the price matrix field price was not added(was added as 0) to the cart if the price matrix is shown as conditionally dependent on two other fields.

If the price matrix field is shown conditionally as dependent on only one field; that was working well. The issue was happening only if the number of the dependencies are **2**

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots
<!-- if applicable -->

### Test instructions
The issue and reproducing steps were explained after the investigations on https://github.com/Codeinwp/ppom-pro/issues/40#issuecomment-1312602389

- Activate PPOM (from this build), PPOM Pro, WC
- Create a PPOM group and create a price matrix field (at least one); make sure the price matrix field that you created is conditionally shown as dependent on two other PPOM fields in the same group.
- Visit the product on the front side; choose the field and ensure the price matrix is visible, enter a quantity and add the product to the cart
- Visit the cart; and make sure the line total is the same as the was calculated by the product.

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/40.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->