### PR TITLE
Updated data name validation

### DIFF
--- a/classes/ppom.class.php
+++ b/classes/ppom.class.php
@@ -577,27 +577,24 @@ class PPOM_Meta {
 
 			$type = isset( $field['type'] ) ? $field['type'] : '';
 
-			// pricematrix does not have dataname
-			if ( $type == 'pricematrix' ) {
-				continue;
-			}
-			// ignore collapased fields
-			if ( $type == 'collapse' ) {
+			$allowed_types = array( 'pricematrix', 'collapse', 'section', 'divider' );
+
+			if ( in_array( $type, $allowed_types, true ) ) {
 				continue;
 			}
 
-			if ( ! isset( $field['data_name'] ) ) {
+			if ( ! isset( $field['data_name'] ) || '' === trim( $field['data_name'] ) ) {
+				continue;
+			}
+
+			$data_name = strtolower( trim( $field['data_name'] ) );
+			if ( in_array( $data_name, $datanames_array, true ) ) {
+
 				$has_unique = false;
 				break;
 			}
 
-			if ( in_array( $field['data_name'], $datanames_array ) ) {
-
-				$has_unique = false;
-				break;
-			}
-
-			$datanames_array[] = $field['data_name'];
+			$datanames_array[] = $data_name;
 
 		}
 

--- a/classes/ppom.class.php
+++ b/classes/ppom.class.php
@@ -577,9 +577,9 @@ class PPOM_Meta {
 
 			$type = isset( $field['type'] ) ? $field['type'] : '';
 
-			$allowed_types = array( 'pricematrix', 'collapse', 'section', 'divider' );
+			$skip_types = array( 'pricematrix', 'collapse', 'section', 'divider' );
 
-			if ( in_array( $type, $allowed_types, true ) ) {
+			if ( in_array( $type, $skip_types, true ) ) {
 				continue;
 			}
 
@@ -587,7 +587,7 @@ class PPOM_Meta {
 				continue;
 			}
 
-			$data_name = strtolower( trim( $field['data_name'] ) );
+			$data_name = sanitize_key( $field['data_name'] );
 			if ( in_array( $data_name, $datanames_array, true ) ) {
 
 				$has_unique = false;

--- a/tests/unit/test-dataname-validation.php
+++ b/tests/unit/test-dataname-validation.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Unit tests for data-name validation functionality.
+ *
+ * @package ppom-pro
+ */
+
+class Test_DataName_Validation extends PPOM_Test_Case {
+
+	/**
+	 * Creates a mock PPOM_Meta instance with test fields.
+	 *
+	 * @param array $fields Array of field definitions.
+	 * @return PPOM_Meta Mock instance with populated fields.
+	 */
+	private function create_ppom_meta_with_fields( $fields ) {
+		$mock = $this->getMockBuilder( 'PPOM_Meta' )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		// Use reflection to set protected/private properties
+		$reflection = new ReflectionClass( 'PPOM_Meta' );
+		$fields_property = $reflection->getProperty( 'fields' );
+		$fields_property->setAccessible( true );
+		$fields_property->setValue( $mock, $fields );
+
+		return $mock;
+	}
+
+	/**
+	 * Test basic validation scenarios: no fields, empty, single, multiple unique, and duplicates.
+	 *
+	 * @return void
+	 */
+	public function test_basic_validation_scenarios() {
+		// No fields
+		$mock = $this->create_ppom_meta_with_fields( null );
+		$this->assertFalse( $mock->has_unique_datanames() );
+
+		// Empty fields array
+		$mock = $this->create_ppom_meta_with_fields( array() );
+		$this->assertFalse( $mock->has_unique_datanames() );
+
+		// Single valid field
+		$fields = array(
+			array(
+				'type'      => 'text',
+				'data_name' => 'customer_name',
+			),
+		);
+		$mock = $this->create_ppom_meta_with_fields( $fields );
+		$this->assertTrue( $mock->has_unique_datanames() );
+
+		// Multiple unique fields
+		$fields = array(
+			array(
+				'type'      => 'text',
+				'data_name' => 'first_name',
+			),
+			array(
+				'type'      => 'text',
+				'data_name' => 'last_name',
+			),
+			array(
+				'type'      => 'email',
+				'data_name' => 'customer_email',
+			),
+		);
+		$mock = $this->create_ppom_meta_with_fields( $fields );
+		$this->assertTrue( $mock->has_unique_datanames() );
+
+		// Duplicate data_names
+		$fields = array(
+			array(
+				'type'      => 'text',
+				'data_name' => 'customer_name',
+			),
+			array(
+				'type'      => 'text',
+				'data_name' => 'customer_email',
+			),
+			array(
+				'type'      => 'text',
+				'data_name' => 'customer_name',
+			),
+		);
+		$mock = $this->create_ppom_meta_with_fields( $fields );
+		$this->assertFalse( $mock->has_unique_datanames() );
+	}
+
+	/**
+	 * Test handling of empty or whitespace-only data_name values, which should be considered invalid.
+	 *
+	 * @return void
+	 */
+	public function test_empty_data_name() {
+		$fields = array(
+			// Missing data_name
+			array(
+				'type' => 'text',
+			),
+			array(
+				'type'      => 'text',
+				'data_name' => '',
+			),
+			array(
+				'type'      => 'text',
+				'data_name' => '   ',
+			),
+			array(
+				'type'      => 'text',
+				'data_name' => 'customer_name',
+			),
+			array(
+				'type'      => 'email',
+				'data_name' => 'email_address',
+			),
+		);
+
+		$mock = $this->create_ppom_meta_with_fields( $fields );
+		$this->assertTrue( $mock->has_unique_datanames() );
+	}
+
+    /**
+     * Test that excluded field types (pricematrix, collapse, section, divider) are not included in uniqueness checks.
+     *
+     * @return void
+     */
+    public function test_excluded_field_types() {
+        $fields = array(
+            array(
+                'type' => 'pricematrix',
+                'data_name' => 'price_matrix',
+            ),
+            array(
+                'type' => 'collapse',
+                'data_name' => 'collapse_section',
+            ),
+            array(
+                'type' => 'section',
+                'data_name' => 'section_header',
+            ),
+            array(
+                'type' => 'divider',
+                'data_name' => 'divider_line',
+            ),
+            array(
+                'type' => 'text',
+                'data_name' => 'customer_name',
+            ),
+        );
+
+        $mock = $this->create_ppom_meta_with_fields( $fields );
+        $this->assertTrue( $mock->has_unique_datanames() );
+    }
+}


### PR DESCRIPTION
### Summary
Skipped the data name for specific fields( section, divider ) and an empty data name value. 

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/549