### PR TITLE
Escaped value when rendering selected condition

### DIFF
--- a/js/admin/ppom-admin.js
+++ b/js/admin/ppom-admin.js
@@ -1583,7 +1583,7 @@ jQuery(function($) {
                 updateTargetComparisonValueSelect( 
                     conditionTargetsSelect,
                     conditionContainer,
-                    optionsInput?.dataset?.existingvalue
+                    ppom_escape_html(optionsInput?.dataset?.existingvalue)
                 );
             });
         });


### PR DESCRIPTION
### Summary
Escaping the value to make it selected.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/ppom-pro/issues/580