### PR TITLE
Fixed early textdomain loading

### DIFF
--- a/backend/options.php
+++ b/backend/options.php
@@ -16,117 +16,121 @@ if ( ! class_exists( 'PPOM_SettingsFramework' ) ) {
 }
 
 /**
- * Register Panel Fieds Against Panel ID
- * --------------------------------------
- */
-$core_settings = array(
-	'ppom_general_section1'               => array(
-		'type'  => 'section',
-		'title' => __( 'Basic Settings', 'woocommerce-product-addon' ),
-	),
-	'ppom_disable_bootstrap'              => array(
-		'type'  => 'checkbox',
-		'title' => __( 'Disable Bootstrap', 'woocommerce-product-addon' ),
-		'desc'  => __( 'Bootstrap JS is loaded from a CDN by default. You can disable it if your site is already loading it.', 'woocommerce-product-addon' ),
-		'label' => __( 'Yes', 'woocommerce-product-addon' ),
-	),
-	'ppom_enable_legacy_inputs_rendering' => array(
-		'type'  => 'checkbox',
-		'title' => __( 'Legacy Inputs Rendering', 'woocommerce-product-addon' ),
-		'desc'  => __( 'PPOM Version 22.0 is a major update. If any issues occur, you can revert to the previous version using this option.', 'woocommerce-product-addon' ),
-	),
-	'ppom_new_conditions'                 => array(
-		'type'  => 'checkbox',
-		'title' => __( 'Legacy Conditions Script', 'woocommerce-product-addon' ),
-		'desc'  => __( 'If you found any issue in conditions you may enable this option.', 'woocommerce-product-addon' ),
-	),
-	'ppom_legacy_price'                   => array(
-		'type'  => 'checkbox',
-		'title' => __( 'Enable Legacy Price Calculations', 'woocommerce-product-addon' ),
-		'desc'	=> __( 'Enable this option to use the legacy method for price calculations.', 'woocommerce-product-addon' ),
-	),
-	'ppom_permission_mfields'             => array(
-		'type'        => 'select',
-		'title'       => __( 'PPOM Permissions', 'woocommerce-product-addon' ),
-		'desc'        => __( 'You can set permissions here to allow different roles to manage PPOM fields.', 'woocommerce-product-addon' ),
-		'default'     => 'administrator',
-		'placeholder' => __( 'choose role', 'woocommerce-product-addon' ),
-		'options'     => ppom_get_all_editable_roles(),
-		'style'       => 'multiselect',
-	),
-	'ppom_restricted_file_type'           => array(
-		'type'    => 'text',
-		'title'   => __( 'Restricted File Types', 'woocommerce-product-addon' ),
-		'desc'    => __( 'Specify the file types that are restricted from being uploaded in this section.', 'woocommerce-product-addon' ),
-		'default' => __( 'php,php4,php5,php6,php7,phtml,exe,shtml', 'woocommerce-product-addon' ),
-	),
-	'ppom_general_section2'               => array(
-		'type'  => 'section',
-		'title' => __( 'Label Settings', 'woocommerce-product-addon' ),
-	),
-	'ppom_label_option_total'             => array(
-		'type'    => 'text',
-		'title'   => __( 'Option Total Label Inside Price Table', 'woocommerce-product-addon' ),
-		'default' => __( 'Option Total', 'woocommerce-product-addon' ),
-	),
-	'ppom_label_product_price'            => array(
-		'type'    => 'text',
-		'title'   => __( 'Product Price Label inside Price Table', 'woocommerce-product-addon' ),
-		'default' => __( 'Product Price', 'woocommerce-product-addon' ),
-	),
-	'ppom_label_total'                    => array(
-		'type'    => 'text',
-		'title'   => __( 'Total Label inside Price Table', 'woocommerce-product-addon' ),
-		'default' => __( 'Total', 'woocommerce-product-addon' ),
-	),
-	'ppom_label_total_discount'           => array(
-		'type'    => 'text',
-		'title'   => __( 'Total Discount Label Inside Price Table', 'woocommerce-product-addon' ),
-		'default' => __( 'Total Discount', 'woocommerce-product-addon' ),
-	),
-	'ppom_label_option_total_suffex'      => array(
-		'type'  => 'text',
-		'title' => __( 'Option Total Suffix', 'woocommerce-product-addon' ),
-		'desc'  => __( 'Specify the label to display tax or VAT information, such as \'VAT Included\' or \'Tax Applied,\' inside the price table.', 'woocommerce-product-addon' ),
-	),
-);
-
-/**
- * Register Panel Against Tab ID
- * -------------------------------
- */
-$panel_meta = array(
-	'ppom_admin_core_settings' => array(
-		'id'          => 'ppom_admin_core_settings',
-		'title'       => 'General Settings',
-		'desc'        => '',
-		'is_sabpanel' => true,
-		'active'      => 'yes',
-	),
-);
-
-
-/**
- * Register Main Tabs
- * --------------------------
- */
-$register_tabs = array(
-	'ppom_general_tab' => array(
-		'tab_id'  => 'ppom_general_tab',
-		'title'   => 'PPOM',
-		'icon'    => '',
-		'classes' => array( 'active' ),
-		'enable'  => true,
-	),
-);
-
-
-/**
  * Register Settings Panel
  * --------------------------
  */
-PPOMSETTINGS()->register_tabs( $register_tabs )->register_panel( 'ppom_general_tab', $panel_meta );
-PPOMSETTINGS()->register_setting( 'ppom_admin_core_settings', $core_settings );
+
+function ppom_load_free_options() {
+
+	/**
+	 * Register Panel Fieds Against Panel ID
+	 * --------------------------------------
+	 */
+	$core_settings = array(
+		'ppom_general_section1'               => array(
+			'type'  => 'section',
+			'title' => __( 'Basic Settings', 'woocommerce-product-addon' ),
+		),
+		'ppom_disable_bootstrap'              => array(
+			'type'  => 'checkbox',
+			'title' => __( 'Disable Bootstrap', 'woocommerce-product-addon' ),
+			'desc'  => __( 'Bootstrap JS is loaded from a CDN by default. You can disable it if your site is already loading it.', 'woocommerce-product-addon' ),
+			'label' => __( 'Yes', 'woocommerce-product-addon' ),
+		),
+		'ppom_enable_legacy_inputs_rendering' => array(
+			'type'  => 'checkbox',
+			'title' => __( 'Legacy Inputs Rendering', 'woocommerce-product-addon' ),
+			'desc'  => __( 'PPOM Version 22.0 is a major update. If any issues occur, you can revert to the previous version using this option.', 'woocommerce-product-addon' ),
+		),
+		'ppom_new_conditions'                 => array(
+			'type'  => 'checkbox',
+			'title' => __( 'Legacy Conditions Script', 'woocommerce-product-addon' ),
+			'desc'  => __( 'If you found any issue in conditions you may enable this option.', 'woocommerce-product-addon' ),
+		),
+		'ppom_legacy_price'                   => array(
+			'type'  => 'checkbox',
+			'title' => __( 'Enable Legacy Price Calculations', 'woocommerce-product-addon' ),
+			'desc'	=> __( 'Enable this option to use the legacy method for price calculations.', 'woocommerce-product-addon' ),
+		),
+		'ppom_permission_mfields'             => array(
+			'type'        => 'select',
+			'title'       => __( 'PPOM Permissions', 'woocommerce-product-addon' ),
+			'desc'        => __( 'You can set permissions here to allow different roles to manage PPOM fields.', 'woocommerce-product-addon' ),
+			'default'     => 'administrator',
+			'placeholder' => __( 'choose role', 'woocommerce-product-addon' ),
+			'options'     => ppom_get_all_editable_roles(),
+			'style'       => 'multiselect',
+		),
+		'ppom_restricted_file_type'           => array(
+			'type'    => 'text',
+			'title'   => __( 'Restricted File Types', 'woocommerce-product-addon' ),
+			'desc'    => __( 'Specify the file types that are restricted from being uploaded in this section.', 'woocommerce-product-addon' ),
+			'default' => __( 'php,php4,php5,php6,php7,phtml,exe,shtml', 'woocommerce-product-addon' ),
+		),
+		'ppom_general_section2'               => array(
+			'type'  => 'section',
+			'title' => __( 'Label Settings', 'woocommerce-product-addon' ),
+		),
+		'ppom_label_option_total'             => array(
+			'type'    => 'text',
+			'title'   => __( 'Option Total Label Inside Price Table', 'woocommerce-product-addon' ),
+			'default' => __( 'Option Total', 'woocommerce-product-addon' ),
+		),
+		'ppom_label_product_price'            => array(
+			'type'    => 'text',
+			'title'   => __( 'Product Price Label inside Price Table', 'woocommerce-product-addon' ),
+			'default' => __( 'Product Price', 'woocommerce-product-addon' ),
+		),
+		'ppom_label_total'                    => array(
+			'type'    => 'text',
+			'title'   => __( 'Total Label inside Price Table', 'woocommerce-product-addon' ),
+			'default' => __( 'Total', 'woocommerce-product-addon' ),
+		),
+		'ppom_label_total_discount'           => array(
+			'type'    => 'text',
+			'title'   => __( 'Total Discount Label Inside Price Table', 'woocommerce-product-addon' ),
+			'default' => __( 'Total Discount', 'woocommerce-product-addon' ),
+		),
+		'ppom_label_option_total_suffex'      => array(
+			'type'  => 'text',
+			'title' => __( 'Option Total Suffix', 'woocommerce-product-addon' ),
+			'desc'  => __( 'Specify the label to display tax or VAT information, such as \'VAT Included\' or \'Tax Applied,\' inside the price table.', 'woocommerce-product-addon' ),
+		),
+	);
+
+	/**
+	 * Register Main Tabs
+	 * --------------------------
+	 */
+	$register_tabs = array(
+		'ppom_general_tab' => array(
+			'tab_id'  => 'ppom_general_tab',
+			'title'   => 'PPOM',
+			'icon'    => '',
+			'classes' => array( 'active' ),
+			'enable'  => true,
+		),
+	);
+
+	/**
+	 * Register Panel Against Tab ID
+	 * -------------------------------
+	 */
+	$panel_meta = array(
+		'ppom_admin_core_settings' => array(
+			'id'          => 'ppom_admin_core_settings',
+			'title'       => 'General Settings',
+			'desc'        => '',
+			'is_sabpanel' => true,
+			'active'      => 'yes',
+		),
+	);
+
+	PPOMSETTINGS()->register_tabs( $register_tabs )->register_panel( 'ppom_general_tab', $panel_meta );
+	PPOMSETTINGS()->register_setting( 'ppom_admin_core_settings', $core_settings );
+}
+add_action( 'init', 'ppom_load_free_options' );
+
 function ppom_load_pro_options() {
 	$pro_settings = array(
 		'ppom_pro_basics'                    => array(

--- a/backend/settings-panel.class.php
+++ b/backend/settings-panel.class.php
@@ -73,9 +73,12 @@ class PPOM_SettingsFramework {
 	var $scripts_class;
 
 	function __construct() {
+		$this->config = array(
+			'id'         => 'ppom',
+			'plugin_url' => PPOM_URL,
+		);
 
-
-		$this->register_config();
+		add_action( 'init', array( $this, 'register_config' ) );
 
 		self::$assets_url = $this->get_config( 'plugin_url' ) . '/backend/assets';
 
@@ -120,9 +123,8 @@ class PPOM_SettingsFramework {
 	 */
 	public function register_config() {
 
-		$this->config = array(
+		$config = array(
 			'name'            => __( 'PPOM Admin Settings', 'woocommerce-product-addon' ),
-			'id'              => 'ppom',
 			'version'         => '1.0',
 			'form_tag'        => false,
 			'menu_type'       => 'wc',
@@ -136,8 +138,9 @@ class PPOM_SettingsFramework {
 			'plugin_name'     => __( 'PPOM', 'woocommerce-product-addon' ),
 			'plugin_version'  => PPOM_VERSION,
 			'plugin_domain'   => 'woocommerce-product-addon',
-			'plugin_url'      => PPOM_URL,
 		);
+
+		$this->config = array_merge( $this->config, $config );
 	}
 
 

--- a/classes/admin.class.php
+++ b/classes/admin.class.php
@@ -36,17 +36,7 @@ class NM_PersonalizedProduct_Admin extends NM_PersonalizedProduct {
 		/*
 		 * [1] TODO: change this for plugin admin pages
 		*/
-		$this->menu_pages = array(
-			array(
-				'page_title'  => __( 'PPOM', 'woocommerce-product-addon' ),
-				'menu_title'  => __( 'PPOM', 'woocommerce-product-addon' ),
-				'cap'         => 'manage_options',
-				'slug'        => 'ppom',
-				'callback'    => 'product_meta',
-				'parent_slug' => 'woocommerce',
-			),
-		);
-
+		add_action( 'init', array( $this, 'menu_page_options' ) );
 
 		add_action(
 			'admin_menu',
@@ -88,6 +78,22 @@ class NM_PersonalizedProduct_Admin extends NM_PersonalizedProduct {
 
 		add_action( 'admin_init', array( $this, 'set_legacy_user' ) );
 		add_action( 'admin_init', array( $this, 'ppom_create_db_tables' ) );
+	}
+
+	/**
+	 * Menu page options.
+	 */
+	public function menu_page_options() {
+		$this->menu_pages = array(
+			array(
+				'page_title'  => __( 'PPOM', 'woocommerce-product-addon' ),
+				'menu_title'  => __( 'PPOM', 'woocommerce-product-addon' ),
+				'cap'         => 'manage_options',
+				'slug'        => 'ppom',
+				'callback'    => 'product_meta',
+				'parent_slug' => 'woocommerce',
+			),
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Summary
I've fixed the early textdomain loading issue.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/468