### PR TITLE
fix: improved file input type matching on frontend

### DIFF
--- a/js/ppom-conditions-v2.js
+++ b/js/ppom-conditions-v2.js
@@ -275,10 +275,9 @@ function ppom_check_conditions(data_name, callback) {
 
     let is_matched = false;
     const ppom_type = jQuery(`.ppom-input[data-data_name="${data_name}"]`).data('type');
-
+    const is_file  = jQuery("a.file.ppom-input").length > 0;
     let event_type, element_data_name;
-    // const field_val = ppom_get_element_value(data_name);
-    // console.log('data_name',data_name);
+
     jQuery(`div.ppom-cond-${data_name}`).each(function() {
         // return this.data('cond-val1').match(/\w*-Back/);
         // console.log(jQuery(this));
@@ -326,7 +325,7 @@ function ppom_check_conditions(data_name, callback) {
                     }
                 });
 
-                if (typeof callback == "function" && ( 'undefined' !== typeof ppom_type || element_data_name !== 'file') )
+                if (typeof callback == "function" && ( 'undefined' !== typeof ppom_type || !is_file ) )
                     callback(element_data_name, event_type);
                 // return is_matched;
             }
@@ -340,13 +339,14 @@ function ppom_check_conditions(data_name, callback) {
                     jQuery(this).addClass(`ppom-locked-${data_name} ppom-c-hide`);
                 }
 
-                if (typeof callback == "function" && ( 'undefined' !== typeof ppom_type || element_data_name !== 'file') )
+                if (typeof callback == "function" && ( 'undefined' !== typeof ppom_type || !is_file) )
                     callback(element_data_name, event_type);
             } else {
 
                 jQuery(this).removeClass(`ppom-locked-${data_name} ppom-c-hide`);
                 // console.log('event_type', event_type);
-                if (typeof callback == "function" && ( 'undefined' !== typeof ppom_type || element_data_name !== 'file') )
+
+                if (typeof callback == "function" && ( 'undefined' !== typeof ppom_type || !is_file) )
                     callback(element_data_name, event_type);
             }
         }


### PR DESCRIPTION
### Summary
I updated the previous change to properly target the input file type. 

An example of how it looks is this: 

```html 
<a href="javascript:;" id="selectfiles-tu_nahrajte_va_u_fotografiu" class="btn btn-primary  form-control file ppom-input tu_nahrajte_va_u_fotografiu" style="position: relative; z-index: 1;">
			Select files		</a>
```



### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

I also tested with the latest field added to the issue and it works, eg:  https://vertis.d.pr/v/aCW0F9
### Test instructions
<!-- Describe how this pull request can be tested. -->

Follow the linked issue. 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #268.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
