### PR TITLE
fix: add fields re-ordering for JSON payload

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -276,6 +276,7 @@ function ppom_admin_save_form_meta() {
 	}
 
 	$_REQUEST['ppom'] = is_array( $_REQUEST['ppom'] ) ? $_REQUEST['ppom'] : json_decode( wp_unslash( $_REQUEST['ppom'] ), true );
+
 	global $wpdb;
 
 	extract( $_REQUEST );
@@ -453,6 +454,7 @@ function ppom_admin_update_form_meta() {
 		wp_send_json( $resp );
 	}
 	$_REQUEST['ppom'] = is_array( $_REQUEST['ppom'] ) ? $_REQUEST['ppom'] : json_decode( wp_unslash( $_REQUEST['ppom'] ), true );
+	
 	global $wpdb;
 
 	$ppom_meta    = isset( $_REQUEST['ppom_meta'] ) ? $_REQUEST['ppom_meta'] : $_REQUEST['ppom'];

--- a/js/admin/ppom-admin.js
+++ b/js/admin/ppom-admin.js
@@ -128,8 +128,14 @@ jQuery(function($) {
         jQuery(".ppom-meta-save-notice").html('<img src="' + ppom_vars.loader + '">').show();
 
         $('.ppom-unsave-data').remove();
-        var data = $(this).serializeJSON();
+        const data = $(this).serializeJSON();
+        
+        const fieldsOrder = Array(...document.querySelectorAll('.ui-sortable-handle[id^="ppom_sort_id_"]'))
+            .map( node => node.id.replace('ppom_sort_id_', '') ); // ['2', '3']
+        data.ppom = fieldsOrder.map( fieldId => data.ppom[fieldId] );
+        
         data.ppom = JSON.stringify(data.ppom);
+
         // Send the JSON data via POST request
         $.ajax({
             url: ajaxurl,
@@ -329,7 +335,7 @@ jQuery(function($) {
             placeholder = '-';
         }
 
-        var html = '<tr class="row_no_' + id + '" id="ppom_sort_id_' + id + '">';
+        var html = '<tr class="row_no_' + id + ' ui-sortable-handle" id="ppom_sort_id_' + id + '">';
         html += '<td class="ppom-sortable-handle"><i class="fa fa-arrows" aria-hidden="true"></i></td>';
         html += '<td class="ppom-check-one-field ppom-checkboxe-style">';
         html += '<label>';


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Because the group field saving payload was switched to JSON in https://github.com/Codeinwp/woocommerce-product-addon/commit/e30abe0c0293d38e43cfff00f3cc014903c93780, the JSON object does not keep the initial order of its key. Thus, we need to reorder the fields before processing them.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a new group field with 2 or more input fields
- Check if you can re-order them.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/404
<!-- Should look like this: `Closes #1, #2, #3.` . -->
