### PR TITLE
Added event listener to reinitialize fields

### DIFF
--- a/classes/frontend-scripts.class.php
+++ b/classes/frontend-scripts.class.php
@@ -569,6 +569,9 @@ class PPOM_FRONTEND_SCRIPTS {
 	/**
 	 * Localizes runtime data onto an enqueued PPOM frontend script handle.
 	 *
+	 * Data is structured by product ID to support multiple products on the same page.
+	 * Each product's data is stored under its product ID key in the global object.
+	 *
 	 * @param string     $handle         Registered script handle.
 	 * @param string     $var_name       JS variable name.
 	 * @param WC_Product $product        Product in the current render context.
@@ -582,6 +585,9 @@ class PPOM_FRONTEND_SCRIPTS {
 		if ( ! wp_script_is( $handle ) ) {
 			return;
 		}
+
+		$product_id    = $product->get_id();
+		$localize_data = array();
 
 		switch ( $handle ) {
 
@@ -654,6 +660,22 @@ class PPOM_FRONTEND_SCRIPTS {
 		$localize_data = array_merge( $js_vars, $localize_data, $global_js_vars );
 
 		$localize_data = apply_filters( $var_name, $localize_data, $product );
+
+		if ( 'ppom_input_vars' === $var_name ) {
+			// Store data in a product-keyed structure for multi-product support.
+			$multi_product_var = 'ppom_input_vars_by_product';
+
+			$existing_data = array();
+			if ( isset( $GLOBALS[ $multi_product_var ] ) && is_array( $GLOBALS[ $multi_product_var ] ) ) {
+				$existing_data = $GLOBALS[ $multi_product_var ];
+			}
+
+			$existing_data[ $product_id ]  = $localize_data;
+			$GLOBALS[ $multi_product_var ] = $existing_data;
+
+			// Localize the multi-product data structure.
+			PPOM_SCRIPTS::localize_script( $handle, $multi_product_var, $existing_data );
+		}
 
 		PPOM_SCRIPTS::localize_script( $handle, $var_name, $localize_data );
 	}

--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -63,7 +63,7 @@ jQuery( function ( $ ) {
 	const wc_cart_form = jQuery( 'form.cart' );
 
 	// Measure
-	$( '.ppom-measure' ).on( 'change', '.ppom-measure-unit', function ( e ) {
+	$( '.ppom-measure' ).off( 'change.ppom' ).on( 'change.ppom', '.ppom-measure-unit', function ( e ) {
 		e.preventDefault();
 		// console.log($(this).text());
 
@@ -77,7 +77,7 @@ jQuery( function ( $ ) {
 	wc_cart_button.removeClass( 'ajax_add_to_cart' );
 
 	// Range slider updated
-	$( document ).on( 'ppom_range_slider_updated', function ( e ) {
+	$( document ).off( 'ppom_range_slider_updated.ppom' ).on( 'ppom_range_slider_updated.ppom', function ( e ) {
 		// console.log(wc_product_qty);
 		$( 'form.cart' ).find( 'input[name="quantity"]' ).val( e.qty );
 		// wc_product_qty.val(e.qty);
@@ -92,11 +92,11 @@ jQuery( function ( $ ) {
 	ppom_init_js_for_ppom_fields( ppom_input_vars.ppom_inputs );
 
 	// Re-init ppom fields.
-	jQuery(document).on('ppom_reinit', function() {
-		if (typeof ppom_input_vars !== 'undefined' && ppom_input_vars.ppom_inputs) {
-			ppom_init_js_for_ppom_fields(ppom_input_vars.ppom_inputs);
+	$( document ).on( 'ppom_reinit', function ( e ) {
+		if ( typeof ppom_input_vars !== 'undefined' && ppom_input_vars.ppom_inputs ) {
+			ppom_init_js_for_ppom_fields( ppom_input_vars.ppom_inputs );
 		}
-	});
+	} );
 } );
 
 /**
@@ -118,6 +118,9 @@ function ppom_init_js_for_ppom_fields( ppom_fields ) {
 
 	jQuery.each( ppom_fields, function ( index, input ) {
 		const InputSelector = jQuery( '#' + input.data_name );
+		if ( InputSelector.data( 'ppom-initialized' ) === true ) {
+			return;
+		}
 
 		// Applying JS on inputs
 		switch ( input.type ) {
@@ -156,7 +159,7 @@ function ppom_init_js_for_ppom_fields( ppom_fields ) {
 					} else {
 						event.preventDefault();
 					}
-				} ).on( 'focus blur', function () {
+				} ).off( 'focus.ppom blur.ppom' ).on( 'focus.ppom blur.ppom', function () {
 					if ( typeof InputSelector.attr( 'max' ) !== 'undefined' ) {
 						if (
 							parseFloat( InputSelector.val() ) >
@@ -368,7 +371,7 @@ function ppom_init_js_for_ppom_fields( ppom_fields ) {
 
 				// Following script is added to close picker
 				// when color is picked
-				jQuery( document ).click( function ( e ) {
+				jQuery( document ).off( 'click.ppomColor' ).on( 'click.ppomColor', function ( e ) {
 					if (
 						! jQuery( e.target ).is(
 							'.ppom-input.color, .iris-picker, .iris-picker-inner'
@@ -379,7 +382,7 @@ function ppom_init_js_for_ppom_fields( ppom_fields ) {
 					}
 				} );
 
-				jQuery( '.ppom-input.color' ).click( function ( event ) {
+				jQuery( '.ppom-input.color' ).off( 'click.ppomColor' ).on( 'click.ppomColor', function ( event ) {
 					jQuery( '.ppom-input.color' ).iris( 'hide' );
 					jQuery( this ).iris( 'show' );
 					return event;
@@ -394,8 +397,11 @@ function ppom_init_js_for_ppom_fields( ppom_fields ) {
 					break;
 				}
 
-				jQuery( document ).on(
-					'click',
+				jQuery( document ).off(
+					'click.ppomPalettes' + input.data_name,
+					`.ppom-palettes-${ input.data_name } input.ppom-input`
+				).on(
+					'click.ppomPalettes' + input.data_name,
 					`.ppom-palettes-${ input.data_name } input.ppom-input`,
 					function ( e ) {
 						if (
@@ -456,7 +462,7 @@ function ppom_init_js_for_ppom_fields( ppom_fields ) {
 					} );
 				}
 
-				jQuery( '.ppom-range-bs-slider' ).on( 'change', function ( e ) {
+				jQuery( '.ppom-range-bs-slider' ).off( 'change.ppom' ).on( 'change.ppom', function ( e ) {
 					jQuery.event.trigger( {
 						type: 'ppom_range_slider_updated',
 						qty: jQuery( this ).val(),
@@ -472,6 +478,9 @@ function ppom_init_js_for_ppom_fields( ppom_fields ) {
 				}
 				break;
 		}
+
+		// Mark this field as initialized to prevent duplicate bindings
+		InputSelector.data( 'ppom-initialized', true );
 	} );
 }
 

--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -92,8 +92,12 @@ jQuery( function ( $ ) {
 	ppom_init_js_for_ppom_fields( ppom_input_vars.ppom_inputs );
 
 	// Re-init ppom fields.
-	$( document ).on( 'ppom_reinit', function ( e ) {
-		if ( typeof ppom_input_vars !== 'undefined' && ppom_input_vars.ppom_inputs ) {
+	$( document ).on( 'ppom_reinit', function ( e, product_id ) {
+		if ( typeof product_id !== 'undefined' ) {
+			ppom_input_vars = ppom_get_product_data( product_id );
+		}
+
+		if ( null !== ppom_input_vars && typeof 'undefined' !== ppom_input_vars && ppom_input_vars.ppom_inputs ) {
 			ppom_init_js_for_ppom_fields( ppom_input_vars.ppom_inputs );
 		}
 	} );
@@ -603,4 +607,26 @@ function ppom_bulkquantity_price_manager( quantity, data_name ) {
 
 String.prototype.ppom_js_stripSlashes = function () {
 	return this.replace( /\\(.)/gm, '$1' );
+};
+
+/**
+ * Get the localized data for a specific product.
+ * falling back to the single-product structure if needed.
+ *
+ * @param {number} productId
+ * @returns {object|null}
+ */
+function ppom_get_product_data(productId) {
+	if (typeof window['ppom_input_vars_by_product'] !== 'undefined' && 
+		window['ppom_input_vars_by_product'][productId]) {
+		return window['ppom_input_vars_by_product'][productId];
+	}
+
+	// Fallback to single-product data for backward compatibility
+	if (typeof window['ppom_input_vars'] !== 'undefined' && 
+		window['ppom_input_vars'].product_id == productId) {
+		return window['ppom_input_vars'];
+	}
+
+	return null;
 };

--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -90,6 +90,13 @@ jQuery( function ( $ ) {
 	}
 
 	ppom_init_js_for_ppom_fields( ppom_input_vars.ppom_inputs );
+
+	// Re-init ppom fields.
+	jQuery(document).on('ppom_reinit', function() {
+		if (typeof ppom_input_vars !== 'undefined' && ppom_input_vars.ppom_inputs) {
+			ppom_init_js_for_ppom_fields(ppom_input_vars.ppom_inputs);
+		}
+	});
 } );
 
 /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -703,12 +703,6 @@ parameters:
 			path: classes/frontend-scripts.class.php
 
 		-
-			message: '#^Variable \$localize_data might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: classes/frontend-scripts.class.php
-
-		-
 			message: '#^Method PPOM_InputManager\:\:input_classes_array\(\) should return list\<string\> but returns \(array\|null\)\.$#'
 			identifier: return.type
 			count: 1


### PR DESCRIPTION
### Summary
Added a custom event listener to re-initialize PPOM fields.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/546