### PR TITLE
Fixed fatal error

### DIFF
--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -329,7 +329,7 @@ function ppom_woocommerce_update_cart_fees( $cart_items, $values ) {
 	$ppom_item_order_qty = floatval( $cart_items['quantity'] );
 
 	// Getting option price
-	$option_prices = json_decode( stripslashes( $values['ppom']['ppom_option_price'] ), true );
+	$option_prices = json_decode( wp_unslash( $values['ppom']['ppom_option_price'] ), true );
 	// ppom_pa($option_prices);
 	$total_option_price = 0;
 	$ppom_matrix_price  = 0;
@@ -559,7 +559,7 @@ function ppom_woocommerce_add_fixed_fee( $cart ) {
 		}
 
 		// Getting option price
-		$option_prices = json_decode( stripslashes( $item['ppom']['ppom_option_price'] ), true );
+		$option_prices = json_decode( wp_unslash( $item['ppom']['ppom_option_price'] ), true );
 
 		if ( $option_prices ) {
 			foreach ( $option_prices as $fee ) {
@@ -947,7 +947,7 @@ function ppom_woocommerce_control_cart_quantity_legacy( $quantity, $cart_item_ke
 	}
 
 	// Getting option price
-	$option_prices       = json_decode( stripslashes( $cart_item['ppom']['ppom_option_price'] ), true );
+	$option_prices       = json_decode( wp_unslash( $cart_item['ppom']['ppom_option_price'] ), true );
 	$ppom_has_quantities = 0;
 	// ppom_pa($option_prices);
 
@@ -1011,7 +1011,7 @@ function ppom_woocommerce_item_subtotal( $item_subtotal, $cart_item, $cart_item_
 	}
 
 	// Getting option price.
-	$option_prices = json_decode( stripslashes( $cart_item['ppom']['ppom_option_price'] ), true );
+	$option_prices = json_decode( wp_unslash( $cart_item['ppom']['ppom_option_price'] ), true );
 
 	if ( empty( $option_prices ) ) {
 		return $item_subtotal;


### PR DESCRIPTION
### Summary
Used `wp_unslash` instead of `stripslashes` to remove the slashes.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/ppom-pro/issues/609