### PR TITLE
safari mobile file browser opening issue on popup fixed.

### DIFF
--- a/js/ppom-simple-popup.js
+++ b/js/ppom-simple-popup.js
@@ -69,13 +69,13 @@
 
 		const instances = Object.values(uploaderInstances);
 
-        for( let i=0; i<instances.length; i++ ) {
-            if( typeof instances[i].refresh !== 'function' ) {
-                continue;
-            }
+		for( let i=0; i<instances.length; i++ ) {
+			if( typeof instances[i].refresh !== 'function' ) {
+				continue;
+			}
 
-            instances[i].refresh();
-        }
+			instances[i].refresh();
+		}
 	});
 
 	// Init Plugin

--- a/js/ppom-simple-popup.js
+++ b/js/ppom-simple-popup.js
@@ -61,12 +61,10 @@
 	var pluginName = 'megapopup';
 	var prefix = 'ppom-popup';
 
-	$(document).on('click', '[data-model-id]', function(e) {
-		e.preventDefault();
-		var popup_id = $(this).attr('data-model-id');
-
-		$('#' + popup_id).megapopup($(this).data());
-
+	function pluploadRefresh() {
+		if( ! uploaderInstances ) {
+			return;
+		}
 		const instances = Object.values(uploaderInstances);
 
 		for( let i=0; i<instances.length; i++ ) {
@@ -76,6 +74,15 @@
 
 			instances[i].refresh();
 		}
+	}
+
+	$(document).on('click', '[data-model-id]', function(e) {
+		e.preventDefault();
+		var popup_id = $(this).attr('data-model-id');
+
+		$('#' + popup_id).megapopup($(this).data());
+
+		pluploadRefresh();
 	});
 
 	// Init Plugin

--- a/js/ppom-simple-popup.js
+++ b/js/ppom-simple-popup.js
@@ -66,6 +66,16 @@
 		var popup_id = $(this).attr('data-model-id');
 
 		$('#' + popup_id).megapopup($(this).data());
+
+		const instances = Object.values(uploaderInstances);
+
+        for( let i=0; i<instances.length; i++ ) {
+            if( typeof instances[i].refresh !== 'function' ) {
+                continue;
+            }
+
+            instances[i].refresh();
+        }
 	});
 
 	// Init Plugin


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Create an env and activate WC, PPOM, PPOM Pro
- Create a PPOM file group and add a image cropper field to there, attach a product to the group.
- Enable popup mode for the product
- Visit product on front side and you'll see it works fine and "Select Files" button works well.
- On browserstack, create a session with any Safari mobile and visit same product, try to clicking "select files" button and you'll see it doesn't work.
- With that PR the safari mobile issue should be resolved also we should make sure there are no any regression on PPOM popup (Popup feature is an independent feature from Image Cropper and you can use it for any field groups.)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/90
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->