### PR TITLE
Fix Some Repeater Field Issues

### DIFF
--- a/classes/input-meta.class.php
+++ b/classes/input-meta.class.php
@@ -314,7 +314,7 @@ class PPOM_InputManager {
 			$classes[] = 'form-select';
 		}
 
-		$classes = apply_filters( 'ppom_input_meta_classes', $classes, self::$input_meta );
+		$classes = array_filter( apply_filters( 'ppom_input_meta_classes', $classes, self::$input_meta ) );
 
 		return $classes;
 	}

--- a/classes/legacy-meta.class.php
+++ b/classes/legacy-meta.class.php
@@ -157,11 +157,14 @@ class PPOM_Legacy_InputManager {
 		}
 
 		if ( ( $this->input_type == 'radio' && ( $key = array_search( 'form-control', $classes ) ) !== false ) ||
-			 $this->input_type == 'checkbox' && ( $key = array_search( 'form-control', $classes ) ) !== false ) {
+			 ( $this->input_type == 'checkbox' && ( $key = array_search( 'form-control', $classes ) ) !== false ) ||
+			 ( $this->input_type == 'fixedprice' && self::$input_meta['view_type'] === 'radio' && ( $key = array_search( 'form-control', $classes ) ) !== false )
+		)
+		{
 			unset( $classes[ $key ] );
 			$classes[] = 'ppom-check-input';
 		}
 
-		return $classes;
+		return apply_filters( 'ppom_legacy_input_meta_classes', $classes, self::$input_meta );
 	}
 }

--- a/classes/legacy-meta.class.php
+++ b/classes/legacy-meta.class.php
@@ -165,6 +165,6 @@ class PPOM_Legacy_InputManager {
 			$classes[] = 'ppom-check-input';
 		}
 
-		return apply_filters( 'ppom_legacy_input_meta_classes', $classes, self::$input_meta );
+		return array_filter( apply_filters( 'ppom_legacy_input_meta_classes', $classes, self::$input_meta ) );
 	}
 }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
* WP filter added for HTML element classes of the `PPOM_Legacy_InputManager`
* Remove empty strings from HTML form element classes
* Remove `form-control` class from radio elements of Fixed Price Field.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
That PR is helper PR of the https://github.com/Codeinwp/ppom-pro/pull/94

Please check test instructions of the https://github.com/Codeinwp/ppom-pro/pull/94

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/72.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->