### PR TITLE
fix: condition for validation skip for fields with min/max checked

### DIFF
--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -228,20 +228,18 @@ function ppom_check_validation( $product_id, $post_data, $passed = true ) {
 			continue;
 		}
 
-		if ( ! isset( $field['required'] ) || 'on' !== $field['required'] ) {
+		if (
+			empty( $field['data_name'] ) ||
+			(
+				( ! isset( $field['required'] ) || 'on' !== $field['required'] ) &&
+				empty( $field['min_checked'] ) &&
+				empty( $field['max_checked'] )
+			)
+		) {
 			continue;
 		}
 
 		$passed = apply_filters( 'ppom_before_fields_validation', $passed, $field, $post_data, $product_id );
-
-		if (
-			empty( $field['data_name'] ) &&
-			empty( $field['required'] ) &&
-			empty( $field['min_checked'] ) &&
-			empty( $field['max_checked'] )
-		) {
-			continue;
-		}
 
 		$data_name = sanitize_key( $field['data_name'] );
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Fixed the validation condition for checkbox introduced in https://github.com/Codeinwp/woocommerce-product-addon/commit/22b30568889440360ac275ff46d881a9bda23998

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a checkbox and assign a max/min checked options
- When you add a product, an error should be raised if the selected option is not between max/min values (like in the previous version before PRF)

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/399
<!-- Should look like this: `Closes #1, #2, #3.` . -->
