### PR TITLE
fix: add `imageselect` as condition with `is` and `is not` operator

### DIFF
--- a/js/admin/ppom-admin.js
+++ b/js/admin/ppom-admin.js
@@ -2,16 +2,18 @@
 "use strict";
 
 const FIELD_COMPATIBLE_WITH_SELECT_OPTIONS = [ 'select', 'radio', 'switcher', 'image', 'conditional_meta' ];
+const FIELDS_COMPATIBLE_WITH_TEXT = [ 'text', 'textarea', 'date', 'email' ]
+const FIELDS_COMPATIBLE_WITH_NUMBERS = [ ...FIELD_COMPATIBLE_WITH_SELECT_OPTIONS, 'number' ];
+
 const OPERATOR_COMPARISON_VALUE_FIELD_TYPE = {
-    'select': [...FIELD_COMPATIBLE_WITH_SELECT_OPTIONS, 'checkbox'],
+    'select': [...FIELD_COMPATIBLE_WITH_SELECT_OPTIONS, 'checkbox', 'imageselect'],
 }
 const COMPARISON_VALUE_CAN_USE_SELECT = [ 'is', 'not', 'greater than', 'less than' ];
 const HIDE_COMPARISON_INPUT_FIELD = ['any', 'empty', 'odd-number', 'even-number'];
-const FIELDS_COMPATIBLE_WITH_TEXT = [ 'text', 'textarea', 'date', 'email' ]
-const FIELDS_COMPATIBLE_WITH_NUMBERS = [ ...FIELD_COMPATIBLE_WITH_SELECT_OPTIONS, 'number' ];
+
 const OPERATORS_FIELD_COMPATIBILITY = {
-    'is': [...FIELD_COMPATIBLE_WITH_SELECT_OPTIONS, ...FIELDS_COMPATIBLE_WITH_TEXT, ...FIELDS_COMPATIBLE_WITH_NUMBERS, 'checkbox'],
-    'not': [...FIELD_COMPATIBLE_WITH_SELECT_OPTIONS, ...FIELDS_COMPATIBLE_WITH_TEXT, ...FIELDS_COMPATIBLE_WITH_NUMBERS, 'checkbox'],
+    'is': [...FIELD_COMPATIBLE_WITH_SELECT_OPTIONS, ...FIELDS_COMPATIBLE_WITH_TEXT, ...FIELDS_COMPATIBLE_WITH_NUMBERS, 'checkbox', 'imageselect'],
+    'not': [...FIELD_COMPATIBLE_WITH_SELECT_OPTIONS, ...FIELDS_COMPATIBLE_WITH_TEXT, ...FIELDS_COMPATIBLE_WITH_NUMBERS, 'checkbox', 'imageselect'],
     'greater than': FIELDS_COMPATIBLE_WITH_NUMBERS,
     'less than': FIELDS_COMPATIBLE_WITH_NUMBERS,
     'even-number': FIELDS_COMPATIBLE_WITH_NUMBERS,


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Image Dropdown Input can now be used as a condition target.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

![image](https://github.com/user-attachments/assets/92b8d539-1a68-4590-b581-fe2f3f2957ef)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create an Image Dropdown field and another input field.
- Check if you can add a condition to the other input fields based on the values of the Image Dropdown.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/494
<!-- Should look like this: `Closes #1, #2, #3.` . -->
