### PR TITLE
fix: checking that variables passed plupload are defined

### DIFF
--- a/js/file-upload.js
+++ b/js/file-upload.js
@@ -156,7 +156,7 @@ jQuery(function($) {
 
 }); //	jQuery(function($){});
 
-// generate thumbbox 
+// generate thumbbox
 function add_thumb_box(file, $filelist_DIV) {
 
     var inner_html = '<div class="u_i_c_thumb"><div class="progress_bar"><span class="progress_bar_runner"></span><span class="progress_bar_number">(' + plupload.formatSize(file.size) + ')<span></div></div>';
@@ -223,7 +223,7 @@ function ppom_show_cropped_preview(file_name, image_url, image_id) {
         .addClass('ppom-croppie-preview-' + image_id)
         .attr('data-image_id', image_id)
         .appendTo(cropp_preview_container);
-        
+
     var change_image = jQuery('<a/>')
         .addClass('btn ' + image_id)
         .attr('href', '#')
@@ -233,17 +233,17 @@ function ppom_show_cropped_preview(file_name, image_url, image_id) {
             e.preventDefault();
             location.reload();
         });
-        
+
 
     // $filelist_DIV[file_name]['croppie']     = cropp_preview_container.find('.ppom-croppie-preview');
-    
+
     jQuery(croppie_container).on('update.croppie', function(ev, cropData) {
             // console.log(cropData);
             // croppie_container.croppie('result', 'rawcanvas').then(function(canvas) {
             // console.log(canvas);
-            
+
             ppom_generate_cropper_data_for_cart(file_name);
-            
+
             jQuery.event.trigger({
                 type: 'ppom_croppie_update',
                 img_id: image_id,
@@ -252,9 +252,9 @@ function ppom_show_cropped_preview(file_name, image_url, image_id) {
                 dataname: file_name,
                 time: new Date()
             });
-            
+
     });
-    
+
     $filelist_DIV[file_name]['croppie'][image_id] = croppie_container;
     $filelist_DIV[file_name]['image_id'] = image_id;
     $filelist_DIV[file_name]['image_url'] = image_url;
@@ -345,10 +345,16 @@ function ppom_setup_file_upload_input(file_input) {
                 // $filelist_DIV[file_data_name].html('');
                 if ( ! $filelist_DIV[file_data_name].is(':visible') ) {
                     jQuery(document).on('ppom_field_shown', function() {
+
                         jQuery.each(ppom_input_vars.ppom_inputs, function(index, file_input) {
-                            if (file_input.type === 'file' || file_input.type === 'cropper') {
-                                var file_data_name = file_input.data_name;
-                                ppom_setup_file_upload_input(file_input);
+                            if (file_input && (file_input.type === 'file' || file_input.type === 'cropper')) {
+                                if (file_input.data_name
+                                    && file_input.files_allowed
+                                    && file_input.file_size
+                                    && file_input.files_allowed) {
+                                    var file_data_name = file_input.data_name;
+                                    ppom_setup_file_upload_input(file_input);
+                                }
                             }
 
                         });
@@ -407,7 +413,7 @@ function ppom_setup_file_upload_input(file_input) {
                 else {
 
                     plupload.each(files, function(file) {
-                        
+
                         if (file.type.indexOf("image") !== -1 && file.type !== 'image/photoshop') {
 
                             var img = new mOxie.Image;
@@ -654,7 +660,7 @@ function ppom_generate_cropper_data_for_cart(field_name) {
             //console.log(image_url);
             // remove first
             jQuery(`input[name="ppom[fields][${field_name}][${image_id}][cropped]"`).remove();
-            
+
             var fileCheck = jQuery('<input checked="checked" name="ppom[fields][' + field_name + '][' + image_id + '][cropped]" type="checkbox"/>')
                 .val(image_url)
                 .css('display', 'none')

--- a/js/ppom-conditions-v2.js
+++ b/js/ppom-conditions-v2.js
@@ -325,7 +325,7 @@ function ppom_check_conditions(data_name, callback) {
                     }
                 });
 
-                if (typeof callback == "function" && ( 'undefined' !== typeof ppom_type || !is_file ) )
+                if ( typeof callback == "function" )
                     callback(element_data_name, event_type);
                 // return is_matched;
             }
@@ -339,14 +339,14 @@ function ppom_check_conditions(data_name, callback) {
                     jQuery(this).addClass(`ppom-locked-${data_name} ppom-c-hide`);
                 }
 
-                if (typeof callback == "function" && ( 'undefined' !== typeof ppom_type || !is_file) )
+                if ( typeof callback == "function" )
                     callback(element_data_name, event_type);
             } else {
 
                 jQuery(this).removeClass(`ppom-locked-${data_name} ppom-c-hide`);
                 // console.log('event_type', event_type);
 
-                if (typeof callback == "function" && ( 'undefined' !== typeof ppom_type || !is_file) )
+                if ( typeof callback == "function" )
                     callback(element_data_name, event_type);
             }
         }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

An issue with the select for the files upload was fixed first here: https://github.com/Codeinwp/woocommerce-product-addon/commit/bb060530e40da7a9bbec805c3089c2b18a450bf0 but that introduced a lot of regression regarding the conditional fields which I fixed by only allowing this condition on the files input. But when the conditional field is paired with a file field issues still occur. 

To make sure we do not keep pilling regressions trying to fix a fix I started by reverting completely the fix from here: https://github.com/Codeinwp/woocommerce-product-addon/commit/bb060530e40da7a9bbec805c3089c2b18a450bf0 and started to fix the select files. At this point the orders and conditionals were working as before with no issues and only the original issue remained: https://github.com/Codeinwp/ppom-pro/issues/229 . 

The issue with the select was caused by an error with the `plupload` library: https://vertis.d.pr/i/E6L30O . 

I tracked the issue down to some variables being `undefined` and used at the initialization which was breaking the flow. 

Adding a check for their existence before using them fixed the issue.


### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

Follow the issue details. 

I tested myself with the fields provided and it is working as expected and the file is reaching the order: https://vertis.d.pr/i/Mvt2UJ .

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #283.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
