### PR TITLE
fix: show image-based fields in cart block

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -665,7 +665,7 @@ function ppom_generate_cart_meta( $ppom_cart_items, $product_id, $ppom_meta_ids 
 
 					$meta_data = array(
 						'name'    => $field_title,
-						'value'   => ppom_get_image_name( $value ),
+						'value'   => $value,
 						'display' => $display,
 					);
 				}
@@ -1652,7 +1652,12 @@ function ppom_generate_html_for_files( $file_names, $input_type, $item ) {
 function ppom_generate_html_for_images( $images ) {
 	global $post;
 
-	if ( has_block( 'woocommerce/cart', $post ) ) {
+	static $ppom_has_cart_block = null;
+	if ( is_null( $ppom_has_cart_block ) ) {
+		$ppom_has_cart_block = has_block( 'woocommerce/cart', $post );
+	}
+
+	if ( $ppom_has_cart_block ) {
 		return ppom_get_image_name( $images );
 	}
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -665,7 +665,7 @@ function ppom_generate_cart_meta( $ppom_cart_items, $product_id, $ppom_meta_ids 
 
 					$meta_data = array(
 						'name'    => $field_title,
-						'value'   => $value,
+						'value'   => ppom_get_image_name( $value ),
 						'display' => $display,
 					);
 				}
@@ -1650,7 +1650,11 @@ function ppom_generate_html_for_files( $file_names, $input_type, $item ) {
 
 // return html for images selected
 function ppom_generate_html_for_images( $images ) {
+	global $post;
 
+	if ( has_block( 'woocommerce/cart', $post ) ) {
+		return ppom_get_image_name( $images );
+	}
 
 	$ppom_html = '<table class="table table-bordered">';
 	foreach ( $images as $id => $images_meta ) {
@@ -2359,7 +2363,7 @@ function ppom_get_conditional_data_attributes( $meta ) {
 
 		$bound      = isset( $conditions['bound'] ) ? ppom_wpml_translate( $conditions['bound'], 'PPOM' ) : '';
 		$visibility = isset( $conditions['visibility'] ) ? ppom_wpml_translate( $conditions['visibility'], 'PPOM' ) : '';
-		
+
 		$conditions['rules'] = array_filter(
 			$conditions['rules'],
 			function( $rule ) {
@@ -2558,4 +2562,30 @@ function ppom_posted_field_max_min_value_validation( $posted_fields, $field ) {
 	}
 
 	return '';
+}
+
+/**
+ * Get image name from images array.
+ * @param mixed $images
+ * @return string
+ */
+function ppom_get_image_name( $images ) {
+	$updated_value = '';
+
+	if ( is_array( $images ) ) {
+		$total_images = count( $images );
+
+		foreach ( $images as $image_key => $image ) {
+			$image_data = json_decode( stripslashes( $image ), true );
+			if ( isset( $image_data['raw'] ) ) {
+				$updated_value .= $image_data['raw'];
+			}
+
+			if ( $image_key < $total_images - 1 ) {
+				$updated_value .= ', ';
+			}
+		}
+	}
+
+	return $updated_value;
 }

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -676,7 +676,7 @@ function ppom_woocommerce_add_item_meta( $item_meta, $cart_item ) {
 
 			$item_meta[] = array(
 				'name'    => wp_strip_all_tags( $meta_key ),
-				'value'   => $meta_value,
+				'value'   => ppom_get_image_name( $meta_value ),
 				'hidden'  => $hidden,
 				'display' => $display,
 			);

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -302,6 +302,8 @@ function ppom_woocommerce_add_cart_item_data( $cart, $product_id ) {
 	// PPOM also saving cropped images under this filter.
 	$ppom_posted_fields = apply_filters( 'ppom_add_cart_item_data', $_POST['ppom'], $_POST );
 	$cart['ppom']       = $ppom_posted_fields;
+	// var_dump($cart);
+	// exit;
 
 	return $cart;
 }
@@ -665,6 +667,10 @@ function ppom_woocommerce_add_item_meta( $item_meta, $cart_item ) {
 
 		if ( ! empty( $meta_name ) ) {
 
+			if ( ! is_scalar( $meta_value ) ) {
+				$meta_value = wp_json_encode( $meta_value );
+			}
+
 			if ( apply_filters( 'ppom_show_option_price_cart', false ) && isset( $meta['price'] ) ) {
 				$meta_value .= ' (' . wc_price( $meta['price'] ) . ')';
 			}
@@ -676,7 +682,7 @@ function ppom_woocommerce_add_item_meta( $item_meta, $cart_item ) {
 
 			$item_meta[] = array(
 				'name'    => wp_strip_all_tags( $meta_key ),
-				'value'   => ppom_get_image_name( $meta_value ),
+				'value'   => $meta_value,
 				'hidden'  => $hidden,
 				'display' => $display,
 			);
@@ -689,6 +695,7 @@ function ppom_woocommerce_add_item_meta( $item_meta, $cart_item ) {
 			);
 		}
 	}
+	// var_dump($item_meta);
 
 	return $item_meta;
 }

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -302,8 +302,6 @@ function ppom_woocommerce_add_cart_item_data( $cart, $product_id ) {
 	// PPOM also saving cropped images under this filter.
 	$ppom_posted_fields = apply_filters( 'ppom_add_cart_item_data', $_POST['ppom'], $_POST );
 	$cart['ppom']       = $ppom_posted_fields;
-	// var_dump($cart);
-	// exit;
 
 	return $cart;
 }
@@ -695,7 +693,6 @@ function ppom_woocommerce_add_item_meta( $item_meta, $cart_item ) {
 			);
 		}
 	}
-	// var_dump($item_meta);
 
 	return $item_meta;
 }


### PR DESCRIPTION
### Summary
Updated the cart meta item values to titles to render the image-based field on the cart block.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer to review this PR

Closes https://github.com/Codeinwp/ppom-pro/issues/626