### PR TITLE
Fix for the PHP Warning is shown once the PPOM Field Groups deletion

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -565,7 +565,7 @@ function ppom_admin_delete_selected_meta() {
 	$del_ids = [];
 	$del_ids_ph = [];
 
-	// for the performance wise, prefer to use foreach instead of array_map-filter-implode-fill stack.
+	// for the performance wise, prefer to use foreach instead of array_map-array_filter-array_fill stack.
 	foreach( $_POST['productmeta_ids'] as $id ) {
 		$id = absint( $id );
 

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -553,6 +553,8 @@ function ppom_admin_delete_selected_meta() {
 	if ( ! isset( $_POST['ppom_meta_nonce'] )
 		 || ! wp_verify_nonce( $_POST['ppom_meta_nonce'], 'ppom_meta_nonce_action' )
 		 || ! ppom_security_role()
+		 || ! array_key_exists( 'productmeta_ids', $_POST )
+		 || ! is_array( $_POST['productmeta_ids'] )
 	) {
 		_e( 'Sorry, you are not allowed to perform this action', 'woocommerce-product-addon' );
 		die( 0 );
@@ -560,11 +562,26 @@ function ppom_admin_delete_selected_meta() {
 
 	global $wpdb;
 
-	extract( $_REQUEST );
-	$productmeta_ids = implode( ', ', $productmeta_ids );
+	$del_ids = [];
+	$del_ids_ph = [];
+
+	// for the performance wise, prefer to use foreach instead of array_map-filter-implode-fill stack.
+	foreach( $_POST['productmeta_ids'] as $id ) {
+		$id = absint( $id );
+
+		if( 0 === $id ) {
+			continue;
+		}
+
+		$del_ids[] = $id;
+		$del_ids_ph[] = '%d';
+	}
+
+	$del_ids_ph = implode( ', ', $del_ids_ph );
+
 	$tbl_name        = $wpdb->prefix . PPOM_TABLE_META;
 
-	$res = $wpdb->query( $wpdb->prepare( "DELETE FROM {$tbl_name} WHERE productmeta_id IN ({$productmeta_ids})", $productmeta_ids ) );
+	$res = $wpdb->query( $wpdb->prepare( "DELETE FROM {$tbl_name} WHERE productmeta_id IN ({$del_ids_ph})", $del_ids ) );
 
 	if ( $res ) {
 		_e( 'Meta deleted successfully', 'woocommerce-product-addon' );


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
* PHP warning occurs once PPOM Field Groups are deleted has been fixed.
* Code improvement on deletion mechanism infrastructure.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots
<!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
Test case: PPOM Field Group deletion mechanism still works fine without any regression. On the visual side, there are no any fix or improvement made.

1. Install **PPOM Free** from this PR _(the PR doesn't need PPOM Pro but you can install stable Pro if you want)_
2. Install&Activate https://wordpress.org/plugins/wp-debugging/ as Stefan suggested in the issue details (no need to install dependent plugins which suggested by the WP Debugging plugin such as Query Monitor etc.)
3. Create some PPOM Field Groups and their contents are not important feel free to add fields into them randomly.
4. Visit PPOM Field Group listing page. https://vertis.d.pr/i/q7j5xc
5. Delete single PPOM field with using checkbox and make sure the correct group is deleted (https://vertis.d.pr/i/WchdsF)
6. Delete multiple PPOM fields with using checkbox and make sure the PPOM Field Groups you've chosen were deleted correctly.
7. Make sure any PPOM Field Group which you don't choose are not deleted.
8. Make sure any PPOM notice are not shown on PPOM deletion confirmation modal like shared by Stefan in the issue details.

<!-- Issues that this pull request closes. -->
Closes #129 .
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->