### PR TITLE
fix: enquiry form and popup position and close on click outside

### DIFF
--- a/css/ppom-simple-popup.css
+++ b/css/ppom-simple-popup.css
@@ -85,3 +85,11 @@
   top: 0;
   left: 0;
 }
+
+.ppom-enquiry-modal {
+  top: 20%;
+}
+
+.ppom-popup-product-edit-modal {
+  top: 5%;
+}

--- a/js/ppom-simple-popup.js
+++ b/js/ppom-simple-popup.js
@@ -141,8 +141,16 @@
 			modal.trigger(prefix + ':open');
 
 			// close popup listner
-			var closeButton = $('.' + options.popupcloseclass).bind('click.modalEvent', function(e) {
+			$('.' + options.popupcloseclass).bind('click.modalEvent', function(e) {
 				modal.trigger(prefix + ':close');
+				e.preventDefault();
+			});
+
+			// Close popup on overlay click, but not when clicking inside the modal
+			$('.ppom-enquiry-overlay, .ppom-popup-product-edit-overlay').bind('click.modalEvent', function(e) {
+				if (!$(e.target).closest('.ppom-enquiry-modal, .ppom-popup-product-edit-modal').length) {
+					modal.trigger(prefix + ':close');
+				}
 				e.preventDefault();
 			});
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Add better positioning for Enquiery Form and Popup Edit modal along with close on click outside.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

<img width="1401" alt="Screenshot 2024-09-24 at 19 48 53" src="https://github.com/user-attachments/assets/6f8a70c5-77c3-4fa7-b9ea-6614dbd65033">
<img width="1308" alt="Screenshot 2024-09-24 at 19 38 18" src="https://github.com/user-attachments/assets/cc7c2490-c66d-4f52-9cf4-105e1b8db0ca">


### Test instructions
<!-- Describe how this pull request can be tested. -->

> [!IMPORTANT]
> Test with https://github.com/Codeinwp/ppom-pro/pull/470

- Test if the positioning is fine along with close on click outside

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/206
Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/208
<!-- Should look like this: `Closes #1, #2, #3.` . -->
