### PR TITLE
refactor: remove migrate to old settings button

### DIFF
--- a/backend/assets/settings.css
+++ b/backend/assets/settings.css
@@ -45,11 +45,6 @@
     transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
-
-.nmsf-migrate-back-btn {
-    border-radius: 0 !important;
-}
-
 .nmsf-wrapper textarea {
     min-height: 105px;
     max-height: 105px;

--- a/backend/assets/settings.js
+++ b/backend/assets/settings.js
@@ -74,23 +74,6 @@ jQuery(function($) {
         }
     });
 
-
-    /**
-        Migration Event
-    **/
-    $(document).on("click", ".nmsf-migrate-back-btn", function(e) {
-
-        if (!confirm(nmsf_vars.migrate_back_msg)) {
-
-            e.preventDefault();
-            return false;
-        }
-        else {
-            return true;
-        }
-    });
-
-
     /**
         Add Conditional Settings Fields
     **/

--- a/backend/templates/admin-settings.php
+++ b/backend/templates/admin-settings.php
@@ -52,8 +52,6 @@ $migrate_url = wp_nonce_url( $migrate_url, 'ppom_migrate_nonce_action', 'ppom_mi
 				<div class="nmsf-cols col-md-12">
 					<div class="nmsf-panels-area">
                         <p class="submit">
-                            <a href="<?php echo esc_url( $migrate_url ); ?>"
-                               class="woocommerce-save-button components-button is-primary nmsf-migrate-back-btn"><?php echo _e( 'Switch to Legacy Settings', 'woocommerce-product-addon' ); ?></a>
                             <input type="submit" class="woocommerce-save-button components-button is-primary"
                                    value="<?php _e( 'Save changes', 'woocommerce-product-addon' ); ?>"/>
                         </p>


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Removed the switch to the legacy settings button. There is no meaningful functionality tied to it. 

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- The button should no longer be shown.
## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/375
<!-- Should look like this: `Closes #1, #2, #3.` . -->
