### PR TITLE
fix: using missing data when computing default fields values

### DIFF
--- a/classes/form.class.php
+++ b/classes/form.class.php
@@ -370,7 +370,7 @@ class PPOM_Form {
 			$default_value = is_array( $edit_data ) ? map_deep( $edit_data, 'sanitize_text_field' ) : sanitize_text_field( $_GET[ $data_name ] );
 		} elseif ( isset( $_POST['ppom']['fields'][ $data_name ] ) && apply_filters( 'ppom_retain_after_add_to_cart', true ) ) {
 			$edit_data = isset( $_POST['ppom']['fields'][ $data_name ] ) ? $_POST['ppom']['fields'][ $data_name ] : '';
-			$default_value = is_array( $edit_data ) ? map_deep( $edit_data, 'sanitize_text_field' ) : sanitize_text_field( $_GET[ $data_name ] );
+			$default_value = is_array( $edit_data ) ? map_deep( $edit_data, 'sanitize_text_field' ) : sanitize_text_field( $_POST['ppom']['fields'][ $data_name ] );
 		} else {
 			// Default values in settings
 			switch ( $type ) {


### PR DESCRIPTION
### Summary

Uses the correct data when rendering the fields default value. The issue was introduced here: https://github.com/Codeinwp/woocommerce-product-addon/commit/a2f46ad1334ae234efff9df49c76d0352378266e#diff-c21a6eb9b249d2d47f4b61ea124045638ccda17124fc3e1f651e661c2c95d868L368 .

I didn't manage to replicate the issue, I was only able to test that this is not disturbing the existing flow. 
### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

Follow the issue description and attempt to replicate the issue. I personally was not able to replicate it after multiple attempts.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #269.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
