### PR TITLE
Fixed collapse issue with default settings

### DIFF
--- a/classes/form.class.php
+++ b/classes/form.class.php
@@ -102,6 +102,13 @@ class PPOM_Form {
 				return (int) $meta_id === (int) $field['ppom_id'];
 			}
 		);
+		$collapse_fields = array_filter(
+			$fields,
+			function( $collapse_field ) {
+				return isset( $collapse_field['type'] ) && 'collapse' === $collapse_field['type'];
+			}
+		);
+
 		foreach ( $fields as $meta ) {
 
 			$type      = isset( $meta['type'] ) ? $meta['type'] : '';
@@ -143,7 +150,6 @@ class PPOM_Form {
 
 			$field_wrapper_class = $this->field_main_wrapper_classes( $meta );
 
-
 			// Collapse Fields Section
 			if ( $type == 'collapse' ) {
 				$collapse_type = isset( $meta['collapse_type'] ) ? $meta['collapse_type'] : '';
@@ -162,12 +168,12 @@ class PPOM_Form {
 				}
 
 				if ( $collapse_type == 'end' ) {
-					echo '<div class="ppom-collapsed-child-end"></div>';
+					echo '<div class="ppom-collapsed-child-end">';
 				}
 
 				if ( $collapse_type != 'end' ) {
 					echo '<h4 data-collapse-id="' . esc_attr( $data_name ) . '" class="ppom-collapsed-title">' . $title . '</h4>';
-					echo '<div class="collapsed-child"></div>';
+					echo '<div class="collapsed-child">';
 				}
 
 				$section_started = true;
@@ -194,7 +200,6 @@ class PPOM_Form {
 			 */
 			ob_start();
 
-
 			$all_inputs  = ppom_array_all_inputs();
 			$core_inputs = $all_inputs['core'];
 
@@ -205,12 +210,11 @@ class PPOM_Form {
 			do_action( 'ppom_rendering_inputs', $meta, $data_name, $fm->input_classes_array(), $fm->field_label(), $fm->options() );
 			do_action( "ppom_rendering_inputs_{$type}", $meta, $default_value );
 
-
 			$field_html .= ob_get_clean();
 
 			$field_html .= '</div>';
 
-			if ( count( self::$ppom->fields ) == $ppom_field_counter && $section_started ) {
+			if ( count( $collapse_fields ) === $ppom_collapse_counter && $section_started ) {
 				$field_html .= '</div>';
 			}
 

--- a/templates/render-fields.php
+++ b/templates/render-fields.php
@@ -49,6 +49,13 @@ $ppom_field_counter    = 0;
 $ppom_collapse_counter = 0;
 $allow_nextprev        = ppom_get_option( 'ppom-collapse-nextprev' );
 
+$collapse_fields = array_filter(
+	$ppom_fields_meta,
+	function( $collapse_field ) {
+		return isset( $collapse_field['type'] ) && 'collapse' === $collapse_field['type'];
+	}
+);
+
 foreach ( $ppom_fields_meta as $meta ) {
 
 	$type          = ( isset( $meta['type'] ) ? $meta ['type'] : '' );
@@ -734,7 +741,7 @@ foreach ( $ppom_fields_meta as $meta ) {
 
 	echo '</div>';  // col-lg-*
 
-	if ( count( $ppom_fields_meta ) == $ppom_field_counter && $section_started ) {
+	if ( count( $collapse_fields ) === $ppom_collapse_counter && $section_started ) {
 		echo '</div>';
 	}
 }


### PR DESCRIPTION
### Summary
I've fixed the collapse div closed issue. now, the `collapsed-child` div closes based on collapse field counts.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes #322
