### PR TITLE
feat: add new condition options and improve UX & UI

### DIFF
--- a/classes/fields.class.php
+++ b/classes/fields.class.php
@@ -788,7 +788,7 @@ class PPOM_Fields_Meta {
 					$html_input .= '</select>';
 					$html_input .= '</div>';
 
-					$html_input .= '<div class="col-md-2 col-sm-2 ppom-only-if">';
+					$html_input .= '<div>';
 					$html_input .= '<p>' . __( 'only if', 'woocommerce-product-addon' ) . '</p>';
 					$html_input .= '</div>';
 
@@ -807,8 +807,18 @@ class PPOM_Fields_Meta {
 					$html_input .= '<div class="row ppom-condition-clone-js">';
 					foreach ( $condition_rules as $rule_index => $condition ) {
 
-						$element_values   = isset( $condition['element_values'] ) ? stripslashes( $condition['element_values'] ) : '';
-						$element          = isset( $condition['elements'] ) ? stripslashes( $condition['elements'] ) : '';
+						$element_values         = isset( $condition['element_values'] ) ? stripslashes( $condition['element_values'] ) : '';
+						$element                = isset( $condition['elements'] ) ? stripslashes( $condition['elements'] ) : '';
+						$element_constant_value = isset( $condition['element_constant'] ) ? stripslashes( $condition['element_constant'] ) : '';
+
+						$element_between_value_to   = '';
+						$element_between_value_from = '';
+
+						if ( isset( $condition['cond-between-interval'] ) && is_array( $condition['cond-between-interval'] ) ) {
+							$element_between_value_to   = isset( $condition['cond-between-interval']['to'] ) ? $condition['cond-between-interval']['to'] : '';
+							$element_between_value_from = isset( $condition['cond-between-interval']['from'] ) ? $condition['cond-between-interval']['from'] : '';
+						}
+
 						$operator_is      = ( $condition['operators'] == 'is' ) ? 'selected="selected"' : '';
 						$operator_not     = ( $condition['operators'] == 'not' ) ? 'selected="selected"' : '';
 						$operator_greater = ( $condition['operators'] == 'greater than' ) ? 'selected="selected"' : '';
@@ -826,22 +836,53 @@ class PPOM_Fields_Meta {
 						$html_input .= '</div>';
 
 						// is value meta
-						$html_input .= '<div class="col-md-2 col-sm-2">';
+						$pro_enabled = ppom_pro_is_installed() && 'valid' === apply_filters( 'product_ppom_license_status', '' );
+
+						$html_input .= '<div class="col-md-3 col-sm-3">';
 						$html_input .= '<select name="ppom[' . esc_attr( $field_index ) . '][conditions][rules][' . esc_attr( $rule_index ) . '][operators]" class="form-control ppom-conditional-keys" data-metatype="operators">';
+
+						$html_input .= '<optgroup label="' . __( 'Value Comparison', 'woocommerce-product-addon' ) . '">';
 						$html_input .= '<option ' . $operator_is . ' value="is">' . __( 'is', 'woocommerce-product-addon' ) . '</option>';
-						$html_input .= '<option ' . $operator_not . ' value="not">' . __( 'not', 'woocommerce-product-addon' ) . '</option>';
+						$html_input .= '<option ' . $operator_not . ' value="not">' . __( 'is not', 'woocommerce-product-addon' ) . '</option>';
+						$html_input .= '<option ' . selected( 'empty', $condition['operators'], false ) . ' value="empty">' . __( 'is empty', 'woocommerce-product-addon' ) . '</option>';
+						$html_input .= '<option ' . selected( 'any', $condition['operators'], false ) . ' value="any">' . __( 'has any value', 'woocommerce-product-addon' ) . '</option>';
+						$html_input .= '</optgroup>';
+
+						$html_input .= '<optgroup label="' . __( 'Text Matching', 'woocommerce-product-addon' ) . '">';
+						$html_input .= '<option ' . selected( 'contains', $condition['operators'], false ) . ' value="contains" ' . disabled( false, $pro_enabled, false ) . '>' . __( 'contains', 'woocommerce-product-addon' ) . ( ! $pro_enabled ? ' (PRO)' : '' ) . '</option>';
+						$html_input .= '<option ' . selected( 'not-contains', $condition['operators'], false ) . ' value="not-contains" ' . disabled( false, $pro_enabled, false ) . '>' . __( 'does not contain', 'woocommerce-product-addon' ) . ( ! $pro_enabled ? ' (PRO)' : '' ) . '</option>';
+						$html_input .= '<option ' . selected( 'regex', $condition['operators'], false ) . ' value="regex" ' . disabled( false, $pro_enabled, false ) . '>' . __( 'matches RegEx', 'woocommerce-product-addon' ) . ( ! $pro_enabled ? ' (PRO)' : '' ) . '</option>';
+						$html_input .= '</optgroup>';
+
+						$html_input .= '<optgroup label="' . __( 'Numeric Comparison', 'woocommerce-product-addon' ) . '">';
 						$html_input .= '<option ' . $operator_greater . ' value="greater than">' . __( 'greater than', 'woocommerce-product-addon' ) . '</option>';
 						$html_input .= '<option ' . $operator_less . ' value="less than">' . __( 'less than', 'woocommerce-product-addon' ) . '</option>';
+						$html_input .= '<option ' . selected( 'between', $condition['operators'], false ) . ' value="between" ' . disabled( false, $pro_enabled, false ) . '>' . __( 'is between', 'woocommerce-product-addon' ) . ( ! $pro_enabled ? ' (PRO)' : '' ) . '</option>';
+						$html_input .= '<option ' . selected( 'number-multiplier', $condition['operators'], false ) . ' value="number-multiplier" ' . disabled( false, $pro_enabled, false ) . '>' . __( 'is multiple of', 'woocommerce-product-addon' ) . ( ! $pro_enabled ? ' (PRO)' : '' ) . '</option>';
+						$html_input .= '<option ' . selected( 'even-number', $condition['operators'], false ) . ' value="even-number" ' . disabled( false, $pro_enabled, false ) . '>' . __( 'is even', 'woocommerce-product-addon' ) . ( ! $pro_enabled ? ' (PRO)' : '' ) . '</option>';
+						$html_input .= '<option ' . selected( 'odd-number', $condition['operators'], false ) . ' value="odd-number" ' . disabled( false, $pro_enabled, false ) . '>' . __( 'is odd', 'woocommerce-product-addon' ) . ( ! $pro_enabled ? ' (PRO)' : '' ) . '</option>';
+						$html_input .= '</optgroup>';
+
 						$html_input .= '</select> ';
 						$html_input .= '</div>';
 
 						// conditional elements values
-						$html_input .= '<div class="col-md-4 col-sm-4">';
+						$html_input .= '<div class="col-md-3 col-sm-3">';
 
 						$html_input .= '<select name="ppom[' . esc_attr( $field_index ) . '][conditions][rules][' . esc_attr( $rule_index ) . '][element_values]" class="form-control ppom-conditional-keys" data-metatype="element_values"
 										data-existingvalue="' . esc_attr( $element_values ) . '" >';
 						$html_input .= '<option>' . $element_values . '</option>';
 						$html_input .= '</select>';
+						$html_input .= '<input name="ppom[' . esc_attr( $field_index ) . '][conditions][rules][' . esc_attr( $rule_index ) . '][element_constant]" class="form-control ppom-conditional-keys ppom-hide-element" data-metatype="element_constant" value="' . esc_attr( $element_constant_value ) . '" >';
+
+						$html_input .= '<div class="ppom-between-input-container ppom-hide-element"> ';
+						$html_input .= '<input type="number" name="ppom[' . esc_attr( $field_index ) . '][conditions][rules][' . esc_attr( $rule_index ) . '][cond-between-interval][from]" class="form-control ppom-conditional-keys" data-metatype="between-input-from" value="' . esc_attr( $element_between_value_from ) . '" pattern="^\\d+(\\.\\d{1,4})?$">';
+						$html_input .= '<span>' . __( 'and', 'woocommerce-product-addon' ) . '</span>';
+						$html_input .= '<input type="number" name="ppom[' . esc_attr( $field_index ) . '][conditions][rules][' . esc_attr( $rule_index ) . '][cond-between-interval][to]" class="form-control ppom-conditional-keys" data-metatype="between-input-to" value="' . esc_attr( $element_between_value_to ) . '" pattern="^\\d+(\\.\\d{1,4})?$">';
+						$html_input .= '</div>';
+
+						// Upsell
+						$html_input .= '<a class="ppom-upsell-condition ppom-hide-element" target="_blank" href="' . esc_url( tsdk_utmify( tsdk_translate_link( PPOM_UPGRADE_URL ), 'input-field-edit', 'condition' ) ) . '"><span class="dashicons dashicons-external"></span> ' . __('Upgrade to Unlock', 'woocommerce-product-addon') . '</a>';
 
 						// $html_input .= '<input type="text" name="ppom['.esc_attr($field_index).'][conditions][rules]['.esc_attr($rule_index).'][element_values]" class="form-control ppom-conditional-keys" value="'.esc_attr($element_values).'" placeholder="Enter Option" data-metatype="element_values">';
 						$html_input .= '</div>';
@@ -870,6 +911,9 @@ class PPOM_Fields_Meta {
 					$html_input .= '<option value="Hide">' . __( 'Hide', 'woocommerce-product-addon' ) . '</option>';
 					$html_input .= '</select> ';
 					$html_input .= '</div>';
+					$html_input .= '<div>';
+					$html_input .= '<p>' . __( 'only if', 'woocommerce-product-addon' ) . '</p>';
+					$html_input .= '</div>';
 					$html_input .= '<div class="col-md-4 col-sm-4">';
 					$html_input .= '<select class="form-control ppom-condition-visible-bound" data-metatype="bound">';
 					$html_input .= '<option value="All">' . __( 'All', 'woocommerce-product-addon' ) . '</option>';
@@ -891,12 +935,33 @@ class PPOM_Fields_Meta {
 					$html_input .= '</div>';
 
 					// is
+					$pro_enabled = ppom_pro_is_installed() && 'valid' === apply_filters( 'product_ppom_license_status', '' );
+
 					$html_input .= '<div class="col-md-2 col-sm-2">';
 					$html_input .= '<select data-metatype="operators" class="ppom-conditional-keys form-control">';
+
+					$html_input .= '<optgroup label="' . __( 'Value Comparison', 'woocommerce-product-addon' ) . '">';
+					$html_input .= '<option value="any">' . __( 'has any value', 'woocommerce-product-addon' ) . '</option>';
+					$html_input .= '<option value="empty">' . __( 'is empty', 'woocommerce-product-addon' ) . '</option>';
 					$html_input .= '<option value="is">' . __( 'is', 'woocommerce-product-addon' ) . '</option>';
-					$html_input .= '<option value="not">' . __( 'not', 'woocommerce-product-addon' ) . '</option>';
+					$html_input .= '<option value="not">' . __( 'is not', 'woocommerce-product-addon' ) . '</option>';
+					$html_input .= '</optgroup>';
+
+					$html_input .= '<optgroup label="' . __( 'Text Matching', 'woocommerce-product-addon' ) . '">';
+					$html_input .= '<option value="' . ( $pro_enabled ? 'contains' : '' ) . '"' . disabled( false, $pro_enabled, false ) . '>' . __( 'contains', 'woocommerce-product-addon' ) . ( ! $pro_enabled ? ' (PRO)' : '' ) . '</option>';
+					$html_input .= '<option value="' . ( $pro_enabled ? 'not-contains' : '' ) . '"' . disabled( false, $pro_enabled, false ) . '>' . __( 'does not contain', 'woocommerce-product-addon' ) . ( ! $pro_enabled ? ' (PRO)' : '' ) . '</option>';
+					$html_input .= '<option value="' . ( $pro_enabled ? 'regex' : '' ) . '"' . disabled( false, $pro_enabled, false ) . '>' . __( 'matches RegEx', 'woocommerce-product-addon' ) . ( ! $pro_enabled ? ' (PRO)' : '' ) . '</option>';
+					$html_input .= '</optgroup>';
+
+					$html_input .= '<optgroup label="' . __( 'Numeric Comparison', 'woocommerce-product-addon' ) . '">';
 					$html_input .= '<option value="greater than">' . __( 'greater than', 'woocommerce-product-addon' ) . '</option>';
 					$html_input .= '<option value="less than">' . __( 'less than', 'woocommerce-product-addon' ) . '</option>';
+					$html_input .= '<option value="' . ( $pro_enabled ? 'even-number' : '' ) . '"' . disabled( false, $pro_enabled, false ) . '>' . __( 'is even', 'woocommerce-product-addon' ) . ( ! $pro_enabled ? ' (PRO)' : '' ) . '</option>';
+					$html_input .= '<option value="' . ( $pro_enabled ? 'odd-number' : '' ) . '"' . disabled( false, $pro_enabled, false ) . '>' . __( 'is odd', 'woocommerce-product-addon' ) . ( ! $pro_enabled ? ' (PRO)' : '' ) . '</option>';
+					$html_input .= '<option value="' . ( $pro_enabled ? 'between' : '' ) . '"' . disabled( false, $pro_enabled, false ) . '>' . __( 'is between', 'woocommerce-product-addon' ) . ( ! $pro_enabled ? ' (PRO)' : '' ) . '</option>';
+					$html_input .= '<option value="' . ( $pro_enabled ? 'number-multiplier' : '' ) . '"' . disabled( false, $pro_enabled, false ) . '>' . __( 'is multiple of', 'woocommerce-product-addon' ) . ( ! $pro_enabled ? ' (PRO)' : '' ) . '</option>';
+					$html_input .= '</optgroup>';
+
 					$html_input .= '</select> ';
 					$html_input .= '</div>';
 

--- a/css/ppom-admin.css
+++ b/css/ppom-admin.css
@@ -144,6 +144,7 @@ ul.ppom-options-container li {
 
 .ppom-condition-style-wrap p {
     font-size: 15px;
+    margin: 0px;
 }
 
 /*.ppom-slider select.form-control {*/
@@ -767,6 +768,11 @@ select {
 
 .ppom-wrapper .row {
     display: block;
+}
+
+.row.ppom-condition-style-wrap {
+    display: flex;
+    align-items: center;
 }
 
 @media (min-width: 992px) {
@@ -1809,4 +1815,30 @@ header.ppom-modal-header {
     display: block;
     position: absolute;
     right: 20px;
+}
+.ppom-hide-element {
+    display: none !important;
+}
+
+.ppom-invisible-element {
+    visibility: hidden;
+}
+
+.ppom-between-input-container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    gap: 10px;
+}
+
+.ppom-between-input-container span {
+    font-size: 16px;
+}
+
+.ppom-upsell-condition {
+    font-size: 16px;
+    padding: 9px;
+    display: flex;
+    align-items: center;
 }

--- a/templates/admin/ppom-fields.php
+++ b/templates/admin/ppom-fields.php
@@ -691,7 +691,9 @@ $fields_groups = [
 						<th><?php _e( 'Actions', 'woocommerce-product-addon' ); ?></th>
 					</tr>
 					</thead>
+
 					<tfoot>
+					<?php if ( $product_meta && is_array( $product_meta) && 8 < count( $product_meta ) ) { ?>
 					<tr class="ppom-thead-bg">
 						<th></th>
 						<th class="ppom-check-all-field ppom-checkboxe-style">
@@ -708,6 +710,7 @@ $fields_groups = [
 						<th><?php _e( 'Required', 'woocommerce-product-addon' ); ?></th>
 						<th><?php _e( 'Actions', 'woocommerce-product-addon' ); ?></th>
 					</tr>
+					<?php } ?>
 					<tr>
 						<th colspan="12">
 							<div class="ppom-submit-btn text-right">


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Added new condition options for Free and Pro users. Improved the UI and UX.

Checklist:
- [x] Condition Target Select Input
  - [x] Support for dynamic filtering based on operator compatibility with the field type
  - [x] Complete compatibility list with all field types
- [x] Condition Operator Select Input
  - [x] Added new options
  - [x] Locking for PRO options
- [x] Comparision Value Input Fields
  - [x] Change the field based on the operator type.
    - [x] Simple text field for text-based and numeric-based comparison
    - [x] Double numeric fields for `between` operator
    - [x] Hide the field for operators that do not use a second comparison value (`any`, `empty`)
- [x] Field Rendering
  - [x] Render the dataset value user for an operator that uses a second comparison value (`contains`, `not-contains`, `regex`, etc )
  - [x] Render the dataset value for `between` operator
  - [x] Locking for PRO features

> [!IMPORTANT]
> The majority of the fields are not tracked by the conditions scripts. For them to work, we need to create more watchers tailored for each field.

> [!NOTE]
> The code is very cumbersome, so much refactoring was done to simplify and better showcase the functionality.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

![image](https://github.com/user-attachments/assets/fb48fd4d-0d44-46e4-a118-244a45bfc616)

<img width="1163" alt="Screenshot 2024-09-20 at 18 27 57" src="https://github.com/user-attachments/assets/03d43ab8-c70c-4a33-896b-88dd2ab22a23">


### Test instructions
<!-- Describe how this pull request can be tested. -->

> [!NOTE]
> Not all fields are supported to be part of the conditions.

- Make some simple fields like text, select, radio.
- Add another field with conditions based on previously simple fields created.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/429
<!-- Should look like this: `Closes #1, #2, #3.` . -->
