### PR TITLE
fix: chunk file name for uploaded files

### DIFF
--- a/inc/files.php
+++ b/inc/files.php
@@ -272,7 +272,7 @@ function ppom_upload_file() {
 	$file_hash       = substr( hash('haval192,5', $file_name), 0, 8 ) . '-' . $ppom_nonce;
 	$file_name       = str_replace( ".$file_ext", ".$file_hash.$file_ext", $file_name );
 	$file_path       = $file_dir_path . $file_name;
-	
+
 	// Make sure the fileName is unique but only if chunking is disabled
 	if ( $chunks < 2 && file_exists( $file_path ) ) {
 		$ext         = strrpos( $file_name, '.' );
@@ -341,9 +341,10 @@ function ppom_upload_file() {
 		die( UploadFileErrors::get_message_response( $error ) );
 	}
 
-	// Check if file has been uploaded completely.
+	// Check if the file has been uploaded completely.
 	if ( ! $chunks || $chunk === $chunks - 1 ) {
 
+		// Give a unique name to prevent name collisions.
 		$file_name = ppom_create_unique_file_name( $original_name, $file_ext );
 		$unique_file_path = $file_dir_path . $file_name;
 

--- a/tests/test-file-upload.php
+++ b/tests/test-file-upload.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Class Test_File_Upload
+ *
+ * @package ppom-pro
+ */
+
+class Test_File_Upload extends WP_UnitTestCase {
+
+	/**
+     * Test ppom_create_unique_file_name function.
+     */
+    public function test_ppom_create_unique_file_name() {
+        $file_name = 'example';
+        $file_ext = 'jpg';
+
+        $unique_file_name = ppom_create_unique_file_name($file_name, $file_ext);
+
+        // Check if the file name contains the original name
+        $this->assertStringContainsString($file_name, $unique_file_name);
+
+        // Check if the file name contains the extension
+        $this->assertStringContainsString($file_ext, $unique_file_name);
+
+        // Check if the file name contains the unique hash
+        $this->assertMatchesRegularExpression('/\.[a-zA-Z0-9+\/=]+\./', $unique_file_name);
+    }
+
+    /**
+     * Test ppom_create_unique_file_name generates different names on subsequent calls.
+     */
+    public function test_ppom_create_unique_file_name_is_unique() {
+        $file_name = 'example';
+        $file_ext = 'jpg';
+
+        $unique_file_name_1 = ppom_create_unique_file_name($file_name, $file_ext);
+        $unique_file_name_2 = ppom_create_unique_file_name($file_name, $file_ext);
+
+        // Check if the two generated file names are different
+        $this->assertNotEquals($unique_file_name_1, $unique_file_name_2);
+    }
+
+    /**
+     * Test ppom_create_chunk_file function.
+     */
+    public function test_ppom_create_chunk_file_success() {
+        $file_path_to_read = tempnam(sys_get_temp_dir(), 'read');
+        $ppom_chunk_file_path = tempnam(sys_get_temp_dir(), 'chunk');
+        $mode = 'wb';
+
+
+        file_put_contents($file_path_to_read, 'test data');
+
+        $error = ppom_create_chunk_file($file_path_to_read, $ppom_chunk_file_path, $mode);
+
+        $this->assertFalse($error);
+
+        // Check if the chunk file contains the correct data
+        $this->assertFileExists($ppom_chunk_file_path);
+        $this->assertEquals('test data', file_get_contents($ppom_chunk_file_path));
+
+        // Clean up
+        unlink($file_path_to_read);
+        unlink($ppom_chunk_file_path);
+    }
+
+    public function test_ppom_create_chunk_file_input_error() {
+        $file_path_to_read = 'non_existent_file';
+        $ppom_chunk_file_path = tempnam(sys_get_temp_dir(), 'chunk');
+        $mode = 'wb';
+
+        $error = @ppom_create_chunk_file($file_path_to_read, $ppom_chunk_file_path, $mode);
+
+        $this->assertEquals(UploadFileErrors::OPEN_INPUT, $error);
+
+        // Clean up
+        unlink($ppom_chunk_file_path);
+    }
+
+    public function test_ppom_create_chunk_file_output_error() {
+        $file_path_to_read = tempnam(sys_get_temp_dir(), 'read');
+        $ppom_chunk_file_path = '/invalid/path/chunk';
+        $mode = 'wb';
+
+
+        file_put_contents($file_path_to_read, 'test data');
+        $error = @ppom_create_chunk_file($file_path_to_read, $ppom_chunk_file_path, $mode);
+
+        $this->assertEquals(UploadFileErrors::OPEN_OUTPUT, $error);
+
+        // Clean up
+        unlink($file_path_to_read);
+    }
+}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Changes:
- A stable hash was used to add to the chunk file name so that the next request would know where to append the next chunk.
- Added a unique hash to the file when the final file is built.
- Code refactor
- Unit tests

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

![image](https://github.com/user-attachments/assets/1c15178f-8d66-4d26-85ba-c03b9efecbd0)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Use a File input with an image preview
- Load an image larger than 2MB and another one smaller
- Both should have the preview.

In the `wp-content/uploads/ppom_files` you should files with this name structure:

<img width="602" alt="Screenshot 2024-10-11 at 13 41 47" src="https://github.com/user-attachments/assets/fcf7a9ba-13b4-49a1-bf9b-d10740e60918">



## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/489
<!-- Should look like this: `Closes #1, #2, #3.` . -->
