### PR TITLE
prevent arbitrary file uploads

### DIFF
--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -45,7 +45,7 @@ function ppom_hooks_save_cropped_image( $ppom_fields, $posted_data ) {
 				$file_name  = isset( $values['org'] ) ? $values['org'] : '';
 
 				// Verify uploaded file type.
-				$allowed_types = isset( $cropper['file_types'] ) ? sanitize_text_field( $cropper['file_types'] ) : 'jpg,png';
+				$allowed_types = isset( $cropper['file_types'] ) && ! empty( $cropper['file_types'] ) ? sanitize_text_field( $cropper['file_types'] ) : 'jpg,png';
 				$allowed_types = explode( ',', $allowed_types );
 				$dir_path      = ppom_get_dir_path();
 				$file_type     = wp_check_filetype_and_ext( $dir_path . $file_name, $file_name );


### PR DESCRIPTION
### Summary
Check the file type and compare it with the allowed file types. If the file type does not exist in the allowed list, skip the file upload.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/ppom-pro/issues/590