### PR TITLE
fix: checking file extension exists before type validation

### DIFF
--- a/inc/files.php
+++ b/inc/files.php
@@ -94,7 +94,7 @@ function ppom_create_thumb_for_meta( $file_name, $product_id, $cropped = false, 
 		$edited_thumb_path = ppom_get_dir_path() . 'edits/thumbs/' . $file_name;
 		if ( file_exists( $edited_thumb_path ) ) {
 			$file_thumb_url = ppom_get_dir_url() . 'edits/thumbs/' . $file_name;
-		}   
+		}
 	} elseif ( file_exists( $file_dir_path ) && $post_type == 'shop_order' ) {
 		$file_link = $file_thumb_url;
 	} else {
@@ -177,7 +177,7 @@ function ppom_upload_file() {
 	$restricted_type    = ppom_get_option( 'ppom_restricted_file_type', $default_restricted );
 	$restricted_type    = explode( ',', $restricted_type );
 
-	if ( in_array( strtolower( $extension ), $restricted_type ) ) {
+	if ( empty( $extension ) || in_array( strtolower( $extension ), $restricted_type ) ) {
 		$response ['status']  = 'error';
 		$response ['message'] = __( 'File type not valid - ' . $extension, 'woocommerce-product-addon' );
 		wp_send_json( $response );
@@ -372,7 +372,7 @@ function ppom_delete_file() {
 			_e( 'File removed', 'woocommerce-product-addon' );
 		} else {
 			printf( __( 'Error while deleting file %s', 'woocommerce-product-addon' ), $file_path );
-		}   
+		}
 	} else {
 		printf( __( 'Error while deleting file %s', 'woocommerce-product-addon' ), $file_path );
 	}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Checks if the extension output of `wp_check_filetype_and_ext` is not empty before proceeding to validate it. 

For this issue it was not worth to spend more time into adding a test as the function is already stub to an empty function here: https://github.com/Codeinwp/ppom-pro/blob/master/tests/stubs/ppom.php .

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO


### Test instructions
<!-- Describe how this pull request can be tested. -->

Follow issue details. 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/322.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
