### PR TITLE
Fix multiple categories and backward compatibility 

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -9,27 +9,24 @@ jobs:
   phpunit:
     name: Phpunit
     runs-on: ubuntu-22.04
-    services:
-      mysql:
-        image: mysql:5.7
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306/tcp
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
-      - name: Setup PHP version
-        uses: shivammathur/setup-php@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          php-version: "7.2"
-          extensions: simplexml, mysql
-          tools: phpunit-polyfills
-      - name: Checkout source code
-        uses: actions/checkout@v2
-      - name: Install WordPress Test Suite
+          node-version: "18"
+          cache: "yarn"
+      - name: Install NPM deps
         run: |
-          bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:${{ job.services.mysql.ports['3306'] }}
-      - name: Install composer
-        run: composer install --prefer-dist --no-progress --no-suggest
-      - name: Run phpunit
-        run: phpunit
+          yarn install --frozen-lockfile
+      - name: Install composer deps
+        run: composer install
+      - name: Install environment
+        run: |
+          npm run wp-env start
+      - name: Prepare Database
+        run: bash ./bin/e2e-after-setup.sh
+      - name: Run the tests
+        run: |
+          npm run test:unit:php
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ vendor
 languages/woocommerce-product-addon.pot
 *.log
 artifacts
+.phpunit.result.cache

--- a/bin/env/create-products.sh
+++ b/bin/env/create-products.sh
@@ -1,13 +1,25 @@
+# Create new categories
+# NOTE: If the categories with the same slug are already present, it will raise an error.
+echo "Created Category 1 with ID: $category1_id"
+category1_id=$(wp wc product_cat create --name="Category 1" --slug="test_cat_1" --user=admin --porcelain)
+
+echo "Created Category 2 with ID: $category2_id"
+category2_id=$(wp wc product_cat create --name="Category 2" --slug="test_cat_2" --user=admin --porcelain)
+
+echo "Created Category 3 with ID: $category3_id"
+category3_id=$(wp wc product_cat create --name="Category 3" --slug="test_cat_3" --user=admin --porcelain)
+
 # Create products and collect their IDs
 product1_id=$(wp wc product create --name="Product 1" --type="simple" --regular_price="9.99" --user=admin --porcelain)
+echo "Created Product 1 with ID: $product1_id"
+
 product2_id=$(wp wc product create --name="Product 2" --type="simple" --regular_price="19.99" --user=admin --porcelain)
+echo "Created Product 2 with ID: $product2_id"
+
 product3_id=$(wp wc product create --name="Product 3" --type="simple" --regular_price="29.99" --user=admin --porcelain)
+echo "Created Product 3 with ID: $product3_id"
 
-# Get the first category.
-category_id=$(wp wc product_cat list --user=admin --format=ids | awk '{print $1}')
-echo "Category ID: $category_id"
-
-# Add products to the first category
-wp wc product update $product1_id --user=admin --categories='[{"id": '$category_id'}]'
-wp wc product update $product2_id --user=admin --categories='[{"id": '$category_id'}]'
-wp wc product update $product3_id --user=admin --categories='[{"id": '$category_id'}]'
+# Add products to the new categories
+wp wc product update $product1_id --user=admin --categories='[{"id": '$category1_id'}]'
+wp wc product update $product2_id --user=admin --categories='[{"id": '$category2_id'}]'
+wp wc product update $product3_id --user=admin --categories='[{"id": '$category3_id'}]'

--- a/classes/ppom.class.php
+++ b/classes/ppom.class.php
@@ -374,7 +374,8 @@ class PPOM_Meta {
 					$meta_found[] = $row->productmeta_id;
 				} else {
 					// making array of meta cats
-					$meta_cat_array = explode( "\r\n", $row->productmeta_categories );
+
+					$meta_cat_array = preg_split('/\r\n|\n/', $row->productmeta_categories);
 					// Now iterating the product_categories to check it's slug in meta cats
 					foreach ( $product_categories as $cat ) {
 						if ( in_array( $cat->slug, $meta_cat_array ) ) {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "test:e2e:debug": "wp-scripts test-playwright --config tests/e2e/playwright.config.js --ui",
     "test:unit:php:setup": "wp-env start",
     "test:unit:php:setup:debug": "wp-env start --xdebug",
-    "test:unit:php": "wp-env run --env-cwd='wp-content/plugins/woocommerce-product-addon' tests-wordpress vendor/bin/phpunit -c phpunit.xml.dist --verbose"
+    "test:unit:php": "wp-env run --env-cwd='wp-content/plugins/woocommerce-product-addon' tests-wordpress vendor/bin/phpunit -c phpunit.xml --verbose"
   }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,6 +24,9 @@ require_once $_tests_dir . '/includes/functions.php';
  */
 function _register_module() {
 	require_once dirname( dirname( __FILE__ ) ) . '/woocommerce-product-addon.php';
+	include_once PPOM_PATH . '/classes/admin.class.php';
+
+	$ppom_admin = new NM_PersonalizedProduct_Admin();
 }
 
 tests_add_filter( 'muplugins_loaded', '_register_module' );

--- a/tests/e2e/specs/attach-modal.spec.js
+++ b/tests/e2e/specs/attach-modal.spec.js
@@ -5,7 +5,10 @@ import { test, expect } from "@wordpress/e2e-test-utils-playwright";
 import { createSimpleGroupField } from "../utils";
 
 test.describe("Attach Modal", () => {
-	test("attach to products", async ({ page, admin }) => {
+	/**
+	 * Attach a new group field to the first product in list then check if it is rendered.
+	 */
+	test("attach to products and check", async ({ page, admin }) => {
 		await createSimpleGroupField(admin, page);
 		await page.waitForTimeout(500);
 		await admin.visitAdminPage("admin.php?page=ppom");
@@ -34,6 +37,49 @@ test.describe("Attach Modal", () => {
 		const count = await elements.count();
 		for (let i = 0; i < count; i++) {
 			await expect(elements.nth(i)).toBeVisible();
+		}
+	});
+
+	/**
+	 * Attach a new group to multiple categories then check.
+	 */
+	test("attach to multiple categories", async ({ page, admin }) => {
+		const categoriesToUse = ["test_cat_1", "test_cat_2"];
+
+		await createSimpleGroupField(admin, page);
+		await page.waitForTimeout(500);
+		await admin.visitAdminPage("admin.php?page=ppom");
+
+		const firstRow = page
+			.locator("#ppom-groups-export-form tbody tr")
+			.first();
+		const ppomId = await firstRow.locator("td").nth(1).innerText();
+		await firstRow.getByText("Attach to Products").click();
+		await page.waitForLoadState("networkidle");
+
+		await page.evaluate(() => {
+			document.querySelector('#attach-to-categories > div.postbox').classList.remove('closed');
+		});
+
+		const categoriesSelector = page.locator(
+			'#ppom-product-modal select[name="ppom-attach-to-categories\\[\\]"]',
+		);
+	
+		// NOTE: categories created by `create-prodcuts.sh`
+		await categoriesSelector.selectOption(
+			categoriesToUse.map((c) => ({ value: c })),
+		);
+		await page.getByRole("button", { name: "Save" }).click();
+		await page.waitForLoadState("networkidle");
+		await page.reload();
+
+		for (const cat of categoriesToUse) {
+			await page.goto(`/?product_cat=${cat}`);
+			await page.locator('a.add_to_cart_button').first().click();
+
+			const elements = page.locator(`.ppom-id-${ppomId}`);
+			const count = await elements.count();
+			expect(count ).toBeGreaterThan(0);
 		}
 	});
 });

--- a/tests/e2e/specs/group-field-edit.spec.js
+++ b/tests/e2e/specs/group-field-edit.spec.js
@@ -17,6 +17,10 @@ import {
 } from "../utils";
 
 test.describe("Group Fields Edit", () => {
+
+	/**
+	 * Create two input fields and change their order then save and check.
+	 */
 	test("change fields order on saving", async ({ page, admin }) => {
 		await createSimpleGroupField(admin, page);
 		await page.waitForTimeout(500);
@@ -55,6 +59,9 @@ test.describe("Group Fields Edit", () => {
 		expect(newOrderFieldIds).not.toEqual(fieldIds);
 	});
 
+	/**
+	 * Create a select input with two option. Save then change their order and check again.
+	 */
     test("change select option order on saving", async ({ page, admin }) => {
         await admin.visitAdminPage("admin.php?page=ppom");
 

--- a/tests/test-field-saving.php
+++ b/tests/test-field-saving.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Class Test_Field_Saving
+ *
+ * @package ppom-pro
+ */
+
+class Test_Field_Saving extends WP_UnitTestCase {
+
+	/**
+     * Test if the saved categories are in a backward compatible format and tags in a serialized format.
+     */
+    public function test_saving_categories_compatibilities() {
+        global $wpdb;
+        
+        $table_name = $wpdb->prefix . PPOM_TABLE_META;
+        $data = array(
+            'productmeta_name' => 'Test Multiple Categories',
+            'productmeta_validation' => '',
+            'dynamic_price_display' => 'no',
+            'send_file_attachment' => '',
+            'show_cart_thumb' => '',
+            'aviary_api_key' => '',
+            'productmeta_style' => 'selector { }',
+            'productmeta_js' => '',
+            'productmeta_categories' => "accessories\r\nclothing",
+            'the_meta' => '{"1":{"type":"text","title":"Test Cat","data_name":"test_cat","description":"","placeholder":"","error_message":"","maxlength":"","minlength":"","default_value":"","price":"","class":"","input_mask":"","width":"12","visibility":"everyone","visibility_role":"","conditions":{"visibility":"Show","bound":"All","rules":[{"elements":"test_cat","operators":"is","element_values":""}]},"status":"on","ppom_id":"63"}}',
+            'productmeta_created' => '2024-10-16 11:38:45',
+            'productmeta_tags' => 'a:1:{i:0;s:8:"test-tag";}'
+        );
+
+        // Insert data into the table
+        $result = $wpdb->insert($table_name, $data);
+        $this->assertNotFalse( $result );
+        
+        $field_id = $wpdb->insert_id;
+
+        NM_PersonalizedProduct_Admin::save_categories_and_tags( $field_id, ['accessories', 'clothing', 'test-cat'], false );
+        
+        $saved_data = $wpdb->get_row( $wpdb->prepare( "SELECT productmeta_categories, productmeta_tags FROM $table_name WHERE productmeta_id = %d", $field_id ), ARRAY_A );
+       
+        $expected_categories = "accessories\r\nclothing\r\ntest-cat";
+        $this->assertEquals( $expected_categories, $saved_data['productmeta_categories'] );
+        
+        // Tags should not be changed.
+        $expected_tags = 'a:1:{i:0;s:8:"test-tag";}';
+        $this->assertEquals( $expected_tags, $saved_data['productmeta_tags'] );
+    }
+}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

The separator for saved categories was `\r\n` and not just `\n`. Regression introduced in https://github.com/Codeinwp/woocommerce-product-addon/commit/73ea813e604fe989b90316f5b2a1e1c5adc1f55a#diff-de5716d7b637a0feed0d4f345ffb3971f14f694081d2af8dfc59a4889d152155R596

Changes:
- Fixed the separator to be `\r\n` on saving.
- The parser will work both on `\n` and `\r\n`.
- Do not save tags if they are not present in the request.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a group field
- Attach it to some categories and check if it works.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/496
<!-- Should look like this: `Closes #1, #2, #3.` . -->
