### PR TITLE
fix: add shadow to color palette choices to better visibility

### DIFF
--- a/css/ppom-style.css
+++ b/css/ppom-style.css
@@ -89,6 +89,7 @@
   color: #c73c3c;
   transition: 0.5s all;
   -webkit-transition: 0.5s all;
+  box-shadow: 0 0 8px #d9d4d4;
 }
 
 .ppom-palettes label>input:checked+.ppom-single-palette {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Before this PR, some color palette choices was not readable if the colors were the same as the bg color and if the choice was not selected. That's fixed by adding a shadow to them).

**Before (none of them selected):**
![Screen Shot 2022-12-24 at 00 41 52](https://user-images.githubusercontent.com/25361626/209408127-3730eba7-1566-4546-b35f-a00d784f1f2a.png)

**After (none of them selected):**
![Screen Shot 2022-12-24 at 00 41 57](https://user-images.githubusercontent.com/25361626/209408122-0441ffcf-0d5a-4b4e-8d63-96f32b6e1424.png)


### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Create a PPOM Field Group and add a color palette field to that.
2. Add some colors (make sure you've added at least one color same with the bg color - to test the visibility)
3. Go frontend and observe the UI of choices.

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/18.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->