### PR TITLE
refactor: update Black Friday labels

### DIFF
--- a/classes/admin.class.php
+++ b/classes/admin.class.php
@@ -121,6 +121,10 @@ class NM_PersonalizedProduct_Admin extends NM_PersonalizedProduct {
 	 * @return array
 	 */
 	public function upgrade_to_pro_plugin_action( $actions, $plugin_file ) {
+		if ( apply_filters( 'themeisle_sdk_is_black_friday_sale', false ) ) {
+			return $actions;
+		}
+
 		if ( apply_filters( 'product_ppom_license_status', '' ) === 'valid' || apply_filters( 'product_ppom_license_status', '' ) === 'active_expired' ) {
 			return $actions;
 		}

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -934,6 +934,8 @@ function ppom_add_black_friday_data( $configs ) {
 	} else {
 		// translators: %s - discount.
 		$config['title'] = sprintf( __( 'PPOM Pro: %s off this week', 'woocommerce-product-addon' ), '60%' );
+		// translators: %s is the discount percentage.
+		$config['upgrade_menu_text'] = sprintf( __( 'BF Sale - %s off', 'woocommerce-product-addon' ), '60%' );
 	}
 	
 	$url_params    = array(

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -132,7 +132,7 @@ function ppom_meta_list( $post ) {
 	$html .= '<th>' . __( 'Group Name', 'woocommerce-product-addon' ) . '</th>';
 	$html .= '<th>' . __( 'Edit', 'woocommerce-product-addon' ) . '</th>';
 	$html .= '</tr></thead>';
-	
+
 	foreach ( $all_meta as $meta ) {
 		$html .= '<tr data-ppom-search="' . esc_attr( sanitize_key( $meta->productmeta_name ) ) . '" style="cursor: move;">';
 
@@ -250,15 +250,15 @@ function ppom_admin_process_product_meta( $post_id ) {
 
 
 	$ppom_meta_selected = isset( $_POST ['ppom_product_meta'] ) ? $_POST ['ppom_product_meta'] : array();
-	
+
 	if ( is_numeric( $ppom_meta_selected ) ) {
 		$ppom_meta_selected = array( $ppom_meta_selected );
 	} elseif ( ! is_array( $ppom_meta_selected ) ) {
 		$ppom_meta_selected = array();
 	}
-	
+
 	$ppom_meta_selected = array_map( 'intval', $ppom_meta_selected );
-	
+
 	// ppom_pa($ppom_meta_selected); exit;
 	update_post_meta( $post_id, PPOM_PRODUCT_META_KEY, $ppom_meta_selected );
 
@@ -428,7 +428,7 @@ function ppom_admin_save_form_meta() {
 			return ! empty( $pm['type'] ) && ! empty( $pm['data_name'] );
 		}
 	);
-	
+
 	// Updating PPOM Meta with ppom_id in each meta array
 	ppom_admin_update_ppom_meta_only( $ppom_id, $product_meta );
 
@@ -925,19 +925,23 @@ function ppom_add_black_friday_data( $configs ) {
 	$is_expired = 'expired' === $status || 'active-expired' === $status;
 
 	if ( $is_pro ) {
+		// translators: %s is the discount percentage.
+		$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'woocommerce-product-addon' ), '30%' );
 		// translators: %1$s - discount, %2$s - discount.
 		$message = sprintf( __( 'Upgrade your PPOM Pro plan: %1$s off this week. Already on the plan you need? Renew early and save up to %2$s.', 'woocommerce-product-addon' ), '30%', '20%' );
 		$cta_label = __( 'See your options', 'woocommerce-product-addon' );
 	} elseif ( $is_expired ) {
+		// translators: %s is the discount percentage.
+		$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'woocommerce-product-addon' ), '50%' );
 		$message = __( 'Your PPOM Pro features are still here, just locked. Renew at a reduced rate this week.', 'woocommerce-product-addon' );
 		$cta_label = __( 'Reactivate now', 'woocommerce-product-addon' );
 	} else {
+		// translators: %s is the discount percentage.
+		$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'woocommerce-product-addon' ), '60%' );
 		// translators: %s - discount.
 		$config['title'] = sprintf( __( 'PPOM Pro: %s off this week', 'woocommerce-product-addon' ), '60%' );
-		// translators: %s is the discount percentage.
-		$config['upgrade_menu_text'] = sprintf( __( 'BF Sale - %s off', 'woocommerce-product-addon' ), '60%' );
 	}
-	
+
 	$url_params    = array(
 		'utm_term' => $is_pro ? 'plan-' . $plan : 'free',
 		'lkey'     => ! empty( $license ) ? $license : false,
@@ -945,12 +949,7 @@ function ppom_add_black_friday_data( $configs ) {
 	);
 
 	if ( ( $is_pro || $is_expired ) && ! empty( $pro_product_slug ) ) {
-		// translators: %s is the discount percentage.
-		$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'woocommerce-product-addon' ), '30%' );
 		$config['plugin_meta_targets'] = array( $pro_product_slug );
-	} else {
-		// translators: %s is the discount percentage.
-		$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'woocommerce-product-addon' ), '60%' );
 	}
 
 	$config['message']   = $message;

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -919,6 +919,7 @@ function ppom_add_black_friday_data( $configs ) {
 	$plan    = apply_filters( 'product_ppom_license_plan', 0 );
 	$license = apply_filters( 'product_ppom_license_key', false );
 	$status  = apply_filters( 'product_ppom_license_status', false );
+	$pro_product_slug = defined( 'PPOM_PRO_BASENAME' ) ? PPOM_PRO_BASENAME : '';
 
 	$is_pro  = 'valid' === $status;
 	$is_expired = 'expired' === $status || 'active-expired' === $status;
@@ -940,9 +941,19 @@ function ppom_add_black_friday_data( $configs ) {
 		'lkey'     => ! empty( $license ) ? $license : false,
 		'expired'  => $is_expired ? '1' : false,
 	);
-	
-	$config['message']  = $message;
+
+	if ( ( $is_pro || $is_expired ) && ! empty( $pro_product_slug ) ) {
+		// translators: %s is the discount percentage.
+		$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'woocommerce-product-addon' ), '30%' );
+		$config['plugin_meta_targets'] = array( $pro_product_slug );
+	} else {
+		// translators: %s is the discount percentage.
+		$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'woocommerce-product-addon' ), '60%' );
+	}
+
+	$config['message']   = $message;
 	$config['cta_label'] = $cta_label;
+
 	$config['sale_url'] = add_query_arg(
 		$url_params,
 		tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/ppom-bf', 'bfcm', 'ppom' ) )

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -913,29 +913,36 @@ function ppom_admin_bar_menu() {
 function ppom_add_black_friday_data( $configs ) {
 	$config = $configs['default'];
 
-	// translators: %1$s - HTML tag, %2$s - discount, %3$s - HTML tag, %4$s - product name.
-	$message_template = __( 'Our biggest sale of the year: %1$sup to %2$s OFF%3$s on %4$s. Don\'t miss this limited-time offer.', 'woocommerce-product-addon' );
-	$product_label    = 'PPOM';
-	$discount         = '70%';
+	$message = __( 'Conditional fields, file uploads, pricing formulas. Let customers configure products the way they need. Exclusively for existing PPOM users.', 'woocommerce-product-addon' );
+	$cta_label = __( 'Get PPOM Pro', 'woocommerce-product-addon' );
 
 	$plan    = apply_filters( 'product_ppom_license_plan', 0 );
 	$license = apply_filters( 'product_ppom_license_key', false );
-	$is_pro  = 0 < $plan;
+	$status  = apply_filters( 'product_ppom_license_status', false );
+
+	$is_pro  = 'valid' === $status;
+	$is_expired = 'expired' === $status || 'active-expired' === $status;
 
 	if ( $is_pro ) {
-		// translators: %1$s - HTML tag, %2$s - discount, %3$s - HTML tag, %4$s - product name.
-		$message_template = __( 'Get %1$sup to %2$s off%3$s when you upgrade your %4$s plan or renew early.', 'woocommerce-product-addon' );
-		$product_label    = 'PPOM Pro';
-		$discount         = '30%';
+		// translators: %1$s - discount, %2$s - discount.
+		$message = sprintf( __( 'Upgrade your PPOM Pro plan: %1$s off this week. Already on the plan you need? Renew early and save up to %2$s.', 'woocommerce-product-addon' ), '30%', '20%' );
+		$cta_label = __( 'See your options', 'woocommerce-product-addon' );
+	} elseif ( $is_expired ) {
+		$message = __( 'Your PPOM Pro features are still here, just locked. Renew at a reduced rate this week.', 'woocommerce-product-addon' );
+		$cta_label = __( 'Reactivate now', 'woocommerce-product-addon' );
+	} else {
+		// translators: %s - discount.
+		$config['title'] = sprintf( __( 'PPOM Pro: %s off this week', 'woocommerce-product-addon' ), '60%' );
 	}
 	
-	$product_label = sprintf( '<strong>%s</strong>', $product_label );
 	$url_params    = array(
 		'utm_term' => $is_pro ? 'plan-' . $plan : 'free',
 		'lkey'     => ! empty( $license ) ? $license : false,
+		'expired'  => $is_expired ? '1' : false,
 	);
 	
-	$config['message']  = sprintf( $message_template, '<strong>', $discount, '</strong>', $product_label );
+	$config['message']  = $message;
+	$config['cta_label'] = $cta_label;
 	$config['sale_url'] = add_query_arg(
 		$url_params,
 		tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/ppom-bf', 'bfcm', 'ppom' ) )
@@ -945,4 +952,5 @@ function ppom_add_black_friday_data( $configs ) {
 
 	return $configs;
 }
+
 add_filter( 'themeisle_sdk_blackfriday_data', 'ppom_add_black_friday_data' );

--- a/woocommerce-product-addon.php
+++ b/woocommerce-product-addon.php
@@ -30,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'PPOM_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'PPOM_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
-define( 'PPOM_WP_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __DIR__ ) ) );
+define( 'PPOM_WP_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'PPOM_BASENAME', basename( PPOM_WP_PLUGIN_DIR ) );
 define( 'PPOM_PRODUCT_SLUG', PPOM_BASENAME );
 define( 'PPOM_VERSION', '33.0.18' );


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Change the labels for Black Friday promotion. Based on https://github.com/Codeinwp/themeisle/issues/1854

### Screenshots <!-- if applicable -->

<img width="2212" height="892" alt="CleanShot 2026-03-17 at 13 53 10@2x" src="https://github.com/user-attachments/assets/f3a151bd-a789-49b2-a613-c86a7130ab6c" />

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install this plugin: https://github.com/Soare-Robert-Daniel/test-black-friday
- Use this SDK version: https://github.com/Codeinwp/themeisle-sdk-main/pull/309
- Test:
  - If the notice appears during the Black Friday period.
  - If the labels change based on the license status (described in the spreadsheet)
  - If the notice can be dismissed.
  - If the notice appears only if the plugin is 3 days old. Warning: You will see the notice if you have another product that is older than 3 days; in this case, better to disable them.