### PR TITLE
Fix Attach Modal visibility

### DIFF
--- a/templates/admin/ppom-fields.php
+++ b/templates/admin/ppom-fields.php
@@ -25,9 +25,11 @@ $product_meta_id        = 0;
 $product_meta           = array();
 $ppom_field_index       = 1;
 $is_edit_screen         = false;
+$is_new_group           = false;
 
 if ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] == 'new' ) {
 	$is_edit_screen = true;
+	$is_new_group   = true;
 }
 if ( isset( $_REQUEST['productmeta_id'] ) && $_REQUEST ['do_meta'] == 'edit' ) {
 
@@ -542,7 +544,7 @@ $fields_groups = [
 									</select>
 								</div>
 
-								<?php if ( $is_edit_screen ) { ?>
+								<?php if ( $is_edit_screen && ! $is_new_group ) { ?>
                                 <a class="btn btn-sm btn-secondary ppom-products-modal"
                                    data-ppom_id="<?php echo esc_attr( $product_meta_id ); ?>"
                                    data-formmodal-id="ppom-product-modal"

--- a/tests/e2e/specs/attach-modal.spec.js
+++ b/tests/e2e/specs/attach-modal.spec.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { test, expect } from "@wordpress/e2e-test-utils-playwright";
-import { createSimpleGroupField } from "../utils";
+import { addNewField, createSimpleGroupField, fillFieldNameAndId, pickFieldTypeInModal, saveFieldInModal, saveFields } from "../utils";
 
 test.describe("Attach Modal", () => {
 	/**
@@ -81,5 +81,33 @@ test.describe("Attach Modal", () => {
 			const count = await elements.count();
 			expect(count ).toBeGreaterThan(0);
 		}
+	});
+
+	/**
+	 * Attach Modal should be visible only for existing PPOM fields.
+	 */
+	test("attach modal visibility on Group Edit page", async ({ page, admin }) => {
+		await admin.visitAdminPage("admin.php?page=ppom");
+
+		await page.getByRole("link", { name: "Add New Group" }).click();
+		await page.getByRole("textbox").fill("Test Attach Modal visibility");
+
+		await expect( page.locator('[data-formmodal-id="ppom-product-modal"]') ).toBeHidden();
+
+		await addNewField(page);
+		await pickFieldTypeInModal(page, "text");
+		await fillFieldNameAndId(
+			page,
+			1,
+			`Test`,
+			`test`,
+		);
+		await saveFieldInModal(page, 1);
+		await saveFields(page);
+
+		await page.waitForLoadState("networkidle");
+		await page.reload();
+
+		await expect( page.locator('[data-formmodal-id="ppom-product-modal"]') ).toBeVisible();
 	});
 });


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Display the Attach Modal only on edit action of the Group Fields

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

New Group Fields

![image](https://github.com/user-attachments/assets/fc1312bc-6253-46f5-807a-0b3b4c1f0296)

Existing Group Fields

![image](https://github.com/user-attachments/assets/2e69657e-f7db-438b-9e8c-6d7c9f99c93f)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Attach modal should be visible on the page that creates the group fields
- It should be visible on the page that in which the group field is already created

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/497
<!-- Should look like this: `Closes #1, #2, #3.` . -->
