### PR TITLE
Fixed conditional field issue with other languages

### DIFF
--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -705,7 +705,7 @@ function ppom_hooks_input_main_wrapper_class( $wrapper_class, $classes_array, $f
 
 		foreach ( $conditions['rules'] as $index => $rule ) {
 
-			$element        = isset( $rule['elements'] ) ? $rule['elements'] : '';
+			$element        = isset( $rule['elements'] ) ? strtolower( $rule['elements']  ): '';
 			$wrapper_class .= " ppom-cond-{$element}";
 			$wrapper_class .= " ppom-locked-{$element}";
 		}

--- a/js/ppom-conditions-v2.js
+++ b/js/ppom-conditions-v2.js
@@ -291,7 +291,7 @@ function ppom_check_conditions(data_name, callback) {
         let cond_elements = [];
         for (var t = 1; t <= total_cond; t++) {
 
-            const cond_element = jQuery(this).data(`cond-input${t}`);
+            const cond_element = jQuery(this).data(`cond-input${t}`)?.toString()?.toLowerCase();
             const cond_val = jQuery(this).data(`cond-val${t}`).toString();
             const operator = jQuery(this).data(`cond-operator${t}`);
             const field_val = ppom_get_element_value(cond_element);


### PR DESCRIPTION
### Summary
In this PR, I've fixed the string comparison issue with non-English text.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/ppom-pro/issues/255
