### PR TITLE
Make `Download File` to download the file instead of Preview

### DIFF
--- a/classes/admin.class.php
+++ b/classes/admin.class.php
@@ -85,7 +85,6 @@ class NM_PersonalizedProduct_Admin extends NM_PersonalizedProduct {
 			2,
 			10
 		);
-
 	}
 
 
@@ -356,6 +355,17 @@ class NM_PersonalizedProduct_Admin extends NM_PersonalizedProduct {
 			th.column-ppom_meta {
 				width: 10% !important;
 			}
+
+			/* PPOM File Upload uploaded files display */
+			td.ppom-files-display {
+				display: flex;
+				flex-direction: column;
+				gap: 3px;
+			}
+			
+			td.ppom-files-display a.button {
+				text-align: center;
+			}
 		</style>
 		<?php
 	}
@@ -406,6 +416,4 @@ class NM_PersonalizedProduct_Admin extends NM_PersonalizedProduct {
 		include_once PPOM_PATH . '/classes/survey.class.php';
 		PPOM_Survey::get_instance()->init();
 	}
-
-
 }

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1574,36 +1574,45 @@ function ppom_generate_html_for_files( $file_names, $input_type, $item ) {
 	foreach ( $file_name_array as $file_name ) {
 
 		$file_edit_path = ppom_get_dir_path( 'edits' ) . ppom_file_get_name( $file_name, $item->get_product_id() );
-
 		// Making file thumb download with new path
 		$ppom_file_url       = ppom_get_file_download_url( $file_name, $item->get_order_id(), $item->get_product_id() );
-		$ppom_file_thumb_url = ppom_is_file_image( $file_name ) ? ppom_get_dir_url( true ) . $file_name : PPOM_URL . '/images/file.png';
-		$order_html         .= '<tr><td><a href="' . esc_url( $ppom_file_url ) . '">';
-		$order_html         .= '<img class="img-thumbnail" style="width:' . esc_attr( ppom_get_thumbs_size() ) . '" src="' . esc_url( $ppom_file_thumb_url ) . '">';
-		$order_html         .= '</a></td>';
+		$is_image_file       = ppom_is_file_image( $file_name );
+		$ppom_file_thumb_url = $is_image_file ? ppom_get_dir_url( true ) . $file_name : PPOM_URL . '/images/file.png';
+		$order_html         .= '<tr><td class="ppom-files-display">';
 
+		if ( $is_image_file ) {
+			$order_html .= '<a target="_blank" href="' . esc_url( $ppom_file_url ) . '">';
+		}
+		
+		$order_html .= '<img class="img-thumbnail" style="width:' . esc_attr( ppom_get_thumbs_size() ) . '" src="' . esc_url( $ppom_file_thumb_url ) . '">';
+
+		if ( $is_image_file ) {
+			$order_html .= '</a>';
+		}
 
 		// Requested by Kevin, hiding downloading file button after order on thank you page
 		// @since version 16.6
 		if ( is_admin() ) {
-			$order_html .= '<td><a class="button" href="' . esc_url( $ppom_file_url ) . '">';
+			$order_html .= '<a class="button" href="' . esc_url( $ppom_file_url ) . '" download>';
 			$order_html .= __( 'Download File', 'woocommerce-product-addon' );
-			$order_html .= '</a></td>';
+			$order_html .= '</a>';
 		}
+
+		$order_html .= '</td>';
 		$order_html .= '</tr>';
 
 		if ( $input_type == 'cropper' ) {
 
 			$cropped_file_name = ppom_file_get_name( $file_name, $item->get_product_id() );
 			$cropped_url       = ppom_get_dir_url() . 'cropped/' . $cropped_file_name;
-			$order_html       .= '<tr><td><a href="' . esc_url( $cropped_url ) . '">';
+			$order_html       .= '<tr><td><a target="_blank" href="' . esc_url( $cropped_url ) . '">';
 			$order_html       .= '<img style="width:' . esc_attr( ppom_get_thumbs_size() ) . '" class="img-thumbnail" src="' . esc_url( $cropped_url ) . '">';
 			$order_html       .= '</a></td>';
 
 			// Requested by Kevin, hiding downloading file button after order on thank you page
 			// @since version 16.6
 			if ( is_admin() ) {
-				$order_html .= '<td><a class="button" href="' . esc_url( $cropped_url ) . '">';
+				$order_html .= '<td><a target="_blank" class="button" href="' . esc_url( $cropped_url ) . '">';
 				$order_html .= __( 'Cropped', 'woocommerce-product-addon' );
 				$order_html .= '</a></td>';
 			}
@@ -1614,7 +1623,7 @@ function ppom_generate_html_for_files( $file_names, $input_type, $item ) {
 			$edit_file_name = ppom_file_get_name( $file_name, $item->get_product_id() );
 			$edit_url       = ppom_get_dir_url() . 'edits/' . $edit_file_name;
 			$edit_thumb_url = ppom_get_dir_url() . 'edits/thumbs/' . $file_name;
-			$order_html    .= '<tr><td><a href="' . esc_url( $edit_url ) . '">';
+			$order_html    .= '<tr><td><a target="_blank"  href="' . esc_url( $edit_url ) . '">';
 			$order_html    .= '<img style="width:' . esc_attr( ppom_get_thumbs_size() ) . '" class="img-thumbnail" src="' . esc_url( $edit_thumb_url ) . '">';
 			$order_html    .= '</a></td>';
 			$order_html    .= '<td><a class="button" href="' . esc_url( $edit_url ) . '">';


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Refactored the `Download File` into a button with download functionality and layout improvments.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

#### Before

![image](https://github.com/user-attachments/assets/b222ced6-ada3-4a2c-baa4-3e39ae8225ca)

#### After

![image](https://github.com/user-attachments/assets/9fca34d1-196e-47f4-b0b9-8313344cda07)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make a Group Field with an Input Field, then attach it to a product.
- Go to the cart and buy the product along with the uploaded files
- Check the order on the Order Page.
- Click to download the file.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/280
<!-- Should look like this: `Closes #1, #2, #3.` . -->
