### PR TITLE
fix: ensure field is string before validation

### DIFF
--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -236,7 +236,7 @@ function ppom_check_validation( $product_id, $post_data, $passed = true ) {
 
 		$data_name = sanitize_key( $field['data_name'] );
 
-		if ( ! empty($ppom_posted_fields[$data_name]) && $ppom_posted_fields[$data_name] !== strip_tags( $ppom_posted_fields[$data_name] ) ) {
+		if ( ! empty($ppom_posted_fields[$data_name]) && is_string( $ppom_posted_fields[$data_name] ) && $ppom_posted_fields[$data_name] !== strip_tags( $ppom_posted_fields[$data_name] ) ) {
 			$passed = false;
 		}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Checking if a ppom field is string before passing it to `strip_tags` validation.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

Check issue details.

I tested on the instance provided and works as expected after the change.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
