### PR TITLE
Keep the original file name in the cart

### DIFF
--- a/inc/files.php
+++ b/inc/files.php
@@ -107,7 +107,7 @@ function ppom_create_thumb_for_meta( $file_name, $product_id, $cropped = false, 
 
 	$ppom_html  = '<table class="table table-bordered">';
 	$ppom_html .= '<tr><td><a href="' . esc_url( $file_link ) . '" class="lightbox et_pb_lightbox_image" itemprop="image" title="' . esc_attr( $file_name ) . '">' . $thumb_html . '</a></td>';
-	$ppom_html .= '<td>' . esc_attr( ppom_files_trim_name( $file_name ) ) . '</td>';
+	$ppom_html .= '<td style="max-width:300px;text-align:left;">' . esc_attr( ppom_files_trim_name( $file_name ) ) . '</td>';
 	$ppom_html .= '</tr>';
 
 	// Checking if cropped file existing
@@ -207,7 +207,9 @@ function ppom_upload_file() {
 	$file_name       = wp_unique_filename( $file_path_thumb, $file_name );
 	$file_name       = strtolower( $file_name );
 	$file_path       = $file_dir_path . $file_name;
-
+	$file_ext        = pathinfo( $file_name, PATHINFO_EXTENSION );
+	$unique_hash     = md5( microtime() );
+	$file_name       = str_replace( ".$file_ext", ".$unique_hash.$file_ext", $file_name );
 	// var_dump($file_path); exit;
 
 	// Make sure the fileName is unique but only if chunking is disabled
@@ -521,6 +523,8 @@ function ppom_uploaded_file_preview( $file_name, $settings ) {
 
 // Trim long filename to short
 function ppom_files_trim_name( $file_name ) {
+
+	return $file_name;
 
 	$text_length = strlen( $file_name );
 

--- a/inc/files.php
+++ b/inc/files.php
@@ -521,25 +521,15 @@ function ppom_uploaded_file_preview( $file_name, $settings ) {
 	return apply_filters( 'ppom_file_preview_html', $html, $file_name, $settings );
 }
 
-// Trim long filename to short
+/**
+ * File name.
+ *
+ * @param string $file_name File name.
+ *
+ * @return string
+ */
 function ppom_files_trim_name( $file_name ) {
-
 	return $file_name;
-
-	$text_length = strlen( $file_name );
-
-	// for different language string
-	$string_utf8 = strlen( utf8_decode( $file_name ) );
-
-	$max_chars = apply_filters( 'ppom_trim_file_maxchar', 20 );
-
-	if ( $text_length > $max_chars && $text_length == $string_utf8 ) {
-		$trimmed_filename = substr_replace( $file_name, '...', $max_chars / 2, $text_length - $max_chars );
-	} else {
-		$trimmed_filename = $file_name;
-	}
-
-	return $trimmed_filename;
 }
 
 

--- a/js/file-upload.js
+++ b/js/file-upload.js
@@ -325,6 +325,7 @@ function ppom_setup_file_upload_input(file_input) {
         max_file_count: parseInt(file_input.files_allowed),
         unique_names: ppom_file_vars.enable_file_rename,
         chunk_size: '2mb',
+        unique_names: false,
 
         filters: {
             mime_types: [


### PR DESCRIPTION

### Summary
I've kept the original file name on the cart page with the unique hash. e.g: `<original file name>.<random hash>.<file extension>`

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES/NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

-
-

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/191
