### PR TITLE
Fixed file upload field on iOS

### DIFF
--- a/css/ppom-style.css
+++ b/css/ppom-style.css
@@ -208,7 +208,9 @@ height: 100px;*/
 /** ========= PPOM Conditional Fields =========== */
 
 .ppom-c-hide{
-  display:none;
+  visibility: hidden;
+  position: absolute;
+  height: 0;
 }
 
 .ppom-c-show{


### PR DESCRIPTION
### Summary
On iOS Safari, file inputs inside elements with `display: none` are blocked from opening the file picker, even after being made visible. Updated the CSS approach to hide elements without using `display: none`, ensuring inputs remain accessible to Safari.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/ppom-pro/issues/568