### PR TITLE
fix: use fetch for saving meta group fields

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -275,8 +275,6 @@ function ppom_admin_save_form_meta() {
 		wp_send_json( $resp );
 	}
 
-	$_REQUEST['ppom'] = is_array( $_REQUEST['ppom'] ) ? $_REQUEST['ppom'] : json_decode( wp_unslash( $_REQUEST['ppom'] ), true );
-
 	global $wpdb;
 
 	extract( $_REQUEST );
@@ -450,8 +448,6 @@ function ppom_admin_update_form_meta() {
 
 		wp_send_json( $resp );
 	}
-	$_REQUEST['ppom'] = is_array( $_REQUEST['ppom'] ) ? $_REQUEST['ppom'] : json_decode( wp_unslash( $_REQUEST['ppom'] ), true );
-	
 	global $wpdb;
 
 	$ppom_meta    = isset( $_REQUEST['ppom_meta'] ) ? $_REQUEST['ppom_meta'] : $_REQUEST['ppom'];

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -283,6 +283,12 @@ function ppom_admin_save_form_meta() {
 	$aviary_api_key       = 'NA';
 	$show_cart_thumb      = 'NA';
 
+	if ( is_string( $_REQUEST['ppom'] ) ) {
+		$ppom_encoded = $_REQUEST['ppom'];
+		parse_str( $ppom_encoded, $ppom_decoded);
+		$_REQUEST['ppom'] = $ppom_decoded['ppom'];
+	}
+
 	$ppom_meta    = ( isset($_REQUEST['ppom_meta']) ? $_REQUEST['ppom_meta'] : isset($_REQUEST['ppom']) ) ? $_REQUEST['ppom'] : '';
 
 	if ( empty( $ppom_meta ) ) {
@@ -356,6 +362,11 @@ function ppom_admin_save_form_meta() {
 
 
 	$ppom_id = $wpdb->insert_id;
+	if ( is_string( $ppom ) ) {
+		$ppom_encoded = $ppom;
+		parse_str( $ppom_encoded, $ppom_decoded);
+		$ppom = $ppom_decoded['ppom'];
+	}
 
 	$product_meta = apply_filters( 'ppom_meta_data_saving', (array) $ppom, $ppom_id );
 	$product_meta = ppom_sanitize_array_data( $product_meta );
@@ -449,6 +460,12 @@ function ppom_admin_update_form_meta() {
 		wp_send_json( $resp );
 	}
 	global $wpdb;
+
+	if ( is_string( $_REQUEST['ppom'] ) ) {
+		$ppom_encoded = $_REQUEST['ppom'];
+		parse_str( $ppom_encoded, $ppom_decoded);
+		$_REQUEST['ppom'] = $ppom_decoded['ppom'];
+	}
 
 	$ppom_meta    = isset( $_REQUEST['ppom_meta'] ) ? $_REQUEST['ppom_meta'] : $_REQUEST['ppom'];
 	$product_meta = apply_filters( 'ppom_meta_data_saving', (array) $ppom_meta, $productmeta_id );

--- a/js/admin/ppom-admin.js
+++ b/js/admin/ppom-admin.js
@@ -128,38 +128,26 @@ jQuery(function($) {
         jQuery(".ppom-meta-save-notice").html('<img src="' + ppom_vars.loader + '">').show();
 
         $('.ppom-unsave-data').remove();
-        const data = $(this).serializeJSON();
-        
-        const fieldsOrder = Array(...document.querySelectorAll('.ui-sortable-handle[id^="ppom_sort_id_"]'))
-            .map( node => node.id.replace('ppom_sort_id_', '') ); // ['2', '3']
-        data.ppom = fieldsOrder.map( fieldId => data.ppom[fieldId] );
-        
-        data.ppom = JSON.stringify(data.ppom);
-
-        // Send the JSON data via POST request
-        $.ajax({
-            url: ajaxurl,
-            data: data,  // Send as regular object (no need to stringify)
-            type: 'POST',
-            success: function(resp) {
-
-                const bg_color = resp.status == 'success' ? '#4e694859' : '#ee8b94';
-                jQuery(".ppom-meta-save-notice").html(resp.message).css({ 'background-color': bg_color, 'padding': '8px', 'border-left': '5px solid #008c00' });
-                if (resp.status == 'success') {
-                    if (resp.redirect_to != '') {
-                        window.location = resp.redirect_to;
-                    }
-                    else {
-                        window.location.reload(true);
-                    }
+       
+        fetch(ajaxurl, {
+            method: 'POST',
+            body: new FormData(this)
+        })
+        .then(response => response.json())
+        .then(resp => {
+            const bg_color = resp.status == 'success' ? '#4e694859' : '#ee8b94';
+            jQuery(".ppom-meta-save-notice").html(resp.message).css({ 'background-color': bg_color, 'padding': '8px', 'border-left': '5px solid #008c00' });
+            if (resp.status == 'success') {
+                if (resp.redirect_to != '') {
+                    window.location = resp.redirect_to;
+                } else {
+                    window.location.reload();
                 }
-            },
-            error: function() {
-                // Handle error
-                jQuery(".ppom-meta-save-notice").html("An error occurred. Please try again.").css({ 'background-color': '#ee8b94', 'padding': '8px', 'border-left': '5px solid #c00' });
             }
+        })
+        .catch(() => {
+            jQuery(".ppom-meta-save-notice").html("An error occurred. Please try again.").css({ 'background-color': '#ee8b94', 'padding': '8px', 'border-left': '5px solid #c00' });
         });
-
     });
 
 

--- a/js/admin/ppom-admin.js
+++ b/js/admin/ppom-admin.js
@@ -128,10 +128,24 @@ jQuery(function($) {
         jQuery(".ppom-meta-save-notice").html('<img src="' + ppom_vars.loader + '">').show();
 
         $('.ppom-unsave-data').remove();
+
+        const formData = new FormData();
+        const ppomFields = new URLSearchParams();
+        
+        // NOTE: since the request is to big for small values of `max_input_vars`, we will send the PPOM fields as a single string.
+        (new FormData(this)).forEach(( value, key) => {
+            if ( key.startsWith('ppom[') && typeof value === 'string' ) {
+                ppomFields.append( key, value );
+            } else {
+                formData.append(key, value);
+            }
+        });
+
+        formData.append('ppom', ppomFields.toString());
        
         fetch(ajaxurl, {
             method: 'POST',
-            body: new FormData(this)
+            body: formData
         })
         .then(response => response.json())
         .then(resp => {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

This is a second fix to the problem introduced in https://github.com/Codeinwp/woocommerce-product-addon/commit/e30abe0c0293d38e43cfff00f3cc014903c93780

This also removes the workaround from https://github.com/Codeinwp/woocommerce-product-addon/pull/405

The initial problem was using `.serialize(),` which created a problem with PHP limit processing because it had many fields.

The `.ajax` request was sending the data as `application/x-www-form-urlencoded` which is not the right way to send a lot of data.

The request looks like this:

```
POST /wp-admin/admin-ajax.php HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate, br, zstd
Accept-Language: en-US,en;q=0.9
Cache-Control: no-cache
Connection: keep-alive
Content-Length: 5058
Content-Type: application/x-www-form-urlencoded; charset=UTF-8
```

With payload:

```
action=ppom_update_form_meta&ppom_form_nonce=e63840c664&_wp_http_referer=%2Fwp-admin%2Fadmin.php%3Fpage%3Dppom%26productmeta_id%3D47%26do_meta%3Dedit&productmeta_id=47&product_id=&css-tabs=on&productmeta_name=Check+Test&dynamic_price_hide=option_sum&ppom_repeater_enable=&productmeta_style=selector+%7B+%7D&productmeta_js=&ppom=%5B%7B%22type%22%3A%22select%22%2C%22title%22%3A%22Price+Set+1%22%2C%22data_name%22%3A%22price_set_1%22%2C%22description%22%3A%22%22%2C%22error_message%22%3A%22%22%2C%22options%22%3A%7B%220%22%3A%7B%22option%22%3A%22%C2%A330%22%2C%22price%22%3A%2230%22%2C%22weight%22%3A%22%22%2C%22stock%22%3A%22%22%2C%22id%22%3A%22_30%22%7D%2C%221%22%3A%7B%22option%22%3A%22%C2%A310%22%2C%22price%22%3A%2210%22%2C%22weight%22%3A%22%22%2C%22stock%22%3A%22%22%2C%22id%22%3A%22_10%22%7D%2C%222%22%3A%7B%22option%22%3A%22%C2%A320%22%2C%22price%22%3A%2220%22%2C%22weight%22%3A%22%22%2C%22stock%22%3A%22%22%2C%22id%22%3A%22_20%22%7D%7D%2C%22selected%22%3A%22%C2%A310%22%2C%22first_option%22%3A%22%22%2C%22class%22%3A%22%22%2C%22width%22%3A%2212%22%2C%22visibility%22%3A%22everyone%22%2C%22visibility_role%22%3A%22%22%2C%22logic%22%3A%22on%22%2C%22conditions%22%3A%7B%22visibility%22%3A%22Hide%22%2C%22bound%22%3A%22All%22%2C%22rules%22%3A%7B%220%22%3A%7B%22elements%22%3A%22use_price_set_2_instead%22%2C%22operators%22%3A%22is%22%2C%22element_values%22%3A%22Yes%22%2C%22element_constant%22%3A%22%22%2C%22cond-between-interval%22%3A%7B%22from%22%3A%22%22%2C%22to%22%3A%22%22%7D%7D%7D%7D%2C%22cond_field_repeater%22%3A%7B%22origin%22%3A%22%22%7D%2C%22status%22%3A%22on%22%7D%2C%7B%22type%22%3A%22select%22%2C%22title%22%3A%22Price+Set+2%22%2C%22data_name%22%3A%22price_set_2%22%2C%22description%22%3A%22%22%2C%22error_message%22%3A%22%22%2C%22options%22%3A%7B%220%22%3A%7B%22option%22%3A%22%C2%A3100%22%2C%22price%22%3A%22100%22%2C%22weight%22
```

One solution is to encode everything to JSON. This way, all the request is just a huge string and bypass the number of `max_input_vars` allowed. 

The problem is that we need to retain the ordering of fields. If in HTML, `ppom[3]` is before `ppom[1]`, the serialized version will keep this order while the JSON object will re-order them based on the key value. 

In this PR, instead of having a huge JSON string under the key `ppom,` we can have a huge serialized string. And the PHP decoding will keep the order.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->


https://github.com/user-attachments/assets/30afdac3-b8d3-43bc-b10f-b6710028dae4


https://github.com/user-attachments/assets/8cfa15a6-f3a7-49b2-8219-fb0757c214e5



### Test instructions
<!-- Describe how this pull request can be tested. -->

In your WordPress instance, in `php.ini` use those values to reproduce the error:

```
max_input_vars = 2000
max_multipart_body_parts = 1500
```

- make a meta group with lots of fields
- check if they are saved correctly 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/490
<!-- Should look like this: `Closes #1, #2, #3.` . -->
