### PR TITLE
Fixes on Admin -> PPOM Field Modal

### DIFF
--- a/css/ppom-admin.css
+++ b/css/ppom-admin.css
@@ -581,7 +581,7 @@ ul.ppom-options-container li {
 
 .ppom-modal-box {
     position: fixed;
-    top: 0;
+    top: 30px;
     right: 0;
     max-height: 90%;
     left: 0;

--- a/css/ppom-admin.css
+++ b/css/ppom-admin.css
@@ -193,6 +193,12 @@ ul.ppom-options-container li {
     }
 }
 
+@media (max-width: 992px) {
+    .ppom-slider .row>div {
+        display: block;
+    }
+}
+
 /*
     2- Helper Icon With Desciption CSS
 */


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
* PPOM Field Modal (shown during create/update a field) was empty (the inputs were not showing) in the screens lower than 992px width. That's fixed.
* Top position of the modal was refactored (now there is 30px in the top of the modal)

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Issue #50 should be fixed.
- No regression should occur in wider or narrow screens of 992px

### Time
~ 50min

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/50.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->