### PR TITLE
fix: improper usage of the_content filter

### DIFF
--- a/classes/input-meta.class.php
+++ b/classes/input-meta.class.php
@@ -7,8 +7,8 @@
  * @version  1.0
  */
 
-/* 
-**========== Block direct access =========== 
+/*
+**========== Block direct access ===========
 */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -69,7 +69,8 @@ class PPOM_InputManager {
 		// old Filter
 		$desc = apply_filters( 'ppom_description_content', $desc, self::$input_meta );
 		$desc = apply_filters( 'ppom_input_meta_desc', $desc, self::$input_meta );
-		return apply_filters( 'the_content', $desc );
+
+		return do_shortcode($desc);
 	}
 
 

--- a/classes/legacy-meta.class.php
+++ b/classes/legacy-meta.class.php
@@ -7,8 +7,8 @@
  * @version  21.2
  */
 
-/* 
-**========== Block direct access =========== 
+/*
+**========== Block direct access ===========
 */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -71,7 +71,7 @@ class PPOM_Legacy_InputManager {
 
 		// old Filter
 		$desc = apply_filters( 'ppom_description_content', $desc, self::$input_meta );
-		return apply_filters( 'the_content', $desc );
+		return do_shortcode($desc);
 	}
 
 


### PR DESCRIPTION
### Summary

This issue was introduced with the fixes for this https://github.com/Codeinwp/woocommerce-product-addon/issues/159 . 

The problem was the usage of `the_content` filter to render the shortcodes, although it had fixed the shortcode rendering it was not the proper place to use `the_content` filter as only a small part of the page was rendered there i.e. the field description.  

The proposed fix uses the `do_shortcode` function before outputting the field description. 

I tested with the solution and the reviews are working as expected and also the shortcodes are still replaced. 

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO


### Test instructions
<!-- Describe how this pull request can be tested. -->

Follow the linked issue details. 

It is also good to test that https://github.com/Codeinwp/woocommerce-product-addon/issues/159 is not reintroduced. 

<!-- Issues that this pull request closes. -->
Closes #261.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->