### PR TITLE
fix: ensure the callback funtion is defined for file input type

### DIFF
--- a/js/ppom-conditions-v2.js
+++ b/js/ppom-conditions-v2.js
@@ -275,6 +275,7 @@ function ppom_check_conditions(data_name, callback) {
 
     let is_matched = false;
     const ppom_type = jQuery(`.ppom-input[data-data_name="${data_name}"]`).data('type');
+
     let event_type, element_data_name;
     // const field_val = ppom_get_element_value(data_name);
     // console.log('data_name',data_name);
@@ -325,7 +326,7 @@ function ppom_check_conditions(data_name, callback) {
                     }
                 });
 
-                if (typeof callback == "function")
+                if (typeof callback == "function" && ( 'undefined' !== typeof ppom_type || element_data_name !== 'file') )
                     callback(element_data_name, event_type);
                 // return is_matched;
             }
@@ -339,13 +340,13 @@ function ppom_check_conditions(data_name, callback) {
                     jQuery(this).addClass(`ppom-locked-${data_name} ppom-c-hide`);
                 }
 
-                if (typeof callback == "function")
+                if (typeof callback == "function" && ( 'undefined' !== typeof ppom_type || element_data_name !== 'file') )
                     callback(element_data_name, event_type);
             } else {
 
                 jQuery(this).removeClass(`ppom-locked-${data_name} ppom-c-hide`);
                 // console.log('event_type', event_type);
-                if (typeof callback == "function")
+                if (typeof callback == "function" && ( 'undefined' !== typeof ppom_type || element_data_name !== 'file') )
                     callback(element_data_name, event_type);
             }
         }


### PR DESCRIPTION
### Summary

Checks that the callback is defined for the field that allows file inputs. It is close to the same fix that Ghirish provided here: https://github.com/Codeinwp/woocommerce-product-addon/pull/169/files , but restricts the check only to the file fields so that it avoids this issue: https://github.com/Codeinwp/woocommerce-product-addon/issues/262 .

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO


### Test instructions
<!-- Describe how this pull request can be tested. -->

Check the linked issue for details. 

Also check that https://github.com/Codeinwp/woocommerce-product-addon/issues/262 is not reintroduced.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #268.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
