### PR TITLE
Fix Neve + PPOM Visual Compatibility on Single Product Page

### DIFF
--- a/classes/frontend-scripts.class.php
+++ b/classes/frontend-scripts.class.php
@@ -298,6 +298,7 @@ class PPOM_FRONTEND_SCRIPTS {
 					'ajaxurl'    => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
 					'plugin_url' => PPOM_URL,
 					'product_id' => $product_id,
+					'sp_force_display_block'  => apply_filters( 'ppom_sp_ac_force_css_display_block', true ) ? 'on' : 'off' // force display:block for add to cart form of the single product page
 				);
 
 				$decimal_palces = wc_get_price_decimals();

--- a/classes/frontend-scripts.class.php
+++ b/classes/frontend-scripts.class.php
@@ -298,7 +298,7 @@ class PPOM_FRONTEND_SCRIPTS {
 					'ajaxurl'    => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
 					'plugin_url' => PPOM_URL,
 					'product_id' => $product_id,
-					'sp_force_display_block'  => apply_filters( 'ppom_sp_ac_force_css_display_block', true ) ? 'on' : 'off' // force display:block for add to cart form of the single product page
+					'sp_force_display_block'  => apply_filters( 'ppom_sp_ac_force_css_display_block', true ) ? 'on' : 'off' // force display:block instead of display:flex for add to cart form of the single product page
 				);
 
 				$decimal_palces = wc_get_price_decimals();

--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -64,14 +64,13 @@ jQuery(function($) {
 
 // JS Init PPOM Inputs
 function ppom_init_js_for_ppom_fields(ppom_fields) {
-    
-    
-    //console.log(ppom_fields);
-    // Fixed the form button issue
-    if (ppom_fields && ppom_fields.length > 0) {
-        const css_type = jQuery('form.cart').css('display');
-        if (css_type === 'flex') {
-            jQuery('form.cart').addClass('ppom-flex-controller');
+    if( ppom_input_vars.sp_force_display_block === 'on' ){
+        // Fixed the form button issue
+        if (ppom_fields && ppom_fields.length > 0) {
+            const css_type = jQuery('form.cart').css('display');
+            if (css_type === 'flex') {
+                jQuery('form.cart').addClass('ppom-flex-controller');
+            }
         }
     }
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Neve + PPOM had an visual issue on the single product page, that was causing 'add to cart button' was looking weird.

That's been fixed. 

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Install Neve version from https://github.com/Codeinwp/neve/pull/3866
2. You are free to install or do not install the Neve Pro
3. Install PPOM from this PR
4. Visit single product page, observe the "add to cart" button style when PPOM is activated or not. But of the cases should be consistent.

<!-- Issues that this pull request closes. -->
Closes #106.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->