### PR TITLE
Fix/324

### DIFF
--- a/inc/files.php
+++ b/inc/files.php
@@ -134,8 +134,6 @@ function ppom_create_thumb_for_meta( $file_name, $product_id, $cropped = false, 
 
 function ppom_upload_file() {
 
-    var_dump( 'ppom_upload_file');
-    error_log( print_r( 'ppom_upload_file', true ) );
 	header( 'Expires: Mon, 26 Jul 1997 05:00:00 GMT' );
 	header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
 	header( 'Cache-Control: no-store, no-cache, must-revalidate' );

--- a/inc/files.php
+++ b/inc/files.php
@@ -134,6 +134,8 @@ function ppom_create_thumb_for_meta( $file_name, $product_id, $cropped = false, 
 
 function ppom_upload_file() {
 
+    var_dump( 'ppom_upload_file');
+    error_log( print_r( 'ppom_upload_file', true ) );
 	header( 'Expires: Mon, 26 Jul 1997 05:00:00 GMT' );
 	header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s' ) . ' GMT' );
 	header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -169,7 +171,7 @@ function ppom_upload_file() {
 	$file_name = apply_filters( 'ppom_uploaded_filename', $file_name );
 
 	/* ========== Invalid File type checking ========== */
-	$file_type = wp_check_filetype_and_ext( $file_dir_path, $file_name );
+	$file_type = wp_check_filetype_and_ext( $file_dir_path . $file_name, $file_name );
 	$extension = $file_type['ext'];
 
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

This issue was caused because the code was passing a directory to the `wp_check_filetype_and_ext` function first parameter: https://vertis.d.pr/i/ia6uI9 . 

Fixed it by sending the full path of the uploaded object to the function. 

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

Follow the issue details. 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/324.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
