### PR TITLE
fix: delete non-img file btn and workflow

### DIFF
--- a/inc/files.php
+++ b/inc/files.php
@@ -345,17 +345,20 @@ function ppom_upload_file() {
 // Deleting file
 function ppom_delete_file() {
 
-	$file_name = sanitize_file_name( $_REQUEST ['file_name'] );
-
-	$ppom_nonce        = $_REQUEST['ppom_nonce'];
-	$file_nonce_action = 'ppom_deleting_file_action';
-	if ( ! wp_verify_nonce( $ppom_nonce, $file_nonce_action ) ) {
-		printf( __( 'Error while deleting file %s', 'woocommerce-product-addon' ), $file_name );
+	if ( ! isset( $_REQUEST ['file_name'] ) || ! isset( $_REQUEST['ppom_nonce'] ) ) {
+		echo __( 'Missing data.', 'woocommerce-product-addon' );
 		die( 0 );
 	}
 
-	$dir_path = ppom_get_dir_path();
+	$file_name         = sanitize_file_name( $_REQUEST ['file_name'] );
+	$ppom_nonce        = sanitize_key( $_REQUEST['ppom_nonce'] );
+	$file_nonce_action = 'ppom_deleting_file_action';
+	if ( ! wp_verify_nonce( $ppom_nonce, $file_nonce_action ) ) {
+		printf( __( 'Verification failed for file: %s', 'woocommerce-product-addon' ), $file_name );
+		die( 0 );
+	}
 
+	$dir_path  = ppom_get_dir_path();
 	$file_path = $dir_path . $file_name;
 
 	if ( file_exists( $file_path ) && unlink( $file_path ) ) {
@@ -379,7 +382,7 @@ function ppom_delete_file() {
 			printf( __( 'Error while deleting file %s', 'woocommerce-product-addon' ), $file_path );
 		}
 	} else {
-		printf( __( 'Error while deleting file %s', 'woocommerce-product-addon' ), $file_path );
+		printf( __( 'The file %s does not exists.', 'woocommerce-product-addon' ), $file_path );
 	}
 
 	die( 0 );
@@ -477,7 +480,7 @@ function ppom_uploaded_file_preview( $file_name, $settings ) {
 		// Tools group
 		$file_tools .= '<div class="btn-group" role="group" aria-label="Tools" style="text-align: center; display: block;">';
 		// $file_tools .= '<a href="#" class="nm-file-tools btn btn-primary u_i_c_tools_del" title="'.__('Remove', "woocommerce-product-addon").'"><span class="fa fa-times"></span></a>';
-		$file_tools .= '<a href="#" class="nm-file-tools btn btn-primary u_i_c_tools_del" title="' . __( 'Remove', 'woocommerce-product-addon' ) . '">' . __( 'Delete', 'woocommerce-product-addon' ) . '</span></a>';
+		$file_tools .= '<button class="nm-file-tools btn btn-primary u_i_c_tools_del" title="' . __( 'Remove', 'woocommerce-product-addon' ) . '">' . __( 'Delete', 'woocommerce-product-addon' ) . '</button>';
 
 		if ( apply_filters( 'ppom_show_image_popup', false ) ) {
 			$file_tools .= '<a href="#" data-toggle="modal" data-target="#modalFile' . esc_attr( $file_id ) . '" class="btn btn-primary"><span class="fa fa-expand"></span></a>';
@@ -491,8 +494,10 @@ function ppom_uploaded_file_preview( $file_name, $settings ) {
 		$file_meta .= __( 'Size: ', 'woocommerce-product-addon' ) . ppom_get_filesize_in_kb( $file_name );
 		$thumb_url  = PPOM_URL . '/images/file.png';
 
-		$file_tools .= '<a class="btn btn-primary nm-file-tools u_i_c_tools_del" href="" title="' . __( 'Remove', 'woocommerce-product-addon' ) . '"><span class="fa fa-times"></span></a>';    // delete icon
-		// $file_tools .= '<a class="btn btn-primary nm-file-tools u_i_c_tools_del" href="" title="'.__('Remove', "woocommerce-product-addon").'">Delete</a>';	//delete icon
+		// Tools group
+		$file_tools .= '<div class="btn-group" role="group" aria-label="Tools" style="text-align: center; display: block;">';
+		$file_tools .= '<button class="nm-file-tools btn btn-primary u_i_c_tools_del" title="' . __( 'Remove', 'woocommerce-product-addon' ) . '">' . __( 'Delete', 'woocommerce-product-addon' ) . '</button>';
+		$file_tools .= '</div>';
 	}
 
 

--- a/js/file-upload.js
+++ b/js/file-upload.js
@@ -90,53 +90,100 @@ jQuery(function($) {
     });
 
     // Deleting File
-    $(".ppom-wrapper").on('click', '.u_i_c_tools_del', function(e) {
+    document.querySelector('.ppom-wrapper')?.addEventListener('click', async function(e) {
+        if (
+            ! e.target.classList.contains('u_i_c_tools_del') ||
+            ! plupload_instances
+        ) {
+            return;
+        }
+
         e.preventDefault();
 
-        var del_message = ppom_file_vars.delete_file_msg;
-        var a = confirm(del_message);
-        if (a) {
-            // it is removing from uploader instance
-            var fileid = $(this).closest('.ppom-file-wrapper').attr("data-fileid");
-            var file_data_name = $(this).closest('div.ppom-field-wrapper').attr("data-data_name");
-            // console.log(fileid);
-            field_file_count[file_data_name] = 0;
+        const delMessage = ppom_file_vars.delete_file_msg;
+        if ( ! confirm( delMessage ) ) return;
 
-            plupload_instances[file_data_name].removeFile(fileid);
+        const ppomFileWrapper = e.target.closest('.ppom-file-wrapper');
+        const fileId = ppomFileWrapper?.getAttribute("data-fileid");
+        const ppomFieldWrapper = e.target.closest('div.ppom-field-wrapper');
+        const fileDataName = ppomFieldWrapper?.getAttribute("data-data_name");
 
-            var filename = $('input:checkbox[name="ppom[fields][' + file_data_name + '][' + fileid + '][org]"]').val();
+        if ( !fileId || !fileDataName ) return;
 
-            // it is removing physically if uploaded
-            $("#u_i_c_" + fileid).find('img').attr('src', ppom_file_vars.plugin_url + '/images/loading.gif');
+        field_file_count[fileDataName] = 0;
 
-            // console.log('filename ppom[fields][<?php echo ]$args['id']?>['+fileid+']');
-            var data = { action: 'ppom_delete_file', file_name: filename, 'ppom_nonce': ppom_file_vars.ppom_file_delete_nonce };
+        const uploaderInstance = plupload_instances[fileDataName];
+        if ( uploaderInstance ) {
+            uploaderInstance.removeFile(fileId);
+        }
 
-            $.post(ppom_file_vars.ajaxurl, data, function(resp) {
-                alert(resp);
-                $("#u_i_c_" + fileid).hide(500).remove();
+        const checkbox = document.querySelector(`input[name="ppom[fields][${fileDataName}][${fileId}][org]"]`);
+        const fileName = checkbox?.value;
 
-                // it is removing for input Holder
-                $('input:checkbox[name="ppom[fields][' + file_data_name + '][' + fileid + '][org]"]').remove();
+        if ( ! fileName ) return;
 
-                // Removing file container
-                $(this).closest('.u_i_c_box').remove();
+        // Delete animation.
+        const imageElement = document.querySelector(`#u_i_c_${fileId} img`);
+        if ( imageElement ) {
+            imageElement.src = `${ppom_file_vars.plugin_url}/images/loading.gif`;
+        }
 
-                // Removing cropper dom
-                if ($(".ppom-croppie-preview-" + fileid).length > 0) {
-                    $(".ppom-croppie-preview-" + fileid).remove();
+        const data = new URLSearchParams({
+            action: 'ppom_delete_file',
+            file_name: fileName,
+            ppom_nonce: ppom_file_vars.ppom_file_delete_nonce
+        });
+
+        try {
+            const response = await fetch(ppom_file_vars.ajaxurl, {
+                method: 'POST',
+                body: data,
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'X-Requested-With': 'XMLHttpRequest'
                 }
-
-                // Trigger
-                $.event.trigger({
-                    type: "ppom_uploaded_file_removed",
-                    field_name: file_data_name,
-                    fileid: fileid,
-                    time: new Date()
-                });
-
-                field_file_count[file_data_name] -= 1;
             });
+
+            const responseText = await response.text();
+            if ( ! response.ok ) {
+                confirm(`Error: ${responseText}`);
+                return;
+            }
+
+            // Update UI
+            const fileContainer = document.querySelector(`#u_i_c_${fileId}`);
+            if ( fileContainer ) {
+                fileContainer.remove();
+            }
+
+            if ( checkbox ) {
+                checkbox.remove();
+            }
+
+            const parentBox = e.target.closest('.u_i_c_box');
+            if ( parentBox ) {
+                parentBox.remove();
+            }
+
+            const croppiePreview = document.querySelector(`.ppom-croppie-preview-${fileId}`);
+            if ( croppiePreview ) {
+                croppiePreview.remove();
+            }
+
+            // Send action to PPOM_Validate
+            document.dispatchEvent(new CustomEvent("ppom_uploaded_file_removed", {
+                detail: {
+                    field_name: fileDataName,
+                    fileid: fileId,
+                    time: new Date()
+                }
+            }));
+
+            // Decrease file count
+            field_file_count[fileDataName] -= 1;
+
+        } catch (error) {
+            confirm(`Error: ${error.message}`);
         }
     });
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

- Fixed the delete button for non-image files
- Simplified the workflow for deletion (migrating from jQuery)

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

https://github.com/user-attachments/assets/3837df43-7eb5-4c4f-a447-2e69b77b2eed

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Use a File Input Field
- Add an image and non-img file (like zip)
- Check the delete button.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/422
<!-- Should look like this: `Closes #1, #2, #3.` . -->
