### PR TITLE
Fixed tooltip icon color

### DIFF
--- a/classes/plugin.class.php
+++ b/classes/plugin.class.php
@@ -1002,7 +1002,8 @@ class NM_PersonalizedProduct {
 
 		// Check if the tooltip is enabled.
 		if ( isset( $meta['desc_tooltip'] ) && 'on' === $meta['desc_tooltip'] ) {
-			$description = ( ! empty( $meta['description'] ) ) ? ' <span data-ppom-tooltip="ppom_tooltip" class="ppom-tooltip" title="' . esc_attr( $input_desc ) . '"><span class="ppom-tooltip-icon"></span></span>' : '';
+			$icon_color  = ppom_get_option( 'ppom_input_tooltip_iconclr', '#000000' );
+			$description = ( ! empty( $meta['description'] ) ) ? ' <span data-ppom-tooltip="ppom_tooltip" class="ppom-tooltip" title="' . esc_attr( $input_desc ) . '"><span class="ppom-tooltip-icon" style="background-color:' . esc_attr( $icon_color ) .'"></span></span>' : '';
 		}
 		return $description;
 	}

--- a/inc/validation.php
+++ b/inc/validation.php
@@ -348,3 +348,29 @@ function ppom_get_product_limits( $product_id, $variation_id ) {
 	// ppom_pa($limits);
 	return $limits;
 }
+
+/**
+ * By default, WordPress strips CSS values that contain \ ( & } = or comments, such as rgb()
+ * and rgba(), because the core regex in safecss_filter_attr() flags them as unsafe.
+ *
+ * This filter overrides that behavior by checking if the CSS string contains
+ * "rgb(" or "rgba(" and explicitly allows it. All other CSS values still pass
+ * through the normal WordPress sanitization process.
+ *
+ * @since 1.0.0
+ *
+ * @param bool   $allow_css  Whether the CSS in the string is considered safe.
+ * @param string $css_string The full CSS declaration.
+ *
+ * @return bool  True if the CSS is safe and should be allowed, false otherwise.
+ */
+function ppom_safecss_filter_attr( $allow_css, $css_string ) {
+
+    // If the CSS string contains rgb() or rgba(), mark it as safe.
+    if ( stripos( $css_string, 'rgb(' ) !== false || stripos( $css_string, 'rgba(' ) !== false ) {
+        return true;
+    }
+
+    return $allow_css;
+}
+add_filter( 'safecss_filter_attr_allow_css', 'ppom_safecss_filter_attr', 10, 2 );

--- a/templates/frontend/inputs/checkbox.php
+++ b/templates/frontend/inputs/checkbox.php
@@ -59,6 +59,7 @@ $wrapper_class = $has_discount ? 'form-check' : 'form-check-inline';
 
 $check_wrapper_class = apply_filters( 'ppom_checkbox_wrapper_class', $wrapper_class );
 $product_type        = $product->get_type();
+$icon_color          = ppom_get_option( 'ppom_input_tooltip_iconclr', '#000000' );
 
 // change checkbox input form name 
 // add_filter('ppom_input_name_attr', function($form_name, $meta){
@@ -95,7 +96,7 @@ $product_type        = $product->get_type();
 		// if discount price set
 		if ( $has_discount ) {
 			$price        = $discount_price > 0 ? wc_format_sale_price( $option_price, $discount_price ) : wc_price( $option_price );
-			$tooltip      = $tooltip ? ' <span data-ppom-tooltip="ppom_tooltip" class="ppom-tooltip" title="' . esc_attr( $tooltip ) . '"><span class="ppom-tooltip-icon"></span></span>' : '';
+			$tooltip      = $tooltip ? ' <span data-ppom-tooltip="ppom_tooltip" class="ppom-tooltip" title="' . esc_attr( $tooltip ) . '"><span class="ppom-tooltip-icon" style="background-color:' . esc_attr( $icon_color ) . '"></span></span>' : '';
 			$the_label    = $value['raw'] . $tooltip;
 			$option_label = '<span class="ppom-cb-label">' . $the_label . '</span><span class="ppom-cb-price">' . $price . '</span>';
 		}


### PR DESCRIPTION
### Summary
Apply the background color configured in settings to the tooltip icon.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/581