### PR TITLE
Fixed syntax highlighter issue with a new group

### DIFF
--- a/classes/fields.class.php
+++ b/classes/fields.class.php
@@ -84,7 +84,7 @@ class PPOM_Fields_Meta {
 		wp_enqueue_style( 'ppom-select2', PPOM_URL . '/css/select2.css' );
 		wp_enqueue_script( 'ppom-select2', PPOM_URL . '/js/select2.js', array( 'jquery' ), PPOM_VERSION, true );
 
-		if ( isset( $_GET['do_meta'] ) && $_GET['do_meta'] == 'edit' ) {
+		if ( ( isset( $_GET['do_meta'] ) && 'edit' === $_GET['do_meta'] ) || ( isset( $_GET['action'] ) && 'new' === $_GET['action'] ) ) {
 
 			// CSS Code Editor Files
 			wp_enqueue_style( 'ppom-codemirror-theme', PPOM_URL . '/css/codemirror-theme.css' );


### PR DESCRIPTION
### Summary
Fixed custom CSS/JS syntax highlighter issue with a new group 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/ppom-pro/issues/390
