### PR TITLE
Fixed repeater field issue with multiple groups

### DIFF
--- a/classes/ppom.class.php
+++ b/classes/ppom.class.php
@@ -133,6 +133,11 @@ class PPOM_Meta {
 			}
 		}
 
+		// Retrieve fields with the repeater enabled.
+		$is_cloned = is_array( $this->fields ) ? array_filter( array_column( $this->fields, 'is_cloned' ) ) : array();
+		if ( isset( $this->ppom_settings->productmeta_validation ) && ! empty( $is_cloned ) ) {
+			$this->ppom_settings->productmeta_validation = 'on';
+		}
 	}
 
 	public static function get_instance( $product_id ) {


### PR DESCRIPTION
### Summary
In this PR I've fixed the repeater component JS/CSS enqueue issue when using multiple meta groups.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/ppom-pro/issues/371
