### PR TITLE
Fixed broken access control vulnerability

### DIFF
--- a/classes/plugin.class.php
+++ b/classes/plugin.class.php
@@ -927,7 +927,19 @@ class NM_PersonalizedProduct {
 
 	function ppom_attach_meta() {
 
-		$product_id = isset( $_GET['productid'] ) ? intval( $_GET['productid'] ) : '';
+		$product_id  = isset( $_GET['productid'] ) ? intval( $_GET['productid'] ) : '';
+		$product_url = get_permalink( $product_id );
+
+		if ( ! isset( $_GET['nonce'] ) || empty( $_GET['nonce'] ) || ! wp_verify_nonce( $_GET['nonce'], 'ppom_attach' ) ) {
+			wp_redirect( $product_url );
+			exit;
+		}
+
+		if ( ! current_user_can( 'edit_post', $product_id ) ) {
+			wp_redirect( $product_url );
+			exit;
+		}
+											
 		$meta_id    = isset( $_GET['metaid'] ) ? intval( $_GET['metaid'] ) : '';
 		$meta_title = isset( $_GET['metatitle'] ) ? sanitize_title( $_GET['metatitle'] ) : '';
 

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -808,6 +808,7 @@ function ppom_admin_bar_menu() {
 			'metaid'    => $meta->productmeta_id,
 			'metatitle' => $meta->productmeta_name,
 			'action'    => 'ppom_attach',
+			'nonce'     => wp_create_nonce( 'ppom_attach' ),
 		);
 		$apply_link = add_query_arg( $apply_arg, $apply_link );
 		$bar_title  = "Apply {$meta->productmeta_name}";


### PR DESCRIPTION
### Summary
Verify the current user has `edit_post` capability and verify the nonce.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/ppom-pro/issues/605