### PR TITLE
fix: multiple default checked values on Checkbox

### DIFF
--- a/js/admin/ppom-admin.js
+++ b/js/admin/ppom-admin.js
@@ -134,12 +134,16 @@ jQuery(function($) {
         const formData = new FormData();
         const ppomFields = new URLSearchParams();
         
-        // NOTE: since the request is to big for small values of `max_input_vars`, we will send the PPOM fields as a single string.
-        (new FormData(this)).forEach(( value, key) => {
-            if ( key.startsWith('ppom[') && typeof value === 'string' ) {
-                ppomFields.append( key, value );
+        /*
+            NOTE: since the request is to big for small values of `max_input_vars`, we will send the PPOM fields as a single string.
+            
+            INFO: some parts of the code use `\r\n` as delimiter for arrays in textarea. `serializeArray` respect this convention while native JS Form value access sanitize it to just `\n`.
+        */
+        $( this ).serializeArray().forEach(({ value, name }) => {
+            if ( name.startsWith('ppom[') && typeof value === 'string' ) {
+                ppomFields.append( name, value );
             } else {
-                formData.append(key, value);
+                formData.append(name, value);
             }
         });
 

--- a/tests/e2e/specs/checkbox.spec.js
+++ b/tests/e2e/specs/checkbox.spec.js
@@ -1,0 +1,86 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from "@wordpress/e2e-test-utils-playwright";
+
+import {
+    addNewField,
+    addNewOptionInModal,
+    fillFieldNameAndId,
+    fillOptionNameAndValue,
+    pickFieldTypeInModal,
+    saveFieldInModal,
+    saveFields,
+} from "../utils";
+
+const CHECKBOX_OPTIONS = {
+    CHECKED_OPTION_1: 'yes',
+    CHECKED_OPTION_2: 'no',
+    UNCHECKED_OPTION_1: 'maybe'
+};
+
+test.describe("Checkbox", () => {
+    /***
+     * Create a simple checkbox with 3 options. Two will be marked as checked by default. Check if the selection is respected on rendering.
+     */
+    test("check default selected options", async ({ page, admin }) => {
+        await admin.visitAdminPage("admin.php?page=ppom");
+
+        await page.getByRole("link", { name: "Add New Group" }).click();
+        await page
+            .getByRole("textbox")
+            .fill("Default Value for Checkbox");
+
+        await addNewField(page);
+        await pickFieldTypeInModal(page, "checkbox");
+
+        const modelId = 1;
+        const fieldId = `checkbox_test`;
+
+        await fillFieldNameAndId(
+            page,
+            modelId,
+            `Checkbox Default values`,
+            fieldId,
+        );
+
+
+        await page.locator(`textarea[name="ppom\\[${modelId}\\]\\[checked\\]"]`)
+            .fill(`${CHECKBOX_OPTIONS.CHECKED_OPTION_1}\r\n${CHECKBOX_OPTIONS.CHECKED_OPTION_2}`);
+
+        await page
+				.locator(`#ppom_field_model_${modelId}`)
+				.getByText("Add Options", { exact: true })
+				.click();
+
+        await fillOptionNameAndValue(page, modelId, 0, CHECKBOX_OPTIONS.CHECKED_OPTION_1, CHECKBOX_OPTIONS.CHECKED_OPTION_1);
+        await addNewOptionInModal(page, modelId);
+        await fillOptionNameAndValue(page, modelId, 1, CHECKBOX_OPTIONS.CHECKED_OPTION_2, CHECKBOX_OPTIONS.CHECKED_OPTION_2);
+        await addNewOptionInModal(page, modelId);
+        await fillOptionNameAndValue(page, modelId, 2, CHECKBOX_OPTIONS.UNCHECKED_OPTION_1, CHECKBOX_OPTIONS.UNCHECKED_OPTION_1);
+        await saveFieldInModal(page, modelId);
+
+        await saveFields(page);
+        await page.waitForLoadState("networkidle");
+        await page.reload();
+
+        await page.getByText("Attach to Products").click({ force: true });
+        await page.waitForLoadState("networkidle");
+
+        const productSelector = page.locator(
+            'select[name="ppom-attach-to-products\\[\\]"]',
+        );
+        await page.waitForLoadState("networkidle");
+
+        await productSelector.selectOption({ index: 0 });
+        const selectedProductId = await productSelector.inputValue();
+        await page.getByRole("button", { name: "Save", exact: true }).click();
+
+        await page.waitForLoadState("networkidle");
+        await page.goto(`/?p=${selectedProductId}`);
+        
+        await expect(page.locator(`input[name="ppom[fields][${fieldId}][]"][value="${CHECKBOX_OPTIONS.CHECKED_OPTION_1}"]`)).toBeChecked();
+        await expect(page.locator(`input[name="ppom[fields][${fieldId}][]"][value="${CHECKBOX_OPTIONS.CHECKED_OPTION_2}"]`)).toBeChecked();
+        await expect(page.locator(`input[name="ppom[fields][${fieldId}][]"][value="${CHECKBOX_OPTIONS.UNCHECKED_OPTION_1}"]`)).not.toBeChecked();
+    });
+});


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

When you get the values from a textarea with native `Form`, the delimiter will be `\n` instead of `\r\n`. The checkbox was parsing using the `\r\n`: https://github.com/Codeinwp/woocommerce-product-addon/blob/master/templates/render-fields.php#L152

Switched to `serializedArray` to get the values since jQuery respects the `\r\n`. 

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make a simple checkbox with 3 options.
- Set 2 options as default values.
- Check if those 2 values are already selected on the product page.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/425
<!-- Should look like this: `Closes #1, #2, #3.` . -->
