### PR TITLE
fix: do not enforce step min quantity if quantity already set …

### DIFF
--- a/inc/validation.php
+++ b/inc/validation.php
@@ -163,7 +163,7 @@ function ppom_validation_product_limits( $data, $product ) {
 		}
 	}
 
-	if ( empty( $limits['min_qty'] ) && ! $product->is_type( 'group' ) && $limits['step'] > 0 ) {
+	if ( empty( $limits['min_qty'] ) && ! $product->is_type( 'group' ) && $limits['step'] > 0 && $data['min_value'] <= 1 ) {
 		$data['min_value'] = $limits['step'];
 	}
 
@@ -227,7 +227,7 @@ function ppom_validation_variation_limits( $data, $product, $variation ) {
 		}
 	}
 
-	if ( empty( $limits['min_qty'] ) && ! $product->is_type( 'group' ) && $limits['step'] > 0 ) {
+	if ( empty( $limits['min_qty'] ) && ! $product->is_type( 'group' ) && $limits['step'] > 0 && $data['min_qty'] <= 1 ) {
 		$data['min_qty'] = $limits['step'];
 	}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
PPOM would override the min_quantity with the step if no min quantity was set for it's limits.
This conflicted with [WooCommerce Min/Max Quantities](https://woocommerce.com/products/minmax-quantities/) plugin.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots
<!-- if applicable -->
![image](https://github.com/Codeinwp/woocommerce-product-addon/assets/23024731/86cf627e-3069-4eae-aea4-41015f310c3c)


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check that when min quantity is set from **WooCommerce Min/Max Quantities** the quantity is present as a min on the input field see pic.
2. Check how it behaves when setting the min quantity from PPOM for a field it should work as before and use the PPOM-defined limit.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2526.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->