### PR TITLE
Improved the image displayed on the order edit page

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -1541,10 +1541,16 @@ function ppom_extract_matrix_by_quantity( $quantities_field, $product, $quantity
 	return $matrix;
 }
 
-// Return thumbs size
-function ppom_get_thumbs_size() {
+/**
+ * Thumbnail image size.
+ *
+ * @param int $size Image size.
+ *
+ * @return string
+ */
+function ppom_get_thumbs_size( $size = 150 ) {
 
-	return apply_filters( 'ppom_thumbs_size', '150px' );
+	return apply_filters( 'ppom_thumbs_size', sprintf( '%dpx', absint( $size ) ) );
 }
 
 // Return file size in kb
@@ -1638,7 +1644,7 @@ function ppom_generate_html_for_images( $images ) {
 		$images_meta = json_decode( stripslashes( $images_meta ), true );
 		$image_url   = stripslashes( $images_meta['link'] );
 		$image_label = isset( $images_meta['raw'] ) ? $images_meta['raw'] : '';
-		$image_html  = '<img class="img-thumbnail" style="width:' . esc_attr( ppom_get_thumbs_size() ) . '" src="' . esc_url( $image_url ) . '" title="' . esc_attr( $image_label ) . '">';
+		$image_html  = '<img class="img-thumbnail" style="width:' . esc_attr( ppom_get_thumbs_size( 75 ) ) . '" src="' . esc_url( $image_url ) . '" title="' . esc_attr( $image_label ) . '">';
 
 		$ppom_html .= '<tr><td><a href="' . esc_url( $image_url ) . '" class="lightbox" itemprop="image" title="' . esc_attr( $image_label ) . '">' . $image_html . '</a></td>';
 		$ppom_html .= '<td>' . esc_attr( ppom_files_trim_name( $image_label ) ) . '</td>';


### PR DESCRIPTION
### Summary
I've decreased the thumbnail image size for cart item data to fix the broken layout issue on the order edit page.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/ppom-pro/issues/166
