### PR TITLE
Show zero values in cart summary

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -901,6 +901,8 @@ function ppom_generate_cart_meta( $ppom_cart_items, $product_id, $ppom_meta_ids 
 		// new filter with cart $value
 		$meta_data_field   = apply_filters( 'ppom_fields_cart_meta', $meta_data_field, $key, $field_meta, $product_id, $ppom_cart_fields );
 		$ppom_meta[ $key ] = $meta_data_field;
+
+		$ppom_meta[ $key ]['type'] = $field_type;
 	}
 
 	return $ppom_meta;

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -648,8 +648,8 @@ function ppom_woocommerce_add_item_meta( $item_meta, $cart_item ) {
 			$hidden = true;
 		}
 
-		$allowed_input_fields = array( 'text_field', 'textarea', 'number' );
-		$is_allowed_field     = in_array( $key, $allowed_input_fields, true );
+		$allowed_input_fields = array( 'text', 'textarea', 'number' );
+		$is_allowed_field     = in_array( $meta['type'], $allowed_input_fields, true );
 
 		if ( $is_allowed_field && '' === $display ) {
 			// Allow 0 and '0', skip only truly empty values

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -648,9 +648,14 @@ function ppom_woocommerce_add_item_meta( $item_meta, $cart_item ) {
 			$hidden = true;
 		}
 
+		$allowed_input_fields = array( 'text_field', 'textarea', 'number' );
+		$is_allowed_field     = in_array( $key, $allowed_input_fields, true );
 
-		// If no value
-		if ( ! $display ) {
+		if ( $is_allowed_field && '' === $display ) {
+			// Allow 0 and '0', skip only truly empty values
+			continue;
+		} elseif ( ! $is_allowed_field && empty( $display ) ) {
+			// For other fields, treat 0 as empty as well
 			continue;
 		}
 


### PR DESCRIPTION
### Summary
Allowed zero value to text, textarea, and number fields to display their value on the cart summary page.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/251