### PR TITLE
chore: redo addons page content

### DIFF
--- a/css/ppom-admin.css
+++ b/css/ppom-admin.css
@@ -1001,7 +1001,7 @@ ul.ppom-options-container li label {
 .ppom_addons_model_cards_item {
     display: flex;
     padding: 1rem;
-    width: 33%;
+    width: 50%;
 }
 
 @media only screen and (max-width: 600px) {
@@ -1018,6 +1018,7 @@ ul.ppom-options-container li label {
     display: flex;
     flex-direction: column;
     min-height: 240px;
+    width: 100%;
 
     overflow: hidden;
 }

--- a/inc/arrays.php
+++ b/inc/arrays.php
@@ -671,422 +671,57 @@ function ppom_array_get_addons_details() {
 
 	$addons = array(
 		array(
-			'title'   => __( 'Personalization Preview', 'woocommerce-product-addon' ),
-			'desc'    => __( 'PPOM Personalization Preview Addon is the best and simple solution for web2print business using WooCommerce. Now define a fixed position and area for Text in your Templates like on Mug, T-shirt or Visiting Cards with preset font family, size. The client will fill the text with his all of its attributes and send to cart. It’s like a smart Product Designer. Multiple templates can also be attached to one product.', 'woocommerce-product-addon' ),
+			'title'   => __( '30+ Premium Field Types', 'woocommerce-product-addon' ),
+			'desc'    => __( 'PPOM Pro expands your product customization options with over 30 advanced field types, including Date Picker, Image Cropper, Quantities Pack, and Color Picker. These powerful fields allow you to create tailored product flows, offering customers a highly personalized shopping experience and enabling more dynamic interactions with your products.', 'woocommerce-product-addon' ),
 			'actions' => array(
 				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#texter',
+					'title' => __( 'Documentation', 'woocommerce-product-addon' ),
+					'link'  => 'https://docs.themeisle.com/article/1801-what-is-the-difference-between-ppom-free-and-ppom-pro',
 				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Fixed Price', 'woocommerce-product-addon' ),
-			'desc'    => __( 'Sometimes prices are very complex like for a printing company, they are selling their visiting cards in Packages.So Package Price Add-on allows admin to set prices against package. It’s usage is very simple, just add quantity (package) and it’s price. There is also option to set unit like you are selling visiting cards then unit may called as “cards”.', 'woocommerce-product-addon' ),
-			'actions' => array(),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Fields PopUp', 'woocommerce-product-addon' ),
-			'desc'    => __( 'PPOM Fields PopUp wrap all PPOM fields inside a popup. A product with large number of fields can now has simple button with customized label. To enable this PopUp just one click required in product edit page. ', 'woocommerce-product-addon' ),
-			'actions' => array(),
-			'type' => 'feature'
-		),
-		array(
-			'title'   => __( 'Font Picker', 'woocommerce-product-addon' ),
-			'desc'    => __( 'Font selector loads fonts from Google and client can pick font and can see live preview of font effect. Admin can also filter font families and set Custom Fonts.', 'woocommerce-product-addon' ),
-			'actions' => array(
 				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#fonts-picker',
+					'title' => __( 'Demo', 'woocommerce-product-addon' ),
+					'link'  => 'https://demo-ppom-lite.vertisite.cloud/',
 				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Image DropDown', 'woocommerce-product-addon' ),
-			'desc'    => __( 'PPOM Image DropDown Addon show images inside a select box. The title, description, and prices can be added along with all images. It’s best when you have a long list of images and don’t want to use Image Type input.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#image-dropdown',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Bulk Quantity Options', 'woocommerce-product-addon' ),
-			'desc'    => __( 'Bulk Quantity for Options Addon allow store admin to set discount prices for each options. This Addon is best tool for companies like Printin, designing and who looking to sale products with options with different prices.', 'woocommerce-product-addon' ),
-			'actions' => array(),
+			),	
 			'type' => 'field'
 		),
 		array(
 			'title'   => __( 'Cart Edit', 'woocommerce-product-addon' ),
-			'desc'    => __( 'PPOM Cart Edit Addon allow clients to edit fields once these are added to cart on cart page. It has also option to show all meta fields in different column on cart page. Extra column can be disable from Settings -> PPOM Cart tab.', 'woocommerce-product-addon' ),
-			'actions' => array(),
+			'desc'    => __( 'The Cart Edit addon can help the visitors of your website easily change their orders to suit their needs while they\'re checking the cart.  By enabling this, an Edit Options button will appear in the cart under the products\' names. This will get visitors to the product\'s page to change their choices.', 'woocommerce-product-addon' ),
+			'actions' => array(
+				array(
+					'title' => __( 'Documentation', 'woocommerce-product-addon' ),
+					'link'  => 'https://docs.themeisle.com/article/1793-how-to-enable-the-cart-edit-in-ppom',
+				),
+			),
 			'type' => 'feature'
-		),
-		array(
-			'title'   => __( 'Domain Checker', 'woocommerce-product-addon' ),
-			'desc'    => __( 'Domain Checker Addon will check any domain’s availability. Adds domain to cart if it’s not already registered. A simple solution to sell domains with WooCommerce PPOM. Customized messages for domain availability/not-availability. Ajax base script to check domain and show result.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#domain',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Quantities Pack', 'woocommerce-product-addon' ),
-			'desc'    => __( 'PPOM Quantity Pack Add-on is a special input type which is very similar to Variation Quantities input but with a good difference. Like if you are want to sell some products with different options in specific quantities, not sure?', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#quantities-pack',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Super List', 'woocommerce-product-addon' ),
-			'desc'    => __( 'PPOM Super List addon contains many pre-defined lists to render as Select field on product page. It includes Countries, Currencies, Months etc. ', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#super-list',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Collapse', 'woocommerce-product-addon' ),
-			'desc'    => __( 'PPOM Field Collapsed Add-on is front-end design which groups field inside beautiful section. Like steps, and if your product has a large number of fields then it is the best add-on to a short length of your product page.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#collapse',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Text Counter', 'woocommerce-product-addon' ),
-			'desc'    => __( 'PPOM Text Counter Add-on is special type text input field. It can restrict a total number of words or character with nice info panel below. Each word or character can be changed and the price will be added to cart.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#text-counter',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Enquiry Form', 'woocommerce-product-addon' ),
-			'desc'    => __( 'PPOM Enquiry Form Add-on adds button on product page. A customer can ask the admin about any product with PPOM Field in email. All PPOM Meta Fields are sent with message typed by the customer. Multiple email recipients can be added for product enquiry.', 'woocommerce-product-addon' ),
-			'actions' => array(),
-			'type' => 'feature'
-		),
-		array(
-			'title'   => __( 'Variation Quantity Matrix', 'woocommerce-product-addon' ),
-			'desc'    => __( 'PPOM Variation Quantity Matrix Add-on is an advanced form of Variation Quantity Field. Variation Quantity Matrix is a super simple form when quantities need to be collected against multiple options. Like if you selling T-Shirt and need to collect Quantities against each Color of each Size, this Add-on can be used to render a Tabular/Grid. ', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#variation-matrix',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Quantity Option', 'woocommerce-product-addon' ),
-			'desc'    => __( 'PPOM Quantity Option Add-on is simple ‘Number’ input type which can be used to accept option quantity BUT Price can also be set. Like for a Pizza Product, customer have a option to order more then one drink and each extra drink as price. Here this Option Quantity will do the trick.  This Add-on can be used as Name your Price.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#quantity-option',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Emojis', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'The Emoji field adds emoji support to the input (can be textarea, text, dropdown.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#emojis',
-				),
-				array(
-					'title' => __( 'Screenshot (Front)', 'woocommerce-product-addon' ),
-					'link'  => 'https://vertis.d.pr/i/vp3wRy',
-				),
-				array(
-					'title' => __( 'Screenshot (Admin)', 'woocommerce-product-addon' ),
-					'link'  => 'https://vertis.d.pr/i/9SaoOW',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Phone Input', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'The Phone field provides a formatted text input field with a country selection dropdown.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#phone-input',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Chained Input', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'Allows to create chained dropdown options.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#chained-input',
-				),
-				array(
-					'title' => __( 'Screenshot (Front)', 'woocommerce-product-addon' ),
-					'link'  => 'https://vertis.d.pr/i/kFexj7',
-				),
-				array(
-					'title' => __( 'Screenshot (Admin)', 'woocommerce-product-addon' ),
-					'link'  => 'https://vertis.d.pr/i/j4ZiNf',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Conditional Images', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'That field is used to show dependent fields according to the selected image.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#conditional-images',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Select Option Quantity', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'This input allows you to display a dropdown with options along with their quantities.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#select-option',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Radio Switcher', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'The Radio Switcher input creates a more appealing view for the product page, and it allows different images for each option.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#radio-switcher',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Date Range Input', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'Date Range Picker allows clients to select dates, times, or from predefined ranges.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#date-range-picker',
-				),
-				array(
-					'title' => __( 'Demo', 'woocommerce-product-addon' ),
-					'link'  => 'https://demo-ppom-lite.vertisite.cloud/product/demo-for-date-range-input/',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Color Picker', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'Color Picker allows the client to select a color. Palette colors can also be defined in settings.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#color-picker-input',
-				),
-				array(
-					'title' => __( 'Demo', 'woocommerce-product-addon' ),
-					'link'  => 'https://demo-ppom-lite.vertisite.cloud/product/demo-for-color-picker/',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'File Input', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'File Input allows clients to upload files from their computers or mobile devices. Admin can set any file type and size.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#file-upload',
-				),
-				array(
-					'title' => __( 'Demo', 'woocommerce-product-addon' ),
-					'link'  => 'https://demo-ppom-lite.vertisite.cloud/product/demo-for-file-upload-input/',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Image Cropper', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'Just like a File Upload but only supports images with a nice cropper using Croppie JS API.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#image-cropper',
-				),
-				array(
-					'title' => __( 'Demo', 'woocommerce-product-addon' ),
-					'link'  => 'https://demo-ppom-lite.vertisite.cloud/product/demo-for-basic-image-cropping-input/',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Timezone Input', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'Timezone input is a unique form of Select Input, but it has a predefined list of all Time-zones. Different Time-zones can also be filtered with options.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#timezone-input',
-				),
-				array(
-					'title' => __( 'Demo', 'woocommerce-product-addon' ),
-					'link'  => 'https://demo-ppom-lite.vertisite.cloud/product/demo-for-timezone-with-region/',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Variation Quantity', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'Variation Quantities allow clients to order different quantities against different options.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#variation-quantities',
-				),
-				array(
-					'title' => __( 'Demo', 'woocommerce-product-addon' ),
-					'link'  => 'https://demo-ppom-lite.vertisite.cloud/product/demo-for-variation-quantities/',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Images', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'Image input is just like Radio/Checkbox, but images can be uploaded against each option. Price can also be set against each image option.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#image-option-input',
-				),
-				array(
-					'title' => __( 'Demo', 'woocommerce-product-addon' ),
-					'link'  => 'https://demo-ppom-lite.vertisite.cloud/product/demo-for-images-options/',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Price Matrix', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'Price Matrix allows admin to offer client Less Price on Bulk/More quantities. More quantities will decrease the price set in the matrix.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#price-matrix',
-				),
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://demo-ppom-lite.vertisite.cloud/product/demo-for-price-matrix-discount/',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'HTML', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'It’s not input, just to add content/text or HTML. Added HTML is shown on product details.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#html-content',
-				),
-				array(
-					'title' => __( 'Demo', 'woocommerce-product-addon' ),
-					'link'  => 'https://demo-ppom-lite.vertisite.cloud/product/demo-for-basic-html-with-content/',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Color Palettes', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'Display the variations of the products using the Color Palettes. You create the palette from the colors which you wish.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#color-palettes',
-				),
-				array(
-					'title' => __( 'Demo', 'woocommerce-product-addon' ),
-					'link'  => 'https://demo-ppom-lite.vertisite.cloud/product/demo-for-color-palette/',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Audio / Video', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'Audio/Video input allows clients to select Audio/Video options uploaded by Admin in the media library. It’s similar to Image type input but with a different media type. Price can also be set against each option.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#audio-video-input',
-				),
-				array(
-					'title' => __( 'Demo', 'woocommerce-product-addon' ),
-					'link'  => 'https://demo-ppom-lite.vertisite.cloud/product/demo-for-video-audio/',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Measure Input', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'Depending on the products that you provide, some of them could require some measurement specifications, and this can be done using Measure Input.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#measure-input',
-				),
-				array(
-					'title' => __( 'Demo', 'woocommerce-product-addon' ),
-					'link'  => 'https://demo-ppom-lite.vertisite.cloud/product/demo-for-measure-input/',
-				),
-			),
-			'type' => 'field'
-		),
-		array(
-			'title'   => __( 'Divider', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'This input allows you to define each meta field better and to create a more attractive design for your products.', 'woocommerce-product-addon' ),
-			'actions' => array(
-				array(
-					'title' => __( 'Docs', 'woocommerce-product-addon' ),
-					'link'  => 'https://docs.themeisle.com/article/1702-ppom-pro-input-types#divider',
-				),
-			),
-			'type' => 'field'
 		),
 		array(
 			'title'   => __( 'Conditional Field Repeater', 'woocommerce-product-addon' ),
-			'desc'    => esc_html__( 'Conditional Field Repeater is a feature used to repeat a PPOM field by the value of another PPOM field (number field).', 'woocommerce-product-addon' ),
+			'desc'    => esc_html__( 'Conditional Field Repeater allows you to duplicate PPOM fields, enabling customers to repeat a set of options for multiple entries. This is perfect for scenarios where customers need to provide varied input for the same product, like ordering shirts with multiple custom text lines to be printed.', 'woocommerce-product-addon' ),
+			'actions' => array(
+				array(
+					'title' => __( 'Documentation', 'woocommerce-product-addon' ),
+					'link'  => 'https://docs.themeisle.com/article/1700-personalized-product-meta-manager#conditional-repeater',
+				),
+			),
+			'type' => 'feature'
+		),
+		array(
+			'title'   => __( 'Enquiry Form', 'woocommerce-product-addon' ),
+			'desc'    => __( 'Enquiry Form Add-on enhances your product pages by adding a customizable enquiry button. It allows customers to send inquiries directly to the admin about products with PPOM Fields via email. All associated PPOM Meta Fields are included in the customer\'s message.', 'woocommerce-product-addon' ),
 			'actions' => array(),
+			'type' => 'feature'
+		),
+		array(
+			'title'   => __( 'Fields Popup', 'woocommerce-product-addon' ),
+			'desc'    => __( 'The Fields Popup addon allows the PPOM meta fields to be displayed inside a popup on the product page.', 'woocommerce-product-addon' ),
+			'actions' => array(
+				array(
+					'title' => __( 'Documentation', 'woocommerce-product-addon' ),
+					'link'  => 'https://docs.themeisle.com/article/1982-how-to-configure-the-field-popup-in-ppom',
+				),
+			),	
 			'type' => 'feature'
 		),
 	);

--- a/templates/admin/addons-list.php
+++ b/templates/admin/addons-list.php
@@ -45,7 +45,6 @@ $addons_list = ppom_array_get_addons_details();
 				$addon_title = isset( $meta['title'] ) ? $meta['title'] : '';
 				$addon_desc  = isset( $meta['desc'] ) ? $meta['desc'] : '';
 				$actions     = isset( $meta['actions'] ) ? $meta['actions'] : '';
-				$type     = ( isset( $meta['type'] ) && array_key_exists( $meta['type'], $types ) ) ? $types[$meta['type']] : '';
 
 				?>
 				<li class="ppom_addons_model_cards_item">
@@ -53,16 +52,18 @@ $addons_list = ppom_array_get_addons_details();
 						<div class="ppom_addons_model_card_content">
 							<div class="ppom_addons_model_heading_button_display">
 								<h4 class="ppom_addons_model_card_title"><?php echo $addon_title; ?></h4>
-								<span class="badge badge-secondary"><?php esc_html_e('PRO', 'woocommerce-product-addon'); ?></span>
-								<span style="margin-right:5px" class="ppom-addon-type badge badge-secondary"><?php echo esc_html( $type ); ?></span>
+								<?php if ( ! ppom_pro_is_installed() ) : ?>
+									<span class="badge badge-secondary"><?php esc_html_e('PRO', 'woocommerce-product-addon'); ?></span>
+								<?php endif; ?>
 							</div>
 							<hr>
 							<p class="ppom_addons_model_card_text"><?php echo $addon_desc; ?></p>
 							<hr>
 							<div class="ppom-admin-addons-actions">
-								<a class="ppom_addons_model_card_btn"
-								href="<?php echo tsdk_utmify( tsdk_translate_link( PPOM_UPGRADE_URL ), sanitize_key( $addon_title ), 'alladdonspage' ); ?>"
-								target="_blank"><?php esc_html_e('Get Started', 'woocommerce-product-addon'); ?></a>
+								<?php if ( ! ppom_pro_is_installed() ) : ?>
+									<a class="ppom_addons_model_card_btn" href="<?php echo tsdk_utmify( tsdk_translate_link( PPOM_UPGRADE_URL ), sanitize_key( $addon_title ), 'alladdonspage' ); ?>" target="_blank"><?php esc_html_e('Get Started', 'woocommerce-product-addon'); ?></a>
+								<?php endif; ?>
+
 								<?php
 									foreach ( $actions as $action ) {
 										$btn_title = isset( $action['title'] ) ? $action['title'] : '';


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
This PR updates Addons page, and makes few changes:

- Removes separate Field cards and replaces them with a single card outlining all the field types.
- Redoes the description of Addons, and adds Docs link where I could find them.
- Removes Get Starter link for Pro users.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

![Screen Shot 2024-09-12 at 10 24 44-fullpage](https://github.com/user-attachments/assets/f8aca39a-d522-4846-9cfd-757063fb3a2d)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure the content is relevant.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/388.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
