### PR TITLE
Option price not detected on back navigation

### DIFF
--- a/js/price/ppom-price.js
+++ b/js/price/ppom-price.js
@@ -9,7 +9,9 @@ var ppom_product_base_price = ppom_input_vars.wc_product_price;
 
 jQuery(function($) {
 
-    ppom_update_option_prices();
+    $(window).on('load', function() {
+        ppom_update_option_prices();
+    });
 
     // If quantity is changing with some -/+ elements
     $("form.cart .quantity").on('click', function(e) {


### PR DESCRIPTION
### Summary
Update the option price on window load to fix when the back navigation occurs, the price should be updated.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/248