### PR TITLE
refactor: apply contrast design suggestions

### DIFF
--- a/classes/fields.class.php
+++ b/classes/fields.class.php
@@ -1131,8 +1131,8 @@ class PPOM_Fields_Meta {
 				$html_input .= '</table>';
 				$html_input .= '</div>';
 				$html_input .= '<div class="text-right">';
-				$html_input .= '<button class="btn btn-info ppom-save-bulk-json">'.esc_html__( 'Save Changing', 'woocommerce-product-addon' ).'</button> ';
-				$html_input .= '<button class="btn btn-success ppom-edit-bulk-json">'.esc_html__( 'Edit Changing', 'woocommerce-product-addon' ).'</button>';
+				$html_input .= '<button class="btn btn-success ppom-save-bulk-json">'.esc_html__( 'Save Changing', 'woocommerce-product-addon' ).'</button> ';
+				$html_input .= '<button class="btn btn-info ppom-edit-bulk-json">'.esc_html__( 'Edit Changing', 'woocommerce-product-addon' ).'</button>';
 
 				if ( ! empty( $bulk_data ) ) {
 					$html_input .= "<input type='hidden' name='ppom[" . esc_attr( $field_index ) . "][options]' class='ppom-saved-bulk-data ppom-meta-field' value='" . wp_json_encode( $bulk_data ) . "' data-metatype='options'>";

--- a/css/ppom-admin.css
+++ b/css/ppom-admin.css
@@ -90,7 +90,20 @@
 }
 
 .ppom-thead-bg {
-    background-color: #a4c1da8c;
+    background-color: #313350;
+    color: #FFFFFF;
+}
+
+thead .ppom-thead-bg th.ppom-checkboxe-style {
+    filter: brightness(0) invert(1);
+}
+
+#ppom-all-select-products-head-btn + span {
+    color: white;
+}
+
+#ppom-all-select-products-foot-btn + span {
+    color: white;
 }
 
 .ppom_field_table tbody {
@@ -399,10 +412,10 @@ ul.ppom-options-container li {
     padding-bottom: 9px;
     border-bottom: 2px solid #f957006e;
     justify-content: space-between;
+    margin-bottom: 10px;
 }
 
 .ppom-wrapper h1.ppom-heading-style {
-    font-family: roboto;
     font-size:23px;
     display: inline;
     /*font-size: 30px;*/
@@ -663,6 +676,24 @@ table#ppom-meta-table.dataTable th:nth-of-type(4) {
     width: 60%;
 }
 
+@media screen and (max-width: 1500px) {
+    table#ppom-meta-table.dataTable th:nth-of-type(4) {
+        width: 50%;
+    }
+}
+
+@media screen and (max-width: 1200px) {
+    table#ppom-meta-table.dataTable th:nth-of-type(4) {
+        width: 40%;
+    }
+}
+
+@media screen and (max-width: 950px) {
+    table#ppom-meta-table.dataTable th:nth-of-type(4) {
+        width: 30%;
+    }
+}
+
 /*
     11- Wordpress 5.3.1 CSS
 */
@@ -816,7 +847,7 @@ select {
     padding: 12px 30px;
     margin-right: 0.2rem;
     cursor: pointer;
-    background: #90CAF9;
+    background: #DCDCDE;
     font-weight: bold;
     transition: background ease 0.2s;
     margin: 0 !important;

--- a/templates/admin/existing-meta.php
+++ b/templates/admin/existing-meta.php
@@ -104,7 +104,9 @@ wp_nonce_field( 'ppom_meta_nonce_action', 'ppom_meta_nonce' );
 							<a href="<?php echo esc_url( $url_edit ); ?>" title="<?php _e( 'Edit', 'woocommerce-product-addon' ); ?>"
 							   class="button"><span class="dashicons dashicons-edit"></span></a>
 							<a href="<?php echo esc_url( $url_clone ); ?>" title="<?php _e( 'Clone', 'woocommerce-product-addon' ); ?>"
-							   class="button"><span class="dashicons dashicons-image-rotate-right"></span></a>
+							   class="button">
+							   <i class="fa fa-clone"></i>
+							</a>
 						</td>
 					</tr>
 					<?php

--- a/templates/admin/product-modal.php
+++ b/templates/admin/product-modal.php
@@ -16,7 +16,7 @@
 		<footer>
 			<button type="button"
 			        class="btn btn-default close-model ppom-js-modal-close"><?php _e( 'Close', 'woocommerce-product-addon' ); ?></button>
-			<button type="submit" class="btn btn-info"><?php _e( 'Save', 'woocommerce-product-addon' ); ?></button>
+			<button type="submit" class="btn btn-success"><?php _e( 'Save', 'woocommerce-product-addon' ); ?></button>
 		</footer>
 	</form>
 </div>


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

- Update the contrast on some options that were not modified previously. 
- Update clone icon

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

![image](https://github.com/user-attachments/assets/3e84fc8b-4351-47af-9cd1-a94526873cb1)

<img width="1324" alt="Screenshot 2024-09-24 at 19 05 06" src="https://github.com/user-attachments/assets/c03e07b9-9095-486c-b9c3-f48ee9dcc519">

![image](https://github.com/user-attachments/assets/20d66eb8-7595-4ea5-a238-ac0b5a6dbb3c)



## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/421
<!-- Should look like this: `Closes #1, #2, #3.` . -->
