### PR TITLE
Handled quantity field in horizontal layout

### DIFF
--- a/templates/frontend/component/quantities/horizontal-layout.php
+++ b/templates/frontend/component/quantities/horizontal-layout.php
@@ -112,7 +112,7 @@ $options = ppom_convert_options_to_key_val( $fm->options(), $field_meta, $produc
 							data-usebase_price="<?php echo esc_attr( $usebaseprice ); ?>"
 							<?php echo apply_filters( 'ppom_fe_form_element_custom_attr', '', $fm ); ?>
 							value="<?php echo esc_attr( $selected_val ); ?>"
-							style="width:50px;text-align:center"
+							style="width:50px;text-align:center;padding-right:0;"
 							<?php echo esc_attr( $required ); ?>
 					>
 


### PR DESCRIPTION
### Summary
Set the right padding to 0 to adjust the arrows on the input field.

### Test instructions
- Activate Neve theme.
- Go to PPOM and create a new group
- Add the Variation Quantity input
- Add some options with price
- In the settings tab, select the horizontal layout

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer to review this PR

Closes https://github.com/Codeinwp/ppom-pro/issues/461