### PR TITLE
Applied price on initial load in pricing table

### DIFF
--- a/inc/validation.php
+++ b/inc/validation.php
@@ -140,6 +140,7 @@ function ppom_validation_product_limits( $data, $product ) {
 		} else {
 			$data['min_value'] = $limits['min_qty'];
 		}
+		$data['input_value'] = $data['min_value'];
 	}
 
 	// Max qty

--- a/inc/validation.php
+++ b/inc/validation.php
@@ -140,7 +140,6 @@ function ppom_validation_product_limits( $data, $product ) {
 		} else {
 			$data['min_value'] = $limits['min_qty'];
 		}
-		$data['input_value'] = $data['min_value'];
 	}
 
 	// Max qty
@@ -170,6 +169,7 @@ function ppom_validation_product_limits( $data, $product ) {
 		$data['min_value'] = $limits['step'];
 	}
 
+	$data['input_value'] = $data['min_value'];
 
 	return $data;
 }


### PR DESCRIPTION
### Summary
Updated the value when the `min_value` is updated to the quantity input field.

## Steps
1. Go to PPOM and create a new meta-group
2. Add a price matrix
3. Attach to a product and check the product's page
4. On the products'page initial load, the product quantity is shown as 1 instead of the minimum quantity of the price matrix.
5. Once the quantity is updated, the pricing table quantity is also updated as expected.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer to review this PR

Closes https://github.com/Codeinwp/ppom-pro/issues/357