### PR TITLE
Set default maximum image selection

### DIFF
--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -189,7 +189,7 @@ function ppom_init_js_for_ppom_fields(ppom_fields) {
                             const siblings = Array.from(input.parentNode.parentNode.querySelectorAll('input.ppom-input.image'));
                             siblings.filter(sibling => sibling !== input).forEach(sibling => sibling.checked = false);
                         } else {
-                            const maxImgSelection = parseInt( input.dataset?.maxSelection ?? '0' );
+                            const maxImgSelection = parseInt( input.dataset?.maxSelection ?? '1' );
                             if ( maxImgSelection ) {
                                 inputContainer.querySelector('img')?.addEventListener( 'click', () => {
                                     selectedImgs.push( input );


### PR DESCRIPTION
### Summary
In this PR, I’ve updated the default maximum image selection from 0 to 1.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/ppom-pro/issues/477
