### PR TITLE
Applied tax to addon prices when woocommerce tax is enabled

### DIFF
--- a/backend/settings-panel.class.php
+++ b/backend/settings-panel.class.php
@@ -9,6 +9,8 @@
  * @see ppom_load_pro_options()
  */
 
+use PPOM\Support\Helpers;
+
 /* 
 **========== Block direct access =========== 
 */
@@ -395,7 +397,15 @@ class PPOM_SettingsFramework {
 				},
 				ARRAY_FILTER_USE_KEY 
 			);
-			// $settings_meta = $_REQUEST[self::$save_key];
+
+			// If taxable option is explicitly disabled, store it with "no" value.
+			if ( ! isset( $_REQUEST[ self::$save_key ]['ppom_taxable_option_price'] ) || 'yes' !== $_REQUEST[ self::$save_key ]['ppom_taxable_option_price'] ) {
+				$taxable_option_price = Helpers::get_option( 'ppom_taxable_option_price' );
+				if ( 'yes' === $taxable_option_price ) {
+					$_REQUEST[ self::$save_key ]['ppom_taxable_option_price'] = 'no';
+				}
+			}
+
 			$settings_meta = array_map(
 				function ( $setting ) {
 

--- a/src/Pricing/Engine.php
+++ b/src/Pricing/Engine.php
@@ -1595,9 +1595,17 @@ final class Engine {
 		if ( ! function_exists( 'wc_get_price_excluding_tax' ) || $option_price == '' ) {
 			return $option_price;
 		}
+		
+		$taxable_option_price = Helpers::get_option( 'ppom_taxable_option_price' );
 
-		if ( 'yes' != Helpers::get_option( 'ppom_taxable_option_price' ) && ! wc_tax_enabled() ) {
-			return $option_price;
+		if ( 'yes' !== $taxable_option_price ) {
+			if ( false === $taxable_option_price || null === $taxable_option_price ) {
+				if ( ! wc_tax_enabled() ) {
+					return $option_price;
+				}
+			} else {
+				return $option_price;
+			}
 		}
 
 		if ( $option_price >= 0 && ( ! is_product() && apply_filters( 'ppom_handle_option_price_vat_in_cart', true ) === true ) ) {

--- a/src/Pricing/Engine.php
+++ b/src/Pricing/Engine.php
@@ -1596,7 +1596,7 @@ final class Engine {
 			return $option_price;
 		}
 
-		if ( 'yes' != Helpers::get_option( 'ppom_taxable_option_price' ) ) {
+		if ( 'yes' != Helpers::get_option( 'ppom_taxable_option_price' ) && ! wc_tax_enabled() ) {
 			return $option_price;
 		}
 

--- a/tests/unit/src/Pricing/test-pricing-engine.php
+++ b/tests/unit/src/Pricing/test-pricing-engine.php
@@ -13,6 +13,66 @@ use PPOM\Pricing\Engine;
 class Test_Pricing_Engine extends WP_UnitTestCase {
 
 	/**
+	 * Test product instance.
+	 *
+	 * @var WC_Product_Simple
+	 */
+	private $product;
+
+	/**
+	 * Original WooCommerce tax settings.
+	 *
+	 * @var array
+	 */
+	private $original_tax_settings = array();
+
+	/**
+	 * Set up test fixtures before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_tax_settings = array(
+			'woocommerce_calc_taxes'          => get_option( 'woocommerce_calc_taxes' ),
+			'woocommerce_tax_display_shop'    => get_option( 'woocommerce_tax_display_shop' ),
+			'woocommerce_tax_display_cart'    => get_option( 'woocommerce_tax_display_cart' ),
+			'woocommerce_prices_include_tax'  => get_option( 'woocommerce_prices_include_tax' ),
+		);
+
+		if ( class_exists( 'WC_Product_Simple' ) ) {
+			$this->product = new WC_Product_Simple();
+			$this->product->set_regular_price( 100 );
+			$this->product->set_tax_class( 'standard' );
+			$this->product->set_tax_status( 'taxable' );
+			$this->product->save();
+		}
+	}
+
+	/**
+	 * Set up a tax rate for testing.
+	 *
+	 * @param float $rate Tax rate percentage.
+	 */
+	private function setup_tax_rate( $rate ) {
+		global $wpdb;
+
+		$wpdb->insert(
+			$wpdb->prefix . 'woocommerce_tax_rates',
+			array(
+				'tax_rate_country'  => '',
+				'tax_rate_state'    => '',
+				'tax_rate'          => $rate,
+				'tax_rate_name'     => 'VAT',
+				'tax_rate_priority' => 1,
+				'tax_rate_compound' => 0,
+				'tax_rate_shipping' => 1,
+				'tax_rate_order'    => 1,
+				'tax_rate_class'    => '',
+			)
+		);
+	}
+
+	/**
 	 * @return void
 	 */
 	public function test_price_get_addon_total_sums_addon_rows_with_quantity() {
@@ -220,5 +280,116 @@ class Test_Pricing_Engine extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( 2.0, $total );
+	}
+
+	/**
+	 * Test that addon price does not include tax when ppom_taxable_option_price
+	 * setting has never been saved and WC tax is disabled.
+	 *
+	 * @return void
+	 */
+	public function test_option_price_handle_vat_no_tax_when_setting_unset_and_wc_tax_disabled() {
+		if ( ! $this->product ) {
+			$this->markTestSkipped( 'WooCommerce not available.' );
+		}
+
+		delete_option( 'ppom_taxable_option_price' );
+		update_option( 'woocommerce_calc_taxes', 'no' );
+
+		$base_addon_price = 10.00;
+
+		$result_price = Engine::option_price_handle_vat( $base_addon_price, $this->product );
+
+		$this->assertEquals(
+			$base_addon_price,
+			$result_price
+		);
+	}
+
+	/**
+	 * Test that addon price includes tax when WC tax is enabled.
+	 *
+	 * @return void
+	 */
+	public function test_option_price_handle_vat_includes_tax_when_wc_tax_enabled() {
+		if ( ! $this->product ) {
+			$this->markTestSkipped( 'WooCommerce not available.' );
+		}
+
+		// Enable WooCommerce tax calculation
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_display_shop', 'incl' );
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+
+		$this->setup_tax_rate( 20 );
+
+		$base_addon_price = 10.00;
+		$expected_tax_rate = 0.20;
+		$expected_price_with_tax = $base_addon_price * ( 1 + $expected_tax_rate );
+
+		$this->go_to( get_permalink( $this->product->get_id() ) );
+
+		$result_price = Engine::option_price_handle_vat( $base_addon_price, $this->product );
+
+		$this->assertGreaterThan(
+			$base_addon_price,
+			$result_price
+		);
+
+		$delta = 0.01;
+		$this->assertEqualsWithDelta(
+			$expected_price_with_tax,
+			$result_price,
+			$delta
+		);
+	}
+
+	/**
+	 * Test that tax display is context-aware (product page vs cart).
+	 *
+	 * Verifies that tax handling respects woocommerce_tax_display_cart setting in cart,
+	 * and woocommerce_tax_display_shop on product pages.
+	 *
+	 * @return void
+	 */
+	public function test_option_price_handle_vat_context_aware_display() {
+		if ( ! $this->product ) {
+			$this->markTestSkipped( 'WooCommerce not available.' );
+		}
+
+		// Enable WooCommerce tax calculation
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+		update_option( 'ppom_taxable_option_price', 'yes' );
+
+		$this->setup_tax_rate( 20 );
+
+		$base_addon_price = 10.00;
+
+		update_option( 'woocommerce_tax_display_shop', 'incl' );
+		$this->go_to( get_permalink( $this->product->get_id() ) );
+		$product_page_price = Engine::option_price_handle_vat( $base_addon_price, $this->product );
+
+		$this->assertGreaterThan(
+			$base_addon_price,
+			$product_page_price
+		);
+
+		update_option( 'woocommerce_tax_display_cart', 'excl' );
+		$this->go_to( wc_get_cart_url() );
+		$cart_price = Engine::option_price_handle_vat( $base_addon_price, $this->product );
+
+		$this->assertEquals(
+			$base_addon_price,
+			$cart_price
+		);
+
+		update_option( 'woocommerce_tax_display_cart', 'incl' );
+		$cart_price_incl = Engine::option_price_handle_vat( $base_addon_price, $this->product );
+
+		$this->assertGreaterThan(
+			$base_addon_price,
+			$cart_price_incl
+		);
 	}
 }

--- a/tests/unit/src/Pricing/test-pricing-engine.php
+++ b/tests/unit/src/Pricing/test-pricing-engine.php
@@ -293,6 +293,7 @@ class Test_Pricing_Engine extends WP_UnitTestCase {
 			$this->markTestSkipped( 'WooCommerce not available.' );
 		}
 
+		// Ensure ppom_taxable_option_price is not set and WC tax is disabled.
 		delete_option( 'ppom_taxable_option_price' );
 		update_option( 'woocommerce_calc_taxes', 'no' );
 
@@ -315,6 +316,9 @@ class Test_Pricing_Engine extends WP_UnitTestCase {
 		if ( ! $this->product ) {
 			$this->markTestSkipped( 'WooCommerce not available.' );
 		}
+
+		// Ensure ppom_taxable_option_price is not set.
+		delete_option( 'ppom_taxable_option_price' );
 
 		// Enable WooCommerce tax calculation
 		update_option( 'woocommerce_calc_taxes', 'yes' );
@@ -341,6 +345,37 @@ class Test_Pricing_Engine extends WP_UnitTestCase {
 			$expected_price_with_tax,
 			$result_price,
 			$delta
+		);
+
+		// Enabled PPOM taxable option price setting and WC tax, price should still include tax.
+		update_option( 'ppom_taxable_option_price', 'yes' );
+
+		$this->go_to( get_permalink( $this->product->get_id() ) );
+
+		$result_price = Engine::option_price_handle_vat( $base_addon_price, $this->product );
+
+		$this->assertGreaterThan(
+			$base_addon_price,
+			$result_price
+		);
+
+		$delta = 0.01;
+		$this->assertEqualsWithDelta(
+			$expected_price_with_tax,
+			$result_price,
+			$delta
+		);
+
+		// Disabled PPOM taxable option price setting, price should still not include tax.
+		update_option( 'ppom_taxable_option_price', 'no' );
+
+		$this->go_to( get_permalink( $this->product->get_id() ) );
+
+		$result_price = Engine::option_price_handle_vat( $base_addon_price, $this->product );
+
+		$this->assertEquals(
+			$base_addon_price,
+			$result_price
 		);
 	}
 


### PR DESCRIPTION
### Summary
Applied the tax to the option prices when WooCommerce tax is enabled.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/544