### PR TITLE
fix: show uploaded files in email for WooCommerce 9.8.0

### DIFF
--- a/classes/plugin.class.php
+++ b/classes/plugin.class.php
@@ -172,7 +172,7 @@ class NM_PersonalizedProduct {
 
 		// when email improvements feature enabled in woocommerce.
 		if ( ppom_wc_email_improvements_enabled() ) {
-			add_action( 'woocommerce_order_item_meta_end', 'ppom_woocommerce_order_itam_meta_html', 10, 4 );
+			add_action( 'woocommerce_order_item_meta_end', 'ppom_woocommerce_order_item_meta_html', 10, 4 );
 			add_filter( 'woocommerce_display_item_meta', '__return_empty_string' );
 		} else {
 			// Few inputs like file/crop/image need to show meta value in tags

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -1421,17 +1421,17 @@ function ppom_wc_order_again_compatibility( $cart_item_data, $item, $order ) {
  * @param int $item_id The item ID.
  * @param \WC_Order_Item_Product $item The order item object.
  */
-function ppom_woocommerce_order_itam_meta_html( $item_id, $item ) {
+function ppom_woocommerce_order_item_meta_html( $item_id, $item ) {
 	$formatted_meta = $item->get_formatted_meta_data();
 
 	$strings = array();
 	$meta_item_html = '';
 	$output_args = apply_filters( 'ppom_woocommerce_item_meta_args',
 		array(
-			'before'       => '<div style="display: flex; flex-wrap: wrap; gap: 5px;">',
+			'before'       => '<div>',
 			'after'        => '</div>',
 			'separator'    => '<br>',
-			'label_before' => '<span>',
+			'label_before' => '<span style="float: left;">',
 			'label_after'  => ':</span> ',
 		)
 	);
@@ -1442,7 +1442,7 @@ function ppom_woocommerce_order_itam_meta_html( $item_id, $item ) {
 	if ( $strings ) {
 		$meta_item_html = implode( $output_args['separator'], $strings );
 	}
-	echo $meta_item_html;
+	echo wp_kses_post( $meta_item_html );
 }
 
 /**


### PR DESCRIPTION
### Summary
Fixed the uploaded file shown in order emails when WooCommerce v9.8.0+

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/ppom-pro/issues/567