### PR TITLE
Locked the data name field on edit mode

### DIFF
--- a/js/admin/ppom-admin.js
+++ b/js/admin/ppom-admin.js
@@ -266,7 +266,8 @@ jQuery(function($) {
         event.preventDefault();
 
         var the_id = $(this).attr('id');
-        $('#ppom_field_model_' + the_id + '').find('.ppom-close-checker').removeClass('ppom-close-fields');
+        $('#ppom_field_model_' + the_id).find('.ppom-close-checker').removeClass('ppom-close-fields');
+        $('#ppom_field_model_' + the_id).find('input[data-metatype="data_name"]').attr('readonly', true);
     });
 
 
@@ -990,7 +991,7 @@ jQuery(function($) {
         if (wp_field == 'shipping_fields' || wp_field == 'billing_fields') {
             return;
         }
-        selector.find('[data-meta-id="data_name"] input[type="text"]').val(field_id);
+        selector.find('[data-meta-id="data_name"] input[type="text"]:not([readonly])').val(field_id);
     });
 
 

--- a/js/admin/ppom-admin.js
+++ b/js/admin/ppom-admin.js
@@ -59,6 +59,7 @@ jQuery(function($) {
         e.preventDefault();
         $("body").append(append_overly_model);
         var modalBox = $(this).attr('data-modal-id');
+        lockedDataName = false;
         $('#' + modalBox).fadeIn();
     });
 

--- a/js/admin/ppom-admin.js
+++ b/js/admin/ppom-admin.js
@@ -262,12 +262,13 @@ jQuery(function($) {
     /**
         9- Edit Existing Fields
     **/
+    var lockedDataName = false;
     $(document).on('click', '.ppom-edit-field', function(event) {
         event.preventDefault();
 
         var the_id = $(this).attr('id');
         $('#ppom_field_model_' + the_id).find('.ppom-close-checker').removeClass('ppom-close-fields');
-        $('#ppom_field_model_' + the_id).find('input[data-metatype="data_name"]').attr('readonly', true);
+        lockedDataName = true;
     });
 
 
@@ -989,6 +990,9 @@ jQuery(function($) {
 
         var wp_field = selector.find('.ppom-fields-actions').attr('data-table-id');
         if (wp_field == 'shipping_fields' || wp_field == 'billing_fields') {
+            return;
+        }
+        if ( true === lockedDataName ) {
             return;
         }
         selector.find('[data-meta-id="data_name"] input[type="text"]:not([readonly])').val(field_id);


### PR DESCRIPTION
### Summary

I locked the data name field during the edit field.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes #82