### PR TITLE
Helper PR of the Color Palette + Repeater compatibility on PPOM Pro

### DIFF
--- a/templates/frontend/inputs/palettes.php
+++ b/templates/frontend/inputs/palettes.php
@@ -84,6 +84,7 @@ echo '</style>';
 			$without_tax  = $value['without_tax'];
 
 			$option_id = $value['option_id'];
+			$option_classes = sprintf('%s ppom-option-%s', $input_classes, $option_id);
 			$dom_id    = apply_filters( 'ppom_dom_option_id', $option_id, $field_meta );
 
 			// Checked value selected
@@ -111,7 +112,7 @@ echo '</style>';
 							type="checkbox"
 							name="<?php echo esc_attr( $fm->form_name() ); ?>[]"
 							id="<?php echo esc_attr( $dom_id ); ?>"
-							class="<?php echo esc_attr( $input_classes ); ?>"
+							class="<?php echo esc_attr( $option_classes ); ?>"
 							data-title="<?php echo esc_attr( $fm->title() ); ?>"
 							data-label="<?php echo esc_attr( $color_label ); ?>"
 							data-price="<?php echo esc_attr( $option_price ); ?>"
@@ -130,7 +131,7 @@ echo '</style>';
 							type="radio"
 							name="<?php echo esc_attr( $fm->form_name() ); ?>[]"
 							id="<?php echo esc_attr( $dom_id ); ?>"
-							class="<?php echo esc_attr( $input_classes ); ?>"
+							class="<?php echo esc_attr( $option_classes ); ?>"
 							data-title="<?php echo esc_attr( $fm->title() ); ?>"
 							data-label="<?php echo esc_attr( $color_label ); ?>"
 							data-price="<?php echo esc_attr( $option_price ); ?>"


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
This is the helper PR of the https://github.com/Codeinwp/ppom-pro/pull/137

This PR adds a new HTML class to the radio/checkbox inputs of the Color Palette for PPOM Repeater compatibility.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
Please follow the instructions on the https://github.com/Codeinwp/ppom-pro/pull/137

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/124.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->