### PR TITLE
Fixed quantity range in pricing matrix

### DIFF
--- a/js/price/ppom-price.js
+++ b/js/price/ppom-price.js
@@ -1022,17 +1022,50 @@ function ppom_update_get_prices() {
 	const apply_as_discount = ppom_pricematrix_discount == 'on' ? true : false;
 
 	if ( ppom_pricematrix !== undefined ) {
-		jQuery.each( JSON.parse( ppom_pricematrix ), function ( range, meta ) {
+		const matrixData = JSON.parse(ppom_pricematrix);
+		const product_qty = parseInt(ppom_get_order_quantity(), 10);
+
+		// Pre-process keys ONCE (fix performance + ordering issue)
+		const parsedKeys = Object.keys(matrixData).map((range) => {
+			if (range.includes('-')) {
+				const [start, end] = range.split('-').map(Number);
+				return { type: 'range', start, end, key: range };
+			} else {
+				return { type: 'single', value: Number(range), key: range };
+			}
+		});
+
+		console.log(parsedKeys);
+		parsedKeys.sort((a, b) => {
+			const aVal = a.type === 'range' ? a.start : a.value;
+			const bVal = b.type === 'range' ? b.start : b.value;
+			return aVal - bVal;
+		});
+
+		const firstKey = parsedKeys[0]?.key;
+		const lastKey = parsedKeys[parsedKeys.length - 1]?.key;
+
+		jQuery.each(matrixData, function (range, meta) {
 			const option_price = {};
+			let isMatch = false;
 
-			const range_break = range.split( '-' );
-			const range_from = parseInt( range_break[ 0 ] );
-			const range_to = parseInt( range_break[ 1 ] );
-			const product_qty = ppom_get_order_quantity();
+			if (range.indexOf('-') !== -1) {
+				const [range_from, range_to] = range.split('-').map(Number);
 
-			// console.log(range, meta);
+				if (product_qty >= range_from && product_qty <= range_to) {
+					isMatch = true;
+				}
+			} else {
+				const value = Number(range);
 
-			if ( product_qty >= range_from && product_qty <= range_to ) {
+				if (range === firstKey && product_qty <= value) {
+					isMatch = true;
+				} else if (range === lastKey && product_qty >= value) {
+					isMatch = true;
+				}
+			}
+
+			if (isMatch) {
 				option_price.label = meta.label;
 				option_price.price = meta.price;
 				option_price.percent = meta.percent;
@@ -1041,11 +1074,13 @@ function ppom_update_get_prices() {
 					? 'matrix_discount'
 					: 'matrix';
 				option_price.data_name = ppom_pricematrix_id;
-				option_price.matrix_fixed =
-					meta.matrix_fixed == 'on' ? true : false;
-				options_price_added.push( option_price );
+				option_price.matrix_fixed = meta.matrix_fixed === 'on';
+
+				options_price_added.push(option_price);
+
+				return false;
 			}
-		} );
+		});
 	}
 
 	// Variation quantities

--- a/js/price/ppom-price.js
+++ b/js/price/ppom-price.js
@@ -1035,7 +1035,6 @@ function ppom_update_get_prices() {
 			}
 		});
 
-		console.log(parsedKeys);
 		parsedKeys.sort((a, b) => {
 			const aVal = a.type === 'range' ? a.start : a.value;
 			const bVal = b.type === 'range' ? b.start : b.value;

--- a/src/Support/Helpers.php
+++ b/src/Support/Helpers.php
@@ -1514,16 +1514,25 @@ final class Helpers {
 			return $matrix;
 		}
 
+		$quantity = intval( $quantity );
 		foreach ( $ranges as $range => $data ) {
 
-			$range_array = explode( '-', $range );
-			$range_start = $range_array[0];
-			$range_end   = $range_array[1];
+			if ( strpos( $range, '-' ) !== false ) {
+				list( $start, $end ) = array_map( 'intval', explode( '-', $range ) );
+				if ( $quantity >= $start && $quantity <= $end ) {
+					$matrix = $data;
+					break;
+				}
+			} else {
+				$value = intval( $range );
 
-			$quantity = intval( $quantity );
-			if ( $quantity >= $range_start && $quantity <= $range_end ) {
-				$matrix = $data;
-				break;
+				if ( $range === array_key_first( $ranges ) && $quantity <= $value ) {
+					$matrix = $data;
+					break;
+				} elseif ( $range === array_key_last( $ranges ) && $quantity >= $value ) {
+					$matrix = $data;
+					break;
+				}
 			}
 		}
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -308,6 +308,11 @@ final class Validator {
 				$first_range  = reset( $ranges );
 				$qty_ranges   = explode( '-', $first_range['raw'] );
 				$min_quantity = $qty_ranges[0];
+
+				// If first options is not in range format, set min quantity to 1.
+				if ( ! isset( $qty_ranges[1] ) ) {
+					$min_quantity = 1;
+				}
 			}
 		}
 
@@ -329,7 +334,7 @@ final class Validator {
 
 				$last_range   = end( $ranges );
 				$qty_ranges   = explode( '-', $last_range['raw'] );
-				$max_quantity = $qty_ranges[1];
+				$max_quantity = isset( $qty_ranges[1] ) ? $qty_ranges[1] : -1;
 			}
 		}
 

--- a/tests/unit/test-checkout-lifecycle.php
+++ b/tests/unit/test-checkout-lifecycle.php
@@ -262,13 +262,19 @@ class Test_Checkout_Lifecycle extends PPOM_Test_Case {
 					'price_matrix',
 					array(
 						array(
-							'option' => '1-2',
+							'option' => '5',
 							'price'  => '12',
 							'label'  => 'Low quantity',
 							'id'     => 'low_qty',
 						),
 						array(
-							'option' => '3-5',
+							'option' => '5-10',
+							'price'  => '10',
+							'label'  => 'Range quantity',
+							'id'     => 'range_qty',
+						),
+						array(
+							'option' => '11',
 							'price'  => '8',
 							'label'  => 'High quantity',
 							'id'     => 'high_qty',
@@ -279,11 +285,13 @@ class Test_Checkout_Lifecycle extends PPOM_Test_Case {
 			$product->get_id()
 		);
 
-		$initial = $this->restore_cart_item_from_session( wc_get_product( $product->get_id() ), array(), 1 );
-		$updated = $this->restore_cart_item_from_session( wc_get_product( $product->get_id() ), array(), 3 );
+		$low_quantity   = $this->restore_cart_item_from_session( wc_get_product( $product->get_id() ), array(), 3 );
+		$range_quantity = $this->restore_cart_item_from_session( wc_get_product( $product->get_id() ), array(), 7 );
+		$high_quantity  = $this->restore_cart_item_from_session( wc_get_product( $product->get_id() ), array(), 15 );
 
-		$this->assertSame( 12.0, (float) $initial['data']->get_price() );
-		$this->assertSame( 8.0, (float) $updated['data']->get_price() );
+		$this->assertSame( 12.0, (float) $low_quantity['data']->get_price() );
+		$this->assertSame( 10.0, (float) $range_quantity['data']->get_price() );
+		$this->assertSame( 8.0, (float) $high_quantity['data']->get_price() );
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Improved the price matrix handling by correctly supporting “less than”, range, and “greater than” conditions.

### Screenshot
<img width="1065" height="675" alt="image" src="https://github.com/user-attachments/assets/f60089ec-df55-423d-88bf-4e7a0f981dee" />

### Test instructions

1. Add a single quantity value to represent the “less than” condition (e.g., 12) and provide an appropriate label (e.g., “Less than 12”).
2. Add range-based quantities for intermediate values using a hyphen (e.g., 12-23, 24-35) and assign suitable labels for each range.
3. Add a final single quantity value to represent the “greater than” condition (e.g., 35) and provide a label such as “More than 35”
  -  Test with different product quantities to ensure:
  -  Quantities below the first value match the “less than” condition.
  -  Quantities within defined ranges match the correct range.
  -  Quantities above the last value match the “more than” condition.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/ppom-pro/issues/338