### PR TITLE
[PPOM Pro] Empty Field Generation which happens when PPOM Pro is activated has been fixed.

### DIFF
--- a/js/admin/ppom-admin.js
+++ b/js/admin/ppom-admin.js
@@ -474,9 +474,9 @@ jQuery(function($) {
         ppom_close_popup();
         $('#ppom_field_model_' + field_no + '').fadeIn();
 
-        field_no++;
-
         $( document ).trigger( 'ppom_new_field_created', [ clone_new_field, field_no, field_type ] );
+
+        field_no++;
     });
 
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
If PPOM Pro is activated, an empty PPOM field is created during the new field adding. That issue was caused by a conditional field repeater. That's been fixed.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Install PPOM, PPOM Pro
- Try to add a new PPOM field to a group
- Make sure no unwanted blank PPOM field was created.

### Time
~ 52min

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/79.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->