### PR TITLE
Detaching group from product tag

### DIFF
--- a/classes/admin.class.php
+++ b/classes/admin.class.php
@@ -684,6 +684,8 @@ class NM_PersonalizedProduct_Admin extends NM_PersonalizedProduct {
 
 		if ( is_array( $tags ) ) {
 			$data_to_update['productmeta_tags'] = serialize( $tags );
+		} else if ( ! $tags ) {
+			$data_to_update['productmeta_tags'] = '';
 		}
 
 		$wpdb->update(

--- a/tests/test-field-saving.php
+++ b/tests/test-field-saving.php
@@ -35,7 +35,7 @@ class Test_Field_Saving extends WP_UnitTestCase {
         
         $field_id = $wpdb->insert_id;
 
-        NM_PersonalizedProduct_Admin::save_categories_and_tags( $field_id, ['accessories', 'clothing', 'test-cat'], false );
+        NM_PersonalizedProduct_Admin::save_categories_and_tags( $field_id, ['accessories', 'clothing', 'test-cat'], array( 'test-tag' ) );
         
         $saved_data = $wpdb->get_row( $wpdb->prepare( "SELECT productmeta_categories, productmeta_tags FROM $table_name WHERE productmeta_id = %d", $field_id ), ARRAY_A );
        


### PR DESCRIPTION
### Summary
Saved the attached tag value to empty when it gets an empty value.  

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer to review this PR

Closes https://github.com/Codeinwp/ppom-pro/issues/625