### PR TITLE
Fixed missing tooltips on fields

### DIFF
--- a/inc/validation.php
+++ b/inc/validation.php
@@ -37,7 +37,7 @@ function ppom_esc_html( $content ) {
 		'onclick'    => array(),
 		'onchange'   => array(),
 		'onkeyup'    => array(),
-		'data-*'     => array(),
+		'data-*'     => true, // allows all data-* attributes
 		'style'      => array(),
 	);
 	$allowedposttags['form']     = $allowed_atts;


### PR DESCRIPTION
### Summary
Fixed the tooltip is missing in certain fields like: text, radio, quantities, cropper, switcher, etc.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/ppom-pro/issues/573