### PR TITLE
fix: added .ai files to allowed upload mime types

### DIFF
--- a/inc/files.php
+++ b/inc/files.php
@@ -168,8 +168,13 @@ function ppom_upload_file() {
 
 	$file_name = apply_filters( 'ppom_uploaded_filename', $file_name );
 
+	$additional_mime_types = apply_filters( 'ppom_custom_allowed_mime_types', array( 'ai' => 'application/postscript' ) );
+
+	$allowed_mime_types = array_merge( get_allowed_mime_types(), $additional_mime_types );
+
 	/* ========== Invalid File type checking ========== */
-	$file_type = wp_check_filetype_and_ext( $file_dir_path . $file_name, $file_name );
+	$file_type = wp_check_filetype_and_ext( $file_dir_path . $file_name, $file_name, $allowed_mime_types );
+
 	$extension = $file_type['ext'];
 
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

The issue here was that WP is not allowing .Ai files to be uploaded by default. 

To fix this I used `get_allowed_mime_types()` to get the default types allowed by WP then appended '.ai' files to the list before passing it to `wp_check_filetype_and_ext()` .

The added extensions can also be modified by a filter from now on.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

Try to upload an `.ai` file. I used this sample to test: https://github.com/newsdev/ai2html/blob/master/sample%20files/sample-ai-file.ai .

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/328.
<!-- Should look like this: `Closes #1, #2, #3.` . --> 
