### PR TITLE
fix: stripping html tags from order text

### DIFF
--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -132,6 +132,8 @@ function ppom_woocommerce_load_scripts() {
 
 function ppom_woocommerce_validate_product( $passed, $product_id, $qty ) {
 
+    error_log('ppom_woocommerce_validate_product');
+    error_log(print_r($_POST, true));
 	$ppom = new PPOM_Meta( $product_id );
 	if ( ! $ppom->ajax_validation_enabled ) {
 		$passed = ppom_check_validation( $product_id, $_POST );
@@ -155,6 +157,7 @@ function ppom_woocommerce_validate_product( $passed, $product_id, $qty ) {
 
 function ppom_woocommerce_ajax_validate() {
 
+    error_log('ppom_woocommerce_ajax_validate');
 	// ppom_pa($_POST); exit;
 	$ppom_nonce            = $_REQUEST['ppom_nonce'];
 	$validate_nonce_action = 'ppom_validating_action';
@@ -236,7 +239,8 @@ function ppom_check_validation( $product_id, $post_data, $passed = true ) {
 			continue;
 		}
 
-		$data_name = sanitize_key( $field['data_name'] );
+		$data_name = strip_tags( sanitize_key( $field['data_name'] ) );
+
 		$title     = isset( $field['title'] ) ? $field['title'] : '';
 		$type      = isset( $field['type'] ) ? $field['type'] : '';
 
@@ -257,7 +261,7 @@ function ppom_check_validation( $product_id, $post_data, $passed = true ) {
 			$error_message = stripslashes( $error_message );
 			ppom_wc_add_notice( $error_message );
 			$passed = false;
-		}   
+		}
 	}
 
 	// ppom_pa($post_data); exit;
@@ -341,7 +345,7 @@ function ppom_woocommerce_update_cart_fees( $cart_items, $values ) {
 			if ( $option['apply'] == 'quantities' ) {
 				$ppom_total_quantities += $option['quantity'];
 				$ppom_item_order_qty    = $ppom_total_quantities;
-			}       
+			}
 		}
 	}
 
@@ -444,7 +448,7 @@ function ppom_woocommerce_update_cart_fees( $cart_items, $values ) {
 					$new_weight = $wc_product->get_weight() + $option_weight;
 					$wc_product->set_weight( $new_weight );
 				}
-			}       
+			}
 		}
 	}
 
@@ -637,7 +641,7 @@ function ppom_woocommerce_add_item_meta( $item_meta, $cart_item ) {
 		}
 
 
-		// If no value		
+		// If no value
 		if ( ! $display ) {
 			continue;
 		}
@@ -666,7 +670,7 @@ function ppom_woocommerce_add_item_meta( $item_meta, $cart_item ) {
 				'hidden'  => $hidden,
 				'display' => $display,
 			);
-		}   
+		}
 	}
 
 	return $item_meta;
@@ -712,7 +716,7 @@ function ppom_woocommerce_alter_price( $price, $product ) {
 
 				$options = $meta['options'];
 				$ranges  = ppom_convert_options_to_key_val( $options, $meta, $product );
-				// ppom_pa($ranges);	
+				// ppom_pa($ranges);
 
 				if ( isset( $meta['discount'] ) && $meta['discount'] == 'on' ) {
 
@@ -742,7 +746,7 @@ function ppom_woocommerce_alter_price( $price, $product ) {
 					}
 				}
 			}
-		}   
+		}
 	}
 
 	return apply_filters( 'ppom_loop_matrix_price', $price, $from_pice, $to_price );
@@ -750,16 +754,16 @@ function ppom_woocommerce_alter_price( $price, $product ) {
 
 /*
 function ppom_hide_variation_price_html($show, $parent, $variation) {
-	
+
 	$product_id = $parent->get_id();
 	$ppom		= new PPOM_Meta( $product_id );
-	
+
 	if( $ppom->is_exists && $ppom->price_display != 'hide' ) {
 		$show = false;
 	}
-	
+
 	return $show;
-	
+
 }*/
 
 // Set default quantity for price matrix
@@ -1148,6 +1152,7 @@ function ppom_woocommerce_cart_update_validate( $cart_validated, $cart_item_key,
 
 function ppom_woocommerce_order_item_meta( $item, $cart_item_key, $values, $order ) {
 
+    error_log('ppom_woocommerce_order_item_meta');
 	if ( ! isset( $values ['ppom']['fields'] ) ) {
 		return;
 	}

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -132,8 +132,6 @@ function ppom_woocommerce_load_scripts() {
 
 function ppom_woocommerce_validate_product( $passed, $product_id, $qty ) {
 
-    error_log('ppom_woocommerce_validate_product');
-    error_log(print_r($_POST, true));
 	$ppom = new PPOM_Meta( $product_id );
 	if ( ! $ppom->ajax_validation_enabled ) {
 		$passed = ppom_check_validation( $product_id, $_POST );
@@ -157,7 +155,6 @@ function ppom_woocommerce_validate_product( $passed, $product_id, $qty ) {
 
 function ppom_woocommerce_ajax_validate() {
 
-    error_log('ppom_woocommerce_ajax_validate');
 	// ppom_pa($_POST); exit;
 	$ppom_nonce            = $_REQUEST['ppom_nonce'];
 	$validate_nonce_action = 'ppom_validating_action';
@@ -1152,7 +1149,6 @@ function ppom_woocommerce_cart_update_validate( $cart_validated, $cart_item_key,
 
 function ppom_woocommerce_order_item_meta( $item, $cart_item_key, $values, $order ) {
 
-    error_log('ppom_woocommerce_order_item_meta');
 	if ( ! isset( $values ['ppom']['fields'] ) ) {
 		return;
 	}

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -230,17 +230,24 @@ function ppom_check_validation( $product_id, $post_data, $passed = true ) {
 
 		$passed = apply_filters( 'ppom_before_fields_validation', $passed, $field, $post_data, $product_id );
 
-		if ( empty( $field['data_name'] ) || empty( $field['required'] )
-											 && ( empty( $field['min_checked'] ) && empty( $field['max_checked'] ) )
+		if (  empty( $field['data_name'] )  ) {
+			continue;
+		}
+
+		$data_name = sanitize_key( $field['data_name'] );
+
+		if ( ! empty($ppom_posted_fields[$data_name]) && $ppom_posted_fields[$data_name] !== strip_tags( $ppom_posted_fields[$data_name] ) ) {
+			$passed = false;
+		}
+
+		if ( empty( $field['required'] ) && ( empty( $field['min_checked'] ) && empty( $field['max_checked'] ) )
 		) {
 			continue;
 		}
 
-		$data_name = strip_tags( sanitize_key( $field['data_name'] ) );
 
 		$title     = isset( $field['title'] ) ? $field['title'] : '';
 		$type      = isset( $field['type'] ) ? $field['type'] : '';
-
 
 		// var_dump($data_name, ppom_is_field_hidden_by_condition($data_name));
 		// Check if field is required by hidden by condition
@@ -1390,9 +1397,9 @@ function ppom_woocommerce_rename_files( $order_id, $posted_data, $order ) {
 function ppom_wc_order_again_compatibility( $cart_item_data, $item, $order ) {
 	$ppom_data = $item->get_meta('_ppom_fields');
 
-    if( is_array($ppom_data) && array_key_exists( 'fields', $ppom_data ) ) {
-        $cart_item_data['ppom'] = $ppom_data;
-    }
+	if( is_array($ppom_data) && array_key_exists( 'fields', $ppom_data ) ) {
+		$cart_item_data['ppom'] = $ppom_data;
+	}
 
 	return $cart_item_data;
 }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Using `strip_tags` function to remove html tags from the fields data.


### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

Check the linked issue.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/330.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
