### PR TITLE
fix: cart item sanitization

### DIFF
--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -230,24 +230,18 @@ function ppom_check_validation( $product_id, $post_data, $passed = true ) {
 
 		$passed = apply_filters( 'ppom_before_fields_validation', $passed, $field, $post_data, $product_id );
 
-		if (  empty( $field['data_name'] )  ) {
+		if (
+			empty( $field['data_name'] ) &&
+			empty( $field['required'] ) &&
+			empty( $field['min_checked'] ) &&
+			empty( $field['max_checked'] )
+		) {
 			continue;
 		}
 
 		$data_name = sanitize_key( $field['data_name'] );
 
-		if ( ! empty($ppom_posted_fields[$data_name]) && is_string( $ppom_posted_fields[$data_name] ) && $ppom_posted_fields[$data_name] !== strip_tags( $ppom_posted_fields[$data_name] ) ) {
-			$passed = false;
-		}
-
-		if ( empty( $field['required'] ) && ( empty( $field['min_checked'] ) && empty( $field['max_checked'] ) )
-		) {
-			continue;
-		}
-
-
-		$title     = isset( $field['title'] ) ? $field['title'] : '';
-		$type      = isset( $field['type'] ) ? $field['type'] : '';
+		$title = isset( $field['title'] ) ? $field['title'] : '';
 
 		// var_dump($data_name, ppom_is_field_hidden_by_condition($data_name));
 		// Check if field is required by hidden by condition

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Class Test_Functions
+ *
+ * @package ppom-pro
+ */
+
+class Test_Functions extends WP_UnitTestCase {
+
+	/**
+	 * Test recursive sanitization.
+	 * @return void
+	 */
+	public function testRecursiveSanitization() {
+		$input = [
+			'textarea' => '<h1>This is a large header</h1>
+<img src="https://via.placeholder.com/300" alt="Placeholder Image" width="300" height="200">',
+			'select_area' => 'Ares',
+			'html_field' => '<span class="show_description ppom-input-desc">ares</span>',
+			'radio' => 'Aces',
+			'file_field' => [
+				'o_1i0quc48f186hch410vbase1pn0g' => [
+					'org' => 'o_1i0quc48f186hch410vbase1pn0g.png'
+				]
+			],
+			'fixed_price' => 1000,
+			'cropper' => [
+				'o_1i0qucdipef614jnju2ca5q37m' => [
+					'org' => 'o_1i0qucdipef614jnju2ca5q37m.png',
+					'cropped' => 'data:image/png;base64,iVBORw0KGgoAAAAN'
+				]
+			]
+		];
+
+		$expected = [
+			'textarea' => 'This is a large header',
+			'select_area' => 'Ares',
+			'html_field' => 'ares',
+			'radio' => 'Aces',
+			'file_field' => [
+				'o_1i0quc48f186hch410vbase1pn0g' => [
+					'org' => 'o_1i0quc48f186hch410vbase1pn0g.png'
+				]
+			],
+			'fixed_price' => 1000,
+			'cropper' => [
+				'o_1i0qucdipef614jnju2ca5q37m' => [
+					'org' => 'o_1i0qucdipef614jnju2ca5q37m.png',
+					'cropped' => 'data:image/png;base64,iVBORw0KGgoAAAAN'
+				]
+			]
+		];
+
+		$this->assertEquals( $expected, ppom_recursive_sanitization( $input ) );
+	}
+}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Instead of rejecting the cart items with HTML elements, we sanitized them. The sanitation will apply to all the field's values.

> [!NOTE]
> The HTML fields also send their content to the cart item, which makes any combination of fields to be rejected. 

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Use the Textarea, File, and HTML PPOM field.
- In the textarea add some HTML content and add the time to the cart.
- The item should be added, and all HTML elements of the Textarea and HTML fields content should be stripped down.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/306
<!-- Should look like this: `Closes #1, #2, #3.` . -->
