### PR TITLE
Added fixed price support for bulk qty field

### DIFF
--- a/classes/fields.class.php
+++ b/classes/fields.class.php
@@ -1112,7 +1112,7 @@ class PPOM_Fields_Meta {
 				if ( $values ) {
 					$html_input .= "<input type='hidden' name='ppom[" . esc_attr( $field_index ) . "][options]' class='ppom-saved-bulk-data ppom-meta-field' value='" . json_encode( $bulk_data ) . "' data-metatype='options'>";
 				} else {
-					$html_input .= "<input type='hidden' class='ppom-saved-bulk-data ppom-meta-field' data-metatype='options'>";
+					$html_input .= "<input type='hidden' name='ppom[" . esc_attr( $field_index ) . "][options]' class='ppom-saved-bulk-data ppom-meta-field' data-metatype='options'>";
 				}
 
 

--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -284,7 +284,7 @@ function ppom_init_js_for_ppom_fields(ppom_fields) {
                 // Override existing prices with their fixed version.
                 if (fixedPricesMap) {
                     try {
-                        options = JSON.parse(input.options)?.map(obj => ({
+                        const options = JSON.parse(input.options)?.map(obj => ({
                             ...obj,
                             ...fixedPricesMap
                         }));

--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -273,7 +273,25 @@ function ppom_init_js_for_ppom_fields(ppom_fields) {
                 /*if ($('form.cart').closest('div').find('.price').length > 0){
                 	wc_price_DOM = $('form.cart').closest('div').find('.price');
                 }*/
+                
+                const fixedPrices = input?.fixed_prices;
+                if (fixedPrices) {
+                    const fixedPricesList = fixedPrices.split(',').map(item => item.split('|').map(v => v.trim()));
 
+                    if (fixedPricesList.length > 0) {
+                        const fixedPricesListObject = fixedPricesList.reduce((obj, item) => {
+                            obj[item[0].trim()] = item[1].trim();
+                            return obj;
+                        }, {});
+
+                        let options = JSON.parse(input.options);
+                        if (options) {
+                            options = options.map(obj => ({ ...obj, ...fixedPricesListObject }));
+                            input.options = JSON.stringify(options);
+                        }
+                    }
+                }
+                
                 ppom_bulkquantity_meta[input.data_name] = input.options;
 
                 var min_quantity_value = jQuery(`.ppom-bulkquantity-qty.${input.data_name}`).val();

--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -274,14 +274,12 @@ function ppom_init_js_for_ppom_fields(ppom_fields) {
                 	wc_price_DOM = $('form.cart').closest('div').find('.price');
                 }*/
                 
-                const fixedPricesMap = input?.fixed_prices
-                ?.split(',')
-                ?.map(
-                    item => item.split('|').map(v => v.trim())
-                )?.reduce((obj, [variationName, variationPrice]) => {
-                    obj[variationName] = variationPrice;
-                    return obj;
-                }, {});
+                const fixedPricesMap = (input?.fixed_prices ?? '').split(',')
+                    .reduce((obj, item) => {
+                        const [variationName, variationPrice] = item.split('|').map(v => v.trim());
+                        obj[variationName] = variationPrice;
+                        return obj;
+                    }, {});
 
                 // Override existing prices with their fixed version.
                 if (fixedPricesMap) {

--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -274,21 +274,27 @@ function ppom_init_js_for_ppom_fields(ppom_fields) {
                 	wc_price_DOM = $('form.cart').closest('div').find('.price');
                 }*/
                 
-                const fixedPrices = input?.fixed_prices;
-                if (fixedPrices) {
-                    const fixedPricesList = fixedPrices.split(',').map(item => item.split('|').map(v => v.trim()));
+                const fixedPricesMap = input?.fixed_prices
+                ?.split(',')
+                ?.map(
+                    item => item.split('|').map(v => v.trim())
+                )?.reduce((obj, [variationName, variationPrice]) => {
+                    obj[variationName] = variationPrice;
+                    return obj;
+                }, {});
 
-                    if (fixedPricesList.length > 0) {
-                        const fixedPricesListObject = fixedPricesList.reduce((obj, item) => {
-                            obj[item[0].trim()] = item[1].trim();
-                            return obj;
-                        }, {});
-
-                        let options = JSON.parse(input.options);
+                // Override existing prices with their fixed version.
+                if (fixedPricesMap) {
+                    try {
+                        options = JSON.parse(input.options)?.map(obj => ({
+                            ...obj,
+                            ...fixedPricesMap
+                        }));
                         if (options) {
-                            options = options.map(obj => ({ ...obj, ...fixedPricesListObject }));
                             input.options = JSON.stringify(options);
                         }
+                    } catch (e) {
+                        console.error(e);
                     }
                 }
                 


### PR DESCRIPTION
### Summary
In this PR I've added fixed price option support for bulk quantity PPOM field.

### Screenshots
https://tinyurl.com/2y3osh2p

### Test instructions
1. Go to the ppom admin page. e.g: admin.php?page=ppom

2. Create or edit group

3. Add the `Bulk Quantity` field.

4. Add fixed prices with comma separated. e.g: Medium | 10, Small | 20
Ref: https://tinyurl.com/26bdld5v

5. Add a variation with the same name to replace it with a fixed price.
Ref: https://tinyurl.com/262o5m54

6. Assign a group to any product and view it on the front end.
Ref: https://tinyurl.com/2y3osh2p

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/ppom-pro/issues/365
