### PR TITLE
fix: remove event stop propagation  for outside click checking

### DIFF
--- a/js/ppom-simple-popup.js
+++ b/js/ppom-simple-popup.js
@@ -151,7 +151,6 @@
 				if (!$(e.target).closest('.ppom-enquiry-modal, .ppom-popup-product-edit-modal').length) {
 					modal.trigger(prefix + ':close');
 				}
-				e.preventDefault();
 			});
 
 			// disable backgroundclickevent close


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Removed that `.preventDefault` on click checking to prevent blocking some type of input fields inside the popup.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Activate the Popup mode in PPOM Settings and attach some fields to a product.
- Check if you can interact with Input Fields and Add to Cart

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/491
<!-- Should look like this: `Closes #1, #2, #3.` . -->
