### PR TITLE
Fixed PHP fatal error

### DIFF
--- a/classes/fields.class.php
+++ b/classes/fields.class.php
@@ -1059,7 +1059,7 @@ class PPOM_Fields_Meta {
 				$html_input .= '<thead>';
 				$html_input .= '<tr>';
 
-				if ( $values ) {
+				if ( ! empty( $bulk_data ) ) {
 					foreach ( $bulk_data[0] as $title => $value ) {
 						$deleteIcon  = ( $title != 'Quantity Range' && $title != 'Base Price' ) ? '<span class="remove ppom-rm-bulk-variation"><i class="fa fa-times" aria-hidden="true"></i></span>' : '';
 						$html_input .= '<th>' . $title . ' ' . $deleteIcon . '</th>';
@@ -1073,7 +1073,7 @@ class PPOM_Fields_Meta {
 				$html_input .= '</thead>';
 				$html_input .= '<tbody>';
 
-				if ( $values ) {
+				if ( ! empty( $bulk_data ) ) {
 					foreach ( $bulk_data as $row => $data ) {
 						$html_input .= '<tr>';
 						foreach ( $data as $key => $value ) {
@@ -1109,8 +1109,8 @@ class PPOM_Fields_Meta {
 				$html_input .= '<button class="btn btn-info ppom-save-bulk-json">'.esc_html__( 'Save Changing', 'woocommerce-product-addon' ).'</button> ';
 				$html_input .= '<button class="btn btn-success ppom-edit-bulk-json">'.esc_html__( 'Edit Changing', 'woocommerce-product-addon' ).'</button>';
 
-				if ( $values ) {
-					$html_input .= "<input type='hidden' name='ppom[" . esc_attr( $field_index ) . "][options]' class='ppom-saved-bulk-data ppom-meta-field' value='" . json_encode( $bulk_data ) . "' data-metatype='options'>";
+				if ( ! empty( $bulk_data ) ) {
+					$html_input .= "<input type='hidden' name='ppom[" . esc_attr( $field_index ) . "][options]' class='ppom-saved-bulk-data ppom-meta-field' value='" . wp_json_encode( $bulk_data ) . "' data-metatype='options'>";
 				} else {
 					$html_input .= "<input type='hidden' class='ppom-saved-bulk-data ppom-meta-field' data-metatype='options'>";
 				}

--- a/classes/fields.class.php
+++ b/classes/fields.class.php
@@ -1040,7 +1040,7 @@ class PPOM_Fields_Meta {
 			 * @since 7.1
 			 */
 			case 'bulk-quantity':
-				$bulk_data = json_decode( $values, true );
+				$bulk_data = is_string( $values ) ? json_decode( $values, true ) : (array) $values;
 				// ppom_pa($bulk_data[0]);
 				$html_input .= '<div class="ppom-bulk-quantity-wrapper">';
 				$html_input .= '<div class="table-content">';


### PR DESCRIPTION

### Summary
In this PR I've fixed the PHP fatal error while importing ppom fields csv.
More details here: https://github.com/Codeinwp/ppom-pro/issues/364#issuecomment-2272880666

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/ppom-pro/issues/364
