### PR TITLE
Fixed input masking when regex enabled

### DIFF
--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -84,7 +84,7 @@ function ppom_init_js_for_ppom_fields(ppom_fields) {
             // masking
             case 'text':
                 if (input.input_mask == undefined || input.input_mask == '') break;
-                InputSelector.inputmask();
+                InputSelector.inputmask({regex: input.input_mask});
                 if (input.type === 'text' &&
                     input.input_mask !== '' &&
                     input.use_regex !== 'on') {


### PR DESCRIPTION
### Summary
Passed regex to the inputmask function.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/485