### PR TITLE
Hide unsupported field option tabs

### DIFF
--- a/js/admin/ppom-admin.js
+++ b/js/admin/ppom-admin.js
@@ -436,7 +436,18 @@ jQuery(function($) {
 
         var field_model_id = 'ppom_field_model_' + field_no + '';
 
-        clone_new_field.find('.ppom_save_fields_model').end().appendTo('.ppom_save_fields_model').attr('id', field_model_id);
+        clone_new_field.find('.ppom_save_fields_model')
+        .end()
+        .appendTo('.ppom_save_fields_model')
+        .attr('id', field_model_id)
+        .find( '.ppom-tabs-header label.ppom-tabs-label' )
+        .each( function( index, item ) {
+            var tabId = $(item).attr('id');
+            var hasTabOptions = $( '#' + field_model_id, document )?.find( '.ppom_handle_' + tabId )?.length > 0;
+            if ( ! hasTabOptions ) {
+                $(item).hide();
+            }
+        } );
         clone_new_field.find('.ppom-field-checker').attr('data-field-index', field_no);
         clone_new_field.find('.ppom-field-checker').addClass('ppom-add-fields-js-action');
 


### PR DESCRIPTION
### Summary

In this PR, I've hidden the unsupported field tabs.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/ppom-pro/issues/420
