### PR TITLE
Regression Fix for the dataname existing check

### DIFF
--- a/js/admin/ppom-admin.js
+++ b/js/admin/ppom-admin.js
@@ -277,7 +277,7 @@ jQuery(function($) {
         event.preventDefault();
 
         var $this = $(this);
-        var ui = ppom_required_data_name($this, 'new', 0);
+        var ui = ppom_required_data_name($this, 'new');
         if (ui == false) {
             return;
         }
@@ -365,8 +365,7 @@ jQuery(function($) {
         id = Number(id);
 
         var $this = $(this);
-        console.log(id);
-        var ui = ppom_required_data_name($this, 'update', id);
+        var ui = ppom_required_data_name($this, 'update');
 
         if (ui == false) {
             return;
@@ -1017,7 +1016,7 @@ jQuery(function($) {
     /**
         24- Fields Dataname Must Be Required
     **/
-    function ppom_required_data_name($this, context, id) {
+    function ppom_required_data_name($this, context) {
         var selector = $this.closest('.ppom-slider');
         var data_name = selector.find('[data-meta-id="data_name"] input[type="text"]').val();
 
@@ -1027,7 +1026,7 @@ jQuery(function($) {
         if (data_name == '') {
             var msg = 'Data Name must be required';
             var is_ok = false;
-        } else if (('new'===context || ( 'update'===context && selector.data('saved_dataname')!==data_name ) ) && console.log('here') && $.inArray(data_name, allDataName) != -1) {
+        } else if (('new'===context || ( 'update'===context && selector.data('saved_dataname')!==data_name ) ) && $.inArray(data_name, allDataName) != -1) {
             var msg = 'Data Name already exists';
             var is_ok = false;
         }

--- a/js/admin/ppom-admin.js
+++ b/js/admin/ppom-admin.js
@@ -277,7 +277,7 @@ jQuery(function($) {
         event.preventDefault();
 
         var $this = $(this);
-        var ui = ppom_required_data_name($this);
+        var ui = ppom_required_data_name($this, 'new', 0);
         if (ui == false) {
             return;
         }
@@ -361,15 +361,16 @@ jQuery(function($) {
     $(document).on('click', '.ppom-update-field', function(event) {
         event.preventDefault();
 
+        var id = $(this).attr('data-field-index');
+        id = Number(id);
+
         var $this = $(this);
-        var ui = ppom_required_data_name($this);
+        console.log(id);
+        var ui = ppom_required_data_name($this, 'update', id);
 
         if (ui == false) {
             return;
         }
-
-        var id = $(this).attr('data-field-index');
-        id = Number(id);
 
         var data_name = $('#ppom_field_model_' + id + '').find('[data-meta-id="data_name"] input').val();
         var title = $('#ppom_field_model_' + id + '').find('[data-meta-id="title"] input').val();
@@ -1016,16 +1017,17 @@ jQuery(function($) {
     /**
         24- Fields Dataname Must Be Required
     **/
-    function ppom_required_data_name($this) {
+    function ppom_required_data_name($this, context, id) {
         var selector = $this.closest('.ppom-slider');
         var data_name = selector.find('[data-meta-id="data_name"] input[type="text"]').val();
+
         var allDataName = $( 'table.ppom_field_table td.ppom_meta_field_id' ).map(function(){
             return $.trim(jQuery(this).text());
         }).get();
         if (data_name == '') {
             var msg = 'Data Name must be required';
             var is_ok = false;
-        } else if ($.inArray(data_name, allDataName) != -1) {
+        } else if (('new'===context || ( 'update'===context && selector.data('saved_dataname')!==data_name ) ) && console.log('here') && $.inArray(data_name, allDataName) != -1) {
             var msg = 'Data Name already exists';
             var is_ok = false;
         }

--- a/templates/admin/ppom-fields.php
+++ b/templates/admin/ppom-fields.php
@@ -238,7 +238,7 @@ $product_id = isset( $_GET['product_id'] ) ? intval( $_GET['product_id'] ) : '';
 						?>
 
 						<!-- New PPOM Model  -->
-						<div id="ppom_field_model_<?php echo esc_attr( $f_index ); ?>"
+						<div data-saved_dataname="<?php echo esc_attr($the_field_id); ?>" id="ppom_field_model_<?php echo esc_attr( $f_index ); ?>"
 							 class="ppom-modal-box ppom-slider ppom_sort_id_<?php echo esc_attr( $f_index ); ?>">
 							<div class="ppom-model-content">
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
In development branch, the PPOM field update saving feature doesn't work, it was thrown "data name already exists" error. (as I see it comes from https://github.com/Codeinwp/woocommerce-product-addon/pull/97) That's been fixed in this PR.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Dataname validation capabilities comes from https://github.com/Codeinwp/woocommerce-product-addon/pull/97 should be preserved.
- PPOM Field update feature should work fine (with preserving data name check during the update)
#101 

### Time
~ 1h:14min

<!-- Issues that this pull request closes. -->
Closes #98 .
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->