### PR TITLE
fix: remove old textarea input for categories

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -312,8 +312,6 @@ function ppom_admin_save_form_meta() {
 	$aviary_api_key         = isset( $_REQUEST['aviary_api_key'] ) ? sanitize_text_field( $_REQUEST['aviary_api_key'] ) : '';
 	$productmeta_style      = isset( $_REQUEST['productmeta_style'] ) ? sanitize_text_field( $_REQUEST['productmeta_style'] ) : '';
 	$productmeta_js         = isset( $_REQUEST['productmeta_js'] ) ? sanitize_text_field( $_REQUEST['productmeta_js'] ) : '';
-	$productmeta_categories = isset( $_REQUEST['productmeta_categories'] ) ? sanitize_textarea_field( $_REQUEST['productmeta_categories'] ) : '';
-
 
 	if ( strlen( $productmeta_name ) > 50 ) {
 		$resp = array(
@@ -330,7 +328,6 @@ function ppom_admin_save_form_meta() {
 		'send_file_attachment'   => $send_file_attachment,
 		'show_cart_thumb'        => $show_cart_thumb,
 		'aviary_api_key'         => trim( $aviary_api_key ),
-		'productmeta_categories' => $productmeta_categories,
 		'the_meta'               => $product_meta,
 		'productmeta_created'    => current_time( 'mysql' ),
 	);
@@ -474,7 +471,6 @@ function ppom_admin_update_form_meta() {
 	$aviary_api_key         = isset( $_REQUEST['aviary_api_key'] ) ? sanitize_text_field( $_REQUEST['aviary_api_key'] ) : '';
 	$productmeta_style      = isset( $_REQUEST['productmeta_style'] ) ? sanitize_text_field( $_REQUEST['productmeta_style'] ) : '';
 	$productmeta_js         = isset( $_REQUEST['productmeta_js'] ) ? sanitize_text_field( $_REQUEST['productmeta_js'] ) : '';
-	$productmeta_categories = isset( $_REQUEST['productmeta_categories'] ) ? sanitize_textarea_field( $_REQUEST['productmeta_categories'] ) : '';
 
 	if ( strlen( $productmeta_name ) > 50 ) {
 		$resp = array(
@@ -491,7 +487,6 @@ function ppom_admin_update_form_meta() {
 		'send_file_attachment'   => $send_file_attachment,
 		'show_cart_thumb'        => $show_cart_thumb,
 		'aviary_api_key'         => trim( $aviary_api_key ),
-		'productmeta_categories' => $productmeta_categories,
 		'the_meta'               => $product_meta,
 	);
 	if ( ! ppom_is_legacy_user() ) {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Remove the old Categories input from Product edit. This caused an override in field saving.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a new group and attach it to a category
- When adding a new input field and saving, the category should not change.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/403
<!-- Should look like this: `Closes #1, #2, #3.` . -->
