### PR TITLE
fix: `CustomEvent` not properly triggering jQuery event for hidden fields workflow

### DIFF
--- a/js/ppom-conditions-v2.js
+++ b/js/ppom-conditions-v2.js
@@ -61,13 +61,11 @@ jQuery(function($) {
 
         const data_name = modifiedElement.dataset?.data_name;
         ppom_check_conditions(data_name, (element_dataname, event_type) => {
-            const event = new CustomEvent(event_type, {
-                detail: {
-                    field: element_dataname,
-                    time: new Date()
-                }
+            $.event.trigger({
+                type: event_type,
+                field: element_dataname,
+                time: new Date()
             });
-            document.dispatchEvent(event);
         });
     }
     


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

I found out that native `CustomEvent` and `jQuery.trigger` are not the same. I added back the event trigger via `jQuery` for conditions workflow.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Import those fields
[ppom-meta-1728379034.csv](https://github.com/user-attachments/files/17294476/ppom-meta-1728379034.csv)
- The hidden field should not be added to the price when adding the item to cart.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro
<!-- Should look like this: `Closes #1, #2, #3.` . -->
