### PR TITLE
feat: add price multiplier for Measure Input

### DIFF
--- a/classes/inputs/input.measure.php
+++ b/classes/inputs/input.measure.php
@@ -45,63 +45,70 @@ class NM_Measure_wooproduct extends PPOM_Inputs {
 	private function get_settings() {
 
 		$input_meta = array(
-			'title'           => array(
+			'title'            => array(
 				'type'  => 'text',
 				'title' => __( 'Title', 'woocommerce-product-addon' ),
 				'desc'  => __( 'It will be shown as field label', 'woocommerce-product-addon' ),
 			),
-			'data_name'       => array(
+			'data_name'        => array(
 				'type'  => 'text',
 				'title' => __( 'Data name', 'woocommerce-product-addon' ),
 				'desc'  => __( 'REQUIRED: The identification name of this field, that you can insert into body email configuration. Note:Use only lowercase characters and underscores.', 'woocommerce-product-addon' ),
 			),
-			'description'     => array(
+			'description'      => array(
 				'type'  => 'textarea',
 				'title' => __( 'Description', 'woocommerce-product-addon' ),
 				'desc'  => __( 'Small description, it will be display near name title.', 'woocommerce-product-addon' ),
 			),
-			'error_message'   => array(
+			'error_message'    => array(
 				'type'  => 'text',
 				'title' => __( 'Error message', 'woocommerce-product-addon' ),
 				'desc'  => __( 'Insert the error message for validation.', 'woocommerce-product-addon' ),
 			),
-			'max'             => array(
+			'max'              => array(
 				'type'        => 'text',
 				'title'       => __( 'Max. values', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Max. values allowed, leave blank for default', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),
-			'min'             => array(
+			'min'              => array(
 				'type'        => 'text',
 				'title'       => __( 'Min. values', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Min. values allowed, leave blank for default', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),
-			'step'            => array(
+			'step'             => array(
 				'type'        => 'text',
 				'title'       => __( 'Steps', 'woocommerce-product-addon' ),
 				'desc'        => __( 'specified legal number intervals', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),
-			'default_value'   => array(
+			'default_value'    => array(
 				'type'        => 'text',
 				'title'       => __( 'Set default value', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Pre-defined value for measure input', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),
-			'price'           => array(
+			'price-multiplier' => array(
+				'type'        => 'text',
+				'title'       => __( 'Price Multiplier', 'woocommerce-product-addon' ),
+				'desc'        => __( 'Enter a value to adjust the price based on the input measurement. For example, if your price is set per meter but the measurement is entered in centimeters, you might use a multiplier of 0.01 to convert it. These multipliers ensure that the final price accurately reflects the unit of measurement entered.', 'woocommerce-product-addon' ),
+				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
+				'default'     => 1,
+			),
+			'price'            => array(
 				'type'        => 'text',
 				'title'       => __( 'Add-on Price', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Price will be added as Add-on if text provided', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),
-			'class'           => array(
+			'class'            => array(
 				'type'        => 'text',
 				'title'       => __( 'Class', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Insert an additional class(es) (separateb by comma) for more personalization.', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),
-			'width'           => array(
+			'width'            => array(
 				'type'        => 'select',
 				'title'       => __( 'Width', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Select width column.', 'woocommerce-product-addon' ),
@@ -109,7 +116,7 @@ class NM_Measure_wooproduct extends PPOM_Inputs {
 				'default'     => 12,
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),
-			'visibility'      => array(
+			'visibility'       => array(
 				'type'        => 'select',
 				'title'       => __( 'Visibility', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Set field visibility based on user.', 'woocommerce-product-addon' ),
@@ -117,30 +124,30 @@ class NM_Measure_wooproduct extends PPOM_Inputs {
 				'default'     => 'everyone',
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),
-			'visibility_role' => array(
+			'visibility_role'  => array(
 				'type'   => 'text',
 				'title'  => __( 'User Roles', 'woocommerce-product-addon' ),
 				'desc'   => __( 'Role separated by comma.', 'woocommerce-product-addon' ),
 				'hidden' => true,
 			),
-			'desc_tooltip'    => array(
+			'desc_tooltip'     => array(
 				'type'        => 'checkbox',
 				'title'       => __( 'Show tooltip', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Show Description in Tooltip with Help Icon', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),
-			'required'        => array(
+			'required'         => array(
 				'type'        => 'checkbox',
 				'title'       => __( 'Required', 'woocommerce-product-addon' ),
 				'desc'        => __( 'Select this if it must be required.', 'woocommerce-product-addon' ),
 				'col_classes' => array( 'col-md-3', 'col-sm-12' ),
 			),
-			'logic'           => array(
+			'logic'            => array(
 				'type'  => 'checkbox',
 				'title' => __( 'Enable Conditions', 'woocommerce-product-addon' ),
 				'desc'  => __( 'Tick it to turn conditional logic to work below', 'woocommerce-product-addon' ),
 			),
-			'conditions'      => array(
+			'conditions'       => array(
 				'type'  => 'html-conditions',
 				'title' => __( 'Conditions', 'woocommerce-product-addon' ),
 				'desc'  => __( 'Set rules to show or hide the field based on specific conditions', 'woocommerce-product-addon' ),

--- a/inc/nmInput.class.php
+++ b/inc/nmInput.class.php
@@ -303,13 +303,12 @@ class NM_Form {
 		$html .= 'data-price="' . esc_attr( ppom_get_product_price( $product ) ) . '" ';
 		$html .= 'data-title="' . esc_attr( $label ) . '" '; // Input main label/title
 		$html .= 'data-use_units="' . esc_attr( $use_units ) . '" '; // Input main label/title
-		// $html .= '<input type="text" class="form-control" aria-label="Text input with dropdown button">';
 
 		// Values
 		if ( $default_value != '' ) {
 			$html .= 'value="' . esc_attr( $default_value ) . '" ';
 		}
-
+		
 		// Attributes
 		foreach ( $attributes as $attr => $value ) {
 

--- a/inc/prices.php
+++ b/inc/prices.php
@@ -700,9 +700,15 @@ function ppom_get_field_prices( $ppom_fields_post, $product_id, &$product_quanti
 
 			case 'measure':
 				// var_dump($value);
-				$product_quantity = $value;
-				$unit_price       = 0;
-				$field_prices[]   = ppom_generate_field_price( $unit_price, $field_meta, $charge, $options, $product_quantity );
+				$product_quantity    = $value;
+				$unit_price          = 0;
+				$measure_price_field = ppom_generate_field_price( $unit_price, $field_meta, $charge, $options, $product_quantity );
+
+				if ( isset( $field_meta['price-multiplier'] ) && is_numeric( $field_meta['price-multiplier'] ) ) {
+					$measure_price_field['price-multiplier'] = floatval( $field_meta['price-multiplier'] );
+				} 
+
+				$field_prices[]   = $measure_price_field;
 				break;
 
 			case 'eventcalendar':
@@ -988,18 +994,23 @@ function ppom_price_get_total_fixedprice( $price_array ) {
 
 // Get total fixedprice
 function ppom_price_get_total_measure( $price_array ) {
-
 	$total_measure = 0;
 
 	if ( $price_array ) {
 		foreach ( $price_array as $price ) {
+			if ( $price['type'] !== 'measure' ) {
+				continue;
+			}
 
-			if ( $price['type'] == 'measure' ) {
-				if ( $total_measure == 0 ) {
-					$total_measure = $price['quantity'];
-				} else {
-					$total_measure *= $price['quantity'];
-				}
+			$measure = $price['quantity'];
+			if ( isset( $price['price-multiplier'] ) && is_numeric( $price['price-multiplier'] ) ) {
+				$measure *= floatval( $price['price-multiplier'] );
+			}
+			
+			if ( $total_measure == 0 ) {
+				$total_measure = $measure;
+			} else {
+				$total_measure *= $measure;
 			}
 		}
 	}

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -430,10 +430,11 @@ function ppom_woocommerce_update_cart_fees( $cart_items, $values ) {
 					break;
 
 				case 'measure':
-					$measer_qty   = isset( $option['qty'] ) ? intval( $option['qty'] ) : 0;
+					$measer_qty       = isset( $option['qty'] ) ? intval( $option['qty'] ) : 0;
+					$price_multiplier = isset( $option['price_multiplier'] ) ? floatval( $option['price_multiplier'] ) : 1;
 					$option_price = $option['price'];
 
-					$ppomm_measures *= $measer_qty;
+					$ppomm_measures *= $measer_qty * $price_multiplier;
 
 
 					break;

--- a/js/price/ppom-price.js
+++ b/js/price/ppom-price.js
@@ -514,27 +514,17 @@ function ppom_update_option_prices() {
         ppom_show_base_price = false;
 
         ppom_measure_input_found = true;
+       
+        const multiplier = parseFloat(option?.price_multiplier ?? '1' );
+        const priceMultiplier = ! Number.isNaN(multiplier) ? multiplier : 1;
 
         if (option.use_units === 'no') {
-
-            var option_qty = option.qty == '' ? 0 : parseFloat(option.qty);
-            ppom_measure_quantity = option_qty * ppom_measure_quantity;
+            const option_qty = option.qty == '' ? 0 : parseFloat(option.qty);
+            ppom_measure_quantity = option_qty * ppom_measure_quantity * priceMultiplier;
         }
         else {
-
-            ppom_total_price += parseFloat(option.price) * parseFloat(option.qty) * ppom_get_order_quantity();
+            ppom_total_price += parseFloat(option.price) * priceMultiplier * parseFloat(option.qty) * ppom_get_order_quantity();
         }
-        // console.log(ppom_measure_quantity);
-
-        // total_price_label += ' '+ ppom_get_wc_price(ppom_total_price).html()+'x'+option_measure;
-
-        /*var option_price_with_qty = ppom_get_order_quantity() * parseFloat(option.price);
-        var option_label_with_qty = option.label+' x ' + ppom_get_order_quantity();
-        
-        var formatted_option_price  = ppom_get_wc_price( option_price_with_qty );
-        ppom_add_price_item_in_table( option_label_with_qty, formatted_option_price);*/
-
-        // var produc_total = ppom_calculate_totals(ppom_total_discount, productBasePrice, ppom_option_total);
     });
 
     // If measured input has quantities
@@ -745,6 +735,7 @@ function ppom_update_get_prices() {
             if (checked_option_apply === 'measure') {
                 option_price.qty = jQuery(this).attr('data-qty');
                 option_price.use_units = jQuery(this).attr('data-use_units');
+                option_price.price_multiplier = jQuery(this).attr('data-price-multiplier');
             }
             
             // console.log(option_price);

--- a/templates/frontend/inputs/measure.php
+++ b/templates/frontend/inputs/measure.php
@@ -59,6 +59,7 @@ $input_classes = $input_classes . ' ppom-measure-input';
 				data-qty="<?php echo esc_attr( $default_value ); ?>"
 				<?php echo apply_filters( 'ppom_fe_form_element_custom_attr', '', $fm ); ?>
 				style="display: none;"
+				data-price-multiplier="<?php echo esc_attr( $fm->get_meta_value( 'price-multiplier' ) ); ?>"
 				checked
 		>
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Add Price Multiplier feature for Measure Input.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

![image](https://github.com/user-attachments/assets/fe23e7d0-f044-439c-80c1-dd28ce27a7b2)

![image](https://github.com/user-attachments/assets/adaad27b-325b-4f86-9010-afbb94319061)

![image](https://github.com/user-attachments/assets/f135a3cb-4320-4464-b55a-957393deabf6)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a Mesure input
- Set a price multiplier
- Purchase a product and check the value of the final price

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/430
<!-- Should look like this: `Closes #1, #2, #3.` . -->
