### PR TITLE
fix: image selection for Image Input

### DIFF
--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -174,38 +174,37 @@ function ppom_init_js_for_ppom_fields(ppom_fields) {
                      */
                     const selectedImgs = [];
 
-                    container.querySelectorAll('.pre_upload_image').forEach( (/** @type{HTMLDivElement} */ inputContainer) => {
-                        const input = inputContainer.querySelector('input');
-                        if ( ! input ) {
-                            return;
-                        }
-                        
-                        const multiple = input.dataset.allowMultiple || false;
-                        if ( multiple ) {
-                            if (input.dataset.required) {
-                                input.checked = true;
-                            }
-    
-                            const siblings = Array.from(input.parentNode.parentNode.querySelectorAll('input.ppom-input.image'));
-                            siblings.filter(sibling => sibling !== input).forEach(sibling => sibling.checked = false);
-                        } else {
-                            const maxImgSelection = parseInt( input.dataset?.maxSelection ?? '1' );
-                            if ( maxImgSelection ) {
-                                inputContainer.querySelector('img')?.addEventListener( 'click', () => {
-                                    selectedImgs.push( input );
+                    /**
+                     * @type {HTMLInputElement[]} The available images to select.
+                     */
+                    const imgsInput = Array.from(container.querySelectorAll('.ppom-input.pre_upload_image input'));
 
-                                    while( selectedImgs.length > maxImgSelection ) {
-                                        const oldestImgSelected = selectedImgs.shift();
-                                        if ( oldestImgSelected ) {
-                                            oldestImgSelected.checked = false;
-                                        }
+                    for ( const imgInput of imgsInput ) {
+                        const multiple = imgInput.dataset.allowMultiple || false;
+                        const maxImgSelection = parseInt( imgInput.dataset?.maxSelection ?? '-1' );
+
+                        imgInput.addEventListener('click', (e) => {
+                            if ( !e.target.checked ) {
+                                return;
+                            }
+
+                            if ( ! multiple ) {
+                                // Uncheck other inputs.
+                                imgsInput.filter( i => i !== imgInput).forEach( i => {
+                                    i.checked = false;
+                                });
+                            } else if ( 0 < maxImgSelection ) {
+                                // Uncheck oldest checked image.
+                                selectedImgs.push( imgInput );
+                                while( selectedImgs.length > maxImgSelection ) {
+                                    const oldestImgSelected = selectedImgs.shift();
+                                    if ( oldestImgSelected ) {
+                                        oldestImgSelected.checked = false;
                                     }
-                                })
-
+                                }
                             }
-                        }
-                        
-                    });
+                        });
+                    }
                 });
 
                 // Data Tooltip


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Regression made on https://github.com/Codeinwp/woocommerce-product-addon/commit/66bf9e84f558c30125cc92427d4dfe378a88276b 

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create an Input Image
- If the `Multiple` option is not checked, only one image should be selected.
- If `Multiple` and `Max Image Select` are set, the highlighted images will not be more than the value of `Max Image Select`.

> [!NOTE]
> The value of `Min Image Select` is used only in validation and was never a part of the script workflow. Any problem with this value is a new issue.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/493
<!-- Should look like this: `Closes #1, #2, #3.` . -->
