### PR TITLE
Enhanced confirmation dialog for deleting product groups

### DIFF
--- a/classes/fields.class.php
+++ b/classes/fields.class.php
@@ -210,8 +210,9 @@ class PPOM_Fields_Meta {
 				'freemiumCFRContent'     => \PPOM_Freemium::get_instance()->get_freemium_cfr_content(),
 				'freemiumCFRTab'         => \PPOM_Freemium::TAB_KEY_FREEMIUM_CFR,
 				'popup'                  => array(
+					'confirmTitle'    => __( 'Are you sure?', 'woocommerce-product-addon' ),
 					// translators: %s is the name of the field group being deleted.
-					'confirmTitle'    => __( 'Are you sure you want to delete the \'%s\' group? This action cannot be undone.', 'woocommerce-product-addon' ),
+					'deleteGroup'     => __( 'Are you sure you want to delete the \'%s\' group? This action cannot be undone.', 'woocommerce-product-addon' ),
 					'confirmationBtn' => __( 'Confirm', 'woocommerce-product-addon' ),
 					'cancelBtn'       => __( 'Cancel', 'woocommerce-product-addon' ),
 					'finishTitle'     => __( 'Done', 'woocommerce-product-addon' ),

--- a/classes/fields.class.php
+++ b/classes/fields.class.php
@@ -210,7 +210,8 @@ class PPOM_Fields_Meta {
 				'freemiumCFRContent'     => \PPOM_Freemium::get_instance()->get_freemium_cfr_content(),
 				'freemiumCFRTab'         => \PPOM_Freemium::TAB_KEY_FREEMIUM_CFR,
 				'popup'                  => array(
-					'confirmTitle'    => __( 'Are you sure?', 'woocommerce-product-addon' ),
+					// translators: %s is the name of the field group being deleted.
+					'confirmTitle'    => __( 'Are you sure you want to delete the \'%s\' group? This action cannot be undone.', 'woocommerce-product-addon' ),
 					'confirmationBtn' => __( 'Confirm', 'woocommerce-product-addon' ),
 					'cancelBtn'       => __( 'Cancel', 'woocommerce-product-addon' ),
 					'finishTitle'     => __( 'Done', 'woocommerce-product-addon' ),

--- a/css/ppom-admin.css
+++ b/css/ppom-admin.css
@@ -1360,7 +1360,7 @@ a.ppom-attach-upsell-upgrade {
 }
 
 .ppom-popup-title {
-    font-size: 2.5em;
+    font-size: 1.5em;
     margin: 0;
     line-height: 1.3;
 
@@ -1398,6 +1398,14 @@ a.ppom-attach-upsell-upgrade {
 
 .ppom-popup-actions .ppom-btn-cancel {
     background-color: #6c757d;
+}
+
+.ppom-popup-actions .ppom-btn-confirm {
+    background-color: #ff0f0f;
+}
+
+.ppom-popup-actions .ppom-btn-confirm:hover {
+    background-color: #ef6060;
 }
 
 .ppom-popup.ppom-error .ppom-popup-title {

--- a/js/admin/ppom-meta-table.js
+++ b/js/admin/ppom-meta-table.js
@@ -37,12 +37,12 @@ jQuery( function ( $ ) {
 	 * Delete multiple saved PPOM groups after an explicit confirmation step.
 	 *
 	 * @param {number[]} checkedProducts_ids
-	 * @param {string} checkedProductsNames
+	 * @param {string} checkedProducts_names
 	 * @return {void}
 	 */
-	function deleteSelectedProducts( checkedProducts_ids, checkedProductsNames = '' ) {
-		let title = window?.ppom_vars?.i18n.popup.confirmTitle;
-		title = checkedProductsNames ? title.replace( '%s', checkedProductsNames ) : title;
+	function deleteSelectedProducts( checkedProducts_ids, checkedProducts_names = '' ) {
+		let title = window?.ppom_vars?.i18n.popup.deleteGroup;
+		title = checkedProducts_names ? title.replace( '%s', checkedProducts_names ) : window?.ppom_vars?.i18n.popup.confirmTitle;
 		window?.ppomPopup?.open( {
 			title: title,
 			onConfirmation: () => {
@@ -144,9 +144,12 @@ jQuery( function ( $ ) {
 	$( 'body' ).on( 'click', 'a.ppom-delete-single-product', function ( e ) {
 		e.preventDefault();
 		const productmeta_id = $( this ).attr( 'data-product-id' );
+		let title = window?.ppom_vars?.i18n.popup.deleteGroup;
+		const productName = $( this ).data( 'name' );
+		title = productName ? title.replace( '%s', productName ) : window?.ppom_vars?.i18n.popup.confirmTitle;
 
 		window?.ppomPopup?.open( {
-			title: window?.ppom_vars?.i18n.popup.confirmTitle,
+			title: title,
 			onConfirmation: () => {
 				$( '#del-file-' + productmeta_id ).html(
 					'<img src="' + ppom_vars.loader + '">'
@@ -199,14 +202,14 @@ jQuery( function ( $ ) {
 			return;
 		}
 
-		const checkedProductsNames = $('.ppom_product_checkbox:checked')
-			.map(function () {
+		const checkedProductsNames = $( '.ppom_product_checkbox:checked' )
+ 			.map( function () {
 				return this.dataset.name && this.dataset.name.trim() !== ''
 					? this.dataset.name
 					: this.value;
-			})
+			} )
 			.get()
-			.join(', ');
+			.join( ', ' );
 		// Only one action runs per selection. Resetting the select afterwards
 		// prevents DataTables redraws from accidentally replaying the last action.
 		if ( 'delete' === type ) {

--- a/js/admin/ppom-meta-table.js
+++ b/js/admin/ppom-meta-table.js
@@ -37,11 +37,14 @@ jQuery( function ( $ ) {
 	 * Delete multiple saved PPOM groups after an explicit confirmation step.
 	 *
 	 * @param {number[]} checkedProducts_ids
+	 * @param {string} checkedProductsNames
 	 * @return {void}
 	 */
-	function deleteSelectedProducts( checkedProducts_ids ) {
+	function deleteSelectedProducts( checkedProducts_ids, checkedProductsNames = '' ) {
+		let title = window?.ppom_vars?.i18n.popup.confirmTitle;
+		title = checkedProductsNames ? title.replace( '%s', checkedProductsNames ) : title;
 		window?.ppomPopup?.open( {
-			title: window?.ppom_vars?.i18n.popup.confirmTitle,
+			title: title,
 			onConfirmation: () => {
 				$( '#ppom_delete_selected_products_btn' ).html( 'Deleting...' );
 
@@ -196,10 +199,18 @@ jQuery( function ( $ ) {
 			return;
 		}
 
+		const checkedProductsNames = $('.ppom_product_checkbox:checked')
+			.map(function () {
+				return this.dataset.name && this.dataset.name.trim() !== ''
+					? this.dataset.name
+					: this.value;
+			})
+			.get()
+			.join(', ');
 		// Only one action runs per selection. Resetting the select afterwards
 		// prevents DataTables redraws from accidentally replaying the last action.
 		if ( 'delete' === type ) {
-			deleteSelectedProducts( checkedProducts_ids );
+			deleteSelectedProducts( checkedProducts_ids, checkedProductsNames );
 		} else if ( 'export' === type ) {
 			$( '#ppom-groups-export-form' ).submit();
 		}

--- a/templates/admin/existing-meta.php
+++ b/templates/admin/existing-meta.php
@@ -75,7 +75,8 @@ wp_nonce_field( 'ppom_meta_nonce_action', 'ppom_meta_nonce' );
 						<td class="ppom-meta-table-checkbox-mr ppom-checkboxe-style">
 							<label>
 								<input class="ppom_product_checkbox" type="checkbox" name="ppom_meta[]"
-										value="<?php echo esc_attr( $productmeta->productmeta_id ); ?>" data-name="<?php echo esc_attr( $productmeta->productmeta_name ); ?>">
+									value="<?php echo esc_attr( $productmeta->productmeta_id ); ?>"
+									data-name="<?php echo esc_attr( stripcslashes( $productmeta->productmeta_name ) ); ?>">
 								<span></span>
 							</label>
 						</td>
@@ -99,7 +100,8 @@ wp_nonce_field( 'ppom_meta_nonce_action', 'ppom_meta_nonce' );
 						<td class="ppom-admin-meta-actions-colunm">
 							<a id="del-file-<?php echo esc_attr( $productmeta->productmeta_id ); ?>" href="#"
 								class="button button-sm ppom-delete-single-product"
-								data-product-id="<?php echo esc_attr( $productmeta->productmeta_id ); ?>"><span
+								data-product-id="<?php echo esc_attr( $productmeta->productmeta_id ); ?>"
+								data-name="<?php echo esc_attr( stripcslashes( $productmeta->productmeta_name ) ); ?>"><span
 										class="dashicons dashicons-no"></span></a>
 							<a href="<?php echo esc_url( $url_edit ); ?>" title="<?php _e( 'Edit', 'woocommerce-product-addon' ); ?>"
 								class="button"><span class="dashicons dashicons-edit"></span></a>

--- a/templates/admin/existing-meta.php
+++ b/templates/admin/existing-meta.php
@@ -75,7 +75,7 @@ wp_nonce_field( 'ppom_meta_nonce_action', 'ppom_meta_nonce' );
 						<td class="ppom-meta-table-checkbox-mr ppom-checkboxe-style">
 							<label>
 								<input class="ppom_product_checkbox" type="checkbox" name="ppom_meta[]"
-										value="<?php echo esc_attr( $productmeta->productmeta_id ); ?>">
+										value="<?php echo esc_attr( $productmeta->productmeta_id ); ?>" data-name="<?php echo esc_attr( $productmeta->productmeta_name ); ?>">
 								<span></span>
 							</label>
 						</td>

--- a/tests/e2e/specs/group-delete-confirmation.spec.js
+++ b/tests/e2e/specs/group-delete-confirmation.spec.js
@@ -1,0 +1,197 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from "@wordpress/e2e-test-utils-playwright";
+import { createSimpleGroupField } from "../utils";
+
+test.describe("Group Delete Confirmation Dialog", () => {
+	/**
+	 * Helper to get checkbox for a specific group
+	 */
+	function getGroupCheckbox(page, ppomId) {
+		return page.locator(`input.ppom_product_checkbox[value="${ppomId}"]`).locator('xpath=ancestor::label');
+	}
+
+	/**
+	 * Helper to trigger bulk delete action
+	 */
+	async function triggerBulkDelete(page) {
+		await page.locator("#ppom-bulk-actions").selectOption("delete");
+	}
+
+	/**
+	 * Helper to wait for and get the popup dialog
+	 */
+	async function waitForPopup(page) {
+		await page.waitForSelector(".ppom-popup-overlay", { state: "visible" });
+		return page.locator(".ppom-popup-overlay");
+	}
+
+	/**
+	 * Helper to confirm deletion in popup
+	 */
+	async function confirmDeletion(page) {
+		await page.locator(".ppom-popup-overlay .ppom-btn-confirm").click();
+	}
+
+	async function cancelDeletion(page) {
+		await page.locator(".ppom-popup-overlay .ppom-btn-cancel").click();
+	}
+
+	/**
+	 * Delete single group and verify group name in confirmation dialog
+	 */
+	test("displays single group name in delete confirmation dialog", async ({
+		page,
+		admin,
+	}) => {
+		const { baseName, ppomId } = await createSimpleGroupField(admin, page);
+
+		// Navigate to the groups list
+		await admin.visitAdminPage("admin.php?page=ppom");
+
+		// Select the checkbox for our group
+		const checkbox = getGroupCheckbox(page, ppomId);
+		await checkbox.click();
+
+		// Trigger bulk delete
+		await triggerBulkDelete(page);
+
+		// Wait for confirmation popup
+		const popup = await waitForPopup(page);
+
+		// Verify the popup title contains the group name
+		const popupTitle = popup.locator(".ppom-popup-title");
+		await expect(popupTitle).toBeVisible();
+
+		const titleText = await popupTitle.textContent();
+
+		expect(titleText).toContain("Test Group Field");
+
+		// Verify it's formatted correctly (should replace %s with the group name)
+		expect(titleText).not.toContain("%s");
+
+		await cancelDeletion(page);
+	});
+
+	/**
+	 * Delete multiple groups and verify all group names in confirmation dialog
+	 */
+	test("displays multiple group names in delete confirmation dialog", async ({
+		page,
+		admin,
+	}) => {
+		// Create three groups
+		const group1 = await createSimpleGroupField(admin, page);
+		const group2 = await createSimpleGroupField(admin, page);
+		const group3 = await createSimpleGroupField(admin, page);
+
+		// Navigate to the groups list
+		await admin.visitAdminPage("admin.php?page=ppom");
+
+		// Select checkboxes for all three groups
+		await getGroupCheckbox(page, group1.ppomId).check();
+		await getGroupCheckbox(page, group2.ppomId).check();
+		await getGroupCheckbox(page, group3.ppomId).check();
+
+		// Trigger bulk delete
+		await triggerBulkDelete(page);
+
+		// Wait for confirmation popup
+		const popup = await waitForPopup(page);
+
+		// Verify the popup title contains all group names
+		const popupTitle = popup.locator(".ppom-popup-title");
+		await expect(popupTitle).toBeVisible();
+
+		const titleText = await popupTitle.textContent();
+
+		// All three group names should be in the confirmation (all are "Test Group Field")
+		expect(titleText).toContain("Test Group Field");
+
+		// Should be comma-separated.
+		expect(titleText).toMatch(/,/);
+
+		await cancelDeletion(page);
+	});
+
+	/**
+	 * Confirm deletion and verify groups are removed
+	 */
+	test("successfully deletes selected groups after confirmation", async ({
+		page,
+		admin,
+	}) => {
+		const { baseName, ppomId } = await createSimpleGroupField(admin, page);
+
+		// Navigate to the groups list
+		await admin.visitAdminPage("admin.php?page=ppom");
+
+		// Verify the group exists in the table
+		const groupRow = page.locator(`tr td:has-text("${ppomId}")`);
+		await expect(groupRow).toBeVisible();
+
+		// Select the checkbox for our group
+		await getGroupCheckbox(page, ppomId).check();
+
+		// Trigger bulk delete
+		await triggerBulkDelete(page);
+
+		// Wait for confirmation popup and verify it shows the group name
+		const popup = await waitForPopup(page);
+		const popupTitle = popup.locator(".ppom-popup-title");
+		await expect(popupTitle).toContainText("Test Group Field");
+
+		// Confirm the deletion
+		await confirmDeletion(page);
+
+		// Wait for success confirmation popup
+		await page.waitForSelector(".ppom-popup-overlay", { state: "visible" });
+		const successPopup = page.locator(".ppom-popup-overlay");
+		const successTitle = successPopup.locator(".ppom-popup-title");
+
+		// Verify success message appears
+		await expect(successTitle).toBeVisible();
+		const successText = await successTitle.textContent();
+
+		expect(successText).toEqual("Done");
+		await confirmDeletion(page);
+
+		// Verify the group is no longer in the table
+		await expect(groupRow).not.toBeVisible();
+	});
+
+	/**
+	 * Delete single group using delete link (not bulk action)
+	 */
+	test("displays group name when deleting via single delete link", async ({
+		page,
+		admin,
+	}) => {
+		const { baseName, ppomId } = await createSimpleGroupField(admin, page);
+
+		// Navigate to the groups list
+		await admin.visitAdminPage("admin.php?page=ppom");
+
+		// Find and click the delete link for this specific group
+		const deleteLink = page.locator(
+			`a.ppom-delete-single-product[data-product-id="${ppomId}"]`
+		);
+		await deleteLink.waitFor({ state: "visible" });
+		await deleteLink.click();
+
+		// Wait for confirmation popup
+		const popup = await waitForPopup(page);
+
+		// Verify the popup title contains the group name
+		const popupTitle = popup.locator(".ppom-popup-title");
+		await expect(popupTitle).toBeVisible();
+
+		const titleText = await popupTitle.textContent();
+
+		// The confirmation should contain the group name
+		expect(titleText).toContain("Test Group Field");
+
+		await cancelDeletion(page);
+	});
+});


### PR DESCRIPTION
### Summary
Enhanced confirmation dialog for deleting product groups.

### Will affect visual aspect of the product
YES

### Screenshots
<img width="958" height="365" alt="image" src="https://github.com/user-attachments/assets/af794c59-e485-4a9e-b6ee-27d11ff5ce35" />
<img width="958" height="365" alt="image" src="https://github.com/user-attachments/assets/07ef3d83-32a5-4df7-bc20-1435a3e3adf9" />

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/ppom-pro/issues/666