### PR TITLE
fix: allow select input for comparison value on Checkbox

### DIFF
--- a/js/admin/ppom-admin.js
+++ b/js/admin/ppom-admin.js
@@ -1,16 +1,16 @@
 // @ts-check
 "use strict";
 
-const FIELD_COMPATIBLE_WITH_SELECT_OPTIONS = [ 'select', 'radio', 'switcher', 'image','conditional_meta'];
+const FIELD_COMPATIBLE_WITH_SELECT_OPTIONS = [ 'select', 'radio', 'switcher', 'image', 'conditional_meta' ];
 const OPERATOR_COMPARISON_VALUE_FIELD_TYPE = {
-    'select': FIELD_COMPATIBLE_WITH_SELECT_OPTIONS,
+    'select': [...FIELD_COMPATIBLE_WITH_SELECT_OPTIONS, 'checkbox'],
 }
 const COMPARISON_VALUE_CAN_USE_SELECT = [ 'is', 'not', 'greater than', 'less than' ];
 const HIDE_COMPARISON_INPUT_FIELD = ['any', 'empty', 'odd-number', 'even-number'];
 const FIELDS_COMPATIBLE_WITH_TEXT = [ 'text', 'textarea', 'date', 'email' ]
 const FIELDS_COMPATIBLE_WITH_NUMBERS = [ ...FIELD_COMPATIBLE_WITH_SELECT_OPTIONS, 'number' ];
 const OPERATORS_FIELD_COMPATIBILITY = {
-    'is': [...FIELD_COMPATIBLE_WITH_SELECT_OPTIONS, ...FIELDS_COMPATIBLE_WITH_TEXT, ...FIELDS_COMPATIBLE_WITH_NUMBERS, 'checkbox',],
+    'is': [...FIELD_COMPATIBLE_WITH_SELECT_OPTIONS, ...FIELDS_COMPATIBLE_WITH_TEXT, ...FIELDS_COMPATIBLE_WITH_NUMBERS, 'checkbox'],
     'not': [...FIELD_COMPATIBLE_WITH_SELECT_OPTIONS, ...FIELDS_COMPATIBLE_WITH_TEXT, ...FIELDS_COMPATIBLE_WITH_NUMBERS, 'checkbox'],
     'greater than': FIELDS_COMPATIBLE_WITH_NUMBERS,
     'less than': FIELDS_COMPATIBLE_WITH_NUMBERS,


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Register select input as a comparison value for the Checkbox in the Condition tab.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

https://github.com/user-attachments/assets/559e08f5-9179-4a75-bcdc-07b9dd6d0e7a

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a Checkbox to use as a Condition.
- Create another field and set a condition based on the value of the created Checkbox.
- Check if it works like in the video attached. 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/398
<!-- Should look like this: `Closes #1, #2, #3.` . -->
