### PR TITLE
fix: preserve user roles option

### DIFF
--- a/js/admin/ppom-admin.js
+++ b/js/admin/ppom-admin.js
@@ -204,7 +204,7 @@ jQuery(function($) {
     /**
         4- Show And Hide Visibility Role Field
     **/
-    $('.ppom-slider').find('[data-meta-id="visibility_role"]').removeClass('ppom_handle_fields_tab').hide();
+    $('.ppom-slider').find('[data-meta-id="visibility_role"]').hide();
     $('.ppom_save_fields_model .ppom-slider').each(function(i, div) {
         var visibility_value = $(div).find('[data-meta-id="visibility"] select').val();
         if (visibility_value == 'roles') {


### PR DESCRIPTION
### Summary
Prevent removing the class `ppom_handle_fields_tab` on page load from the visibility role field to preserve the field.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/ppom-pro/issues/621
