### PR TITLE
Fixed html breaking issue when used collapse field

### DIFF
--- a/classes/form.class.php
+++ b/classes/form.class.php
@@ -162,12 +162,12 @@ class PPOM_Form {
 				}
 
 				if ( $collapse_type == 'end' ) {
-					echo '<div class="ppom-collapsed-child-end">';
+					echo '<div class="ppom-collapsed-child-end"></div>';
 				}
 
 				if ( $collapse_type != 'end' ) {
 					echo '<h4 data-collapse-id="' . esc_attr( $data_name ) . '" class="ppom-collapsed-title">' . $title . '</h4>';
-					echo '<div class="collapsed-child">';
+					echo '<div class="collapsed-child"></div>';
 				}
 
 				$section_started = true;

--- a/templates/render-fields.php
+++ b/templates/render-fields.php
@@ -202,12 +202,12 @@ foreach ( $ppom_fields_meta as $meta ) {
 		}
 
 		if ( $collapse_type == 'end' ) {
-			echo '<div class="ppom-collapsed-child-end">';
+			echo '<div class="ppom-collapsed-child-end"></div>';
 		}
 
 		if ( $collapse_type != 'end' ) {
 			echo '<h4 data-collapse-id="' . esc_attr( $data_name ) . '" class="ppom-collapsed-title">' . $title . '</h4>';
-			echo '<div class="collapsed-child">';
+			echo '<div class="collapsed-child"></div>';
 		}
 
 		$section_started = true;


### PR DESCRIPTION
### Summary
I've self-closed the `div`, it seems to create an issue when using the collapse field.

More details here: https://github.com/Codeinwp/ppom-pro/issues/344#issuecomment-2203137065 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/ppom-pro/issues/344
