### PR TITLE
Added tooltip feature

### DIFF
--- a/classes/inputs/input.audio.php
+++ b/classes/inputs/input.audio.php
@@ -86,7 +86,7 @@ class NM_Audio_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'     => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.checkbox.php
+++ b/classes/inputs/input.checkbox.php
@@ -102,7 +102,7 @@ class NM_Checkbox_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'    => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.color.php
+++ b/classes/inputs/input.color.php
@@ -115,7 +115,7 @@ class NM_Color_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'    => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.cropper.php
+++ b/classes/inputs/input.cropper.php
@@ -190,7 +190,7 @@ class NM_Cropper_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'        => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.date.php
+++ b/classes/inputs/input.date.php
@@ -156,7 +156,7 @@ class NM_Date_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'      => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.daterange.php
+++ b/classes/inputs/input.daterange.php
@@ -165,7 +165,7 @@ class NM_Daterange_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'    => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.email.php
+++ b/classes/inputs/input.email.php
@@ -85,7 +85,7 @@ class NM_Email_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'    => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.file.php
+++ b/classes/inputs/input.file.php
@@ -149,7 +149,7 @@ class NM_File_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'        => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.image.php
+++ b/classes/inputs/input.image.php
@@ -140,7 +140,7 @@ class NM_Image_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'             => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.measure.php
+++ b/classes/inputs/input.measure.php
@@ -125,7 +125,7 @@ class NM_Measure_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'    => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.number.php
+++ b/classes/inputs/input.number.php
@@ -109,7 +109,7 @@ class NM_Number_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'    => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.palettes.php
+++ b/classes/inputs/input.palettes.php
@@ -133,7 +133,7 @@ class NM_Palettes_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'            => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.pricematrix.php
+++ b/classes/inputs/input.pricematrix.php
@@ -107,7 +107,7 @@ class NM_PriceMatrix_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'        => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.quantities.php
+++ b/classes/inputs/input.quantities.php
@@ -123,7 +123,7 @@ class NM_Quantities_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'     => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.radio.php
+++ b/classes/inputs/input.radio.php
@@ -90,7 +90,7 @@ class NM_Radio_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'    => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.section.php
+++ b/classes/inputs/input.section.php
@@ -74,7 +74,7 @@ class NM_Section_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'    => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.select.php
+++ b/classes/inputs/input.select.php
@@ -98,7 +98,7 @@ class NM_Select_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'    => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.text.php
+++ b/classes/inputs/input.text.php
@@ -133,7 +133,7 @@ class NM_Text_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'    => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.textarea.php
+++ b/classes/inputs/input.textarea.php
@@ -110,7 +110,7 @@ class NM_Textarea_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'    => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/inputs/input.timezone.php
+++ b/classes/inputs/input.timezone.php
@@ -105,7 +105,7 @@ class NM_Timezone_wooproduct extends PPOM_Inputs {
 			),
 			'desc_tooltip'    => array(
 				'type'        => 'checkbox',
-				'title'       => __( 'Show tooltip (PRO)', 'woocommerce-product-addon' ),
+				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),

--- a/classes/plugin.class.php
+++ b/classes/plugin.class.php
@@ -321,6 +321,9 @@ class NM_PersonalizedProduct {
 		add_action( 'in_admin_header', 'ppom_hooks_remove_admin_notices', 99 );
 
 		add_filter( 'woocommerce_order_again_cart_item_data', 'ppom_wc_order_again_compatibility', 10, 3 );
+		// Show description tooltip.
+		add_filter( 'ppom_field_description', array( $this, 'show_tooltip' ), 15, 2 );
+
 	}
 
 	/*
@@ -916,5 +919,22 @@ class NM_PersonalizedProduct {
 
 	}
 
+	/**
+	 * Add tooltip.
+	 *
+	 * @param string $description Field description.
+	 * @param array  $meta Field meta.
+	 *
+	 * @return string
+	 */
+	public function show_tooltip( $description, $meta ) {
+		$input_desc = ! empty( $meta['description'] ) ? $meta['description'] : '';
+		$input_desc = apply_filters( 'ppom_description_content', stripslashes( $input_desc ), $meta );
 
+		// Check if the tooltip is enabled.
+		if ( isset( $meta['desc_tooltip'] ) && 'on' === $meta['desc_tooltip'] ) {
+			$description = ( ! empty( $meta['description'] ) ) ? ' <span data-ppom-tooltip="ppom_tooltip" class="ppom-tooltip" title="' . esc_attr( $input_desc ) . '"><svg width="13px" height="13px" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"></path></svg></span>' : '';
+		}
+		return $description;
+	}
 }


### PR DESCRIPTION
### Summary
The tooltip feature is added to the free version and removed from the pro version.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/ppom-pro/issues/403
