### PR TITLE
Handled legacy price validation

### DIFF
--- a/src/Support/Helpers.php
+++ b/src/Support/Helpers.php
@@ -2086,6 +2086,54 @@ final class Helpers {
 		return apply_filters( 'ppom_option_price_attached', $is_price_attached, $fields_posted, $product_id );
 	}
 
+	/**
+	 * Builds a legacy ppom_option_price structure from posted field values.
+	 *
+	 * @param array<string, mixed> $fields_posted Posted ppom[fields] payload.
+	 * @param int                  $product_id    Product ID to look up field metadata against.
+	 *
+	 * @return array<array<string, mixed>> Option-price entries (empty when no priced options match).
+	 */
+	public static function compute_option_price_from_fields( $fields_posted, $product_id ) {
+
+		$option_prices = array();
+		$ppom_id       = isset( $fields_posted['id'] ) ? $fields_posted['id'] : null;
+
+		foreach ( $fields_posted as $data_name => $value ) {
+
+			$field_meta = self::get_field_meta_by_dataname( $product_id, $data_name, $ppom_id );
+			if ( empty( $field_meta ) ) {
+				continue;
+			}
+
+			$apply = ( isset( $field_meta['onetime'] ) && 'on' === $field_meta['onetime'] ) ? 'onetime' : 'variable';
+
+			if ( is_array( $value ) ) {
+				foreach ( $value as $cb_value ) {
+					$price = self::get_field_option_price( $field_meta, $cb_value );
+					if ( 0 != $price ) {
+						$option_prices[] = array(
+							'apply'     => $apply,
+							'price'     => $price,
+							'data_name' => $data_name,
+						);
+					}
+				}
+			} else {
+				$price = self::get_field_option_price( $field_meta, $value );
+				if ( 0 != $price ) {
+					$option_prices[] = array(
+						'apply'     => $apply,
+						'price'     => $price,
+						'data_name' => $data_name,
+					);
+				}
+			}
+		}
+
+		return $option_prices;
+	}
+
 	// PPOM Get settings
 	public static function get_option( $key, $default_val = false ) {
 

--- a/src/WooCommerce/Product/ProductHandler.php
+++ b/src/WooCommerce/Product/ProductHandler.php
@@ -215,8 +215,9 @@ final class ProductHandler {
 			$passed = self::check_validation( $product_id, $_POST );
 		}
 
-		$fields     = isset( $_POST['ppom']['fields'] ) ? ppom_sanitize_array_data( $_POST['ppom']['fields'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$product_id = isset( $_POST['ppom_product_id'] ) ? intval( $_POST['ppom_product_id'] ) : $product_id; // phpcs:ignore WordPress.Security.NonceVerification
+		$posted_fields = isset( $_POST['ppom']['fields'] ) ? wp_unslash( $_POST['ppom']['fields'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$fields        = is_array( $posted_fields ) ? ppom_sanitize_array_data( $posted_fields ) : null;
+		$product_id    = isset( $_POST['ppom_product_id'] ) ? intval( wp_unslash( $_POST['ppom_product_id'] ) ) : $product_id; // phpcs:ignore WordPress.Security.NonceVerification
 
 		if ( Helpers::get_price_mode() == 'legacy' && $fields ) {
 

--- a/src/WooCommerce/Product/ProductHandler.php
+++ b/src/WooCommerce/Product/ProductHandler.php
@@ -215,12 +215,24 @@ final class ProductHandler {
 			$passed = self::check_validation( $product_id, $_POST );
 		}
 
-		if ( Helpers::get_price_mode() == 'legacy' && isset( $_POST['ppom']['fields'] ) ) {
+		$fields     = isset( $_POST['ppom']['fields'] ) ? ppom_sanitize_array_data( $_POST['ppom']['fields'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$product_id = isset( $_POST['ppom_product_id'] ) ? intval( $_POST['ppom_product_id'] ) : $product_id; // phpcs:ignore WordPress.Security.NonceVerification
 
-			if ( Helpers::is_price_attached_with_fields( $_POST['ppom']['fields'] ) &&
-			empty( $_POST['ppom']['ppom_option_price'] )
-			) {
-				$error_message = __( 'Sorry, an error has occurred. Please enable JavaScript or contact site owner.', 'woocommerce-product-addon' );
+		if ( Helpers::get_price_mode() == 'legacy' && $fields ) {
+
+			if ( Helpers::is_price_attached_with_fields( $fields ) && empty( $_POST['ppom']['ppom_option_price'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+				// Price-matrix pricing is stored in ppom_pricematrix and handled independently.
+				if ( isset( $_POST['ppom']['ppom_pricematrix'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+					return $passed;
+				}
+
+				$computed = Helpers::compute_option_price_from_fields( $fields, $product_id );
+				if ( ! empty( $computed ) ) {
+					$_POST['ppom']['ppom_option_price'] = wp_json_encode( $computed );
+					return $passed;
+				}
+
+				$error_message = __( 'An error occurred while processing your order. Please refresh the page and try again, or contact the site owner.', 'woocommerce-product-addon' );
 				Helpers::wc_add_notice( $error_message );
 				$passed = false;
 

--- a/tests/unit/src/WooCommerce/test-product-handler.php
+++ b/tests/unit/src/WooCommerce/test-product-handler.php
@@ -76,4 +76,91 @@ class Test_Product_Handler extends PPOM_Test_Case {
 			)
 		);
 	}
+
+	/**
+	 * When ppom_option_price is missing but the field selections carry a price,
+	 * validate_product() must compute prices server-side and allow the cart.
+	 *
+	 * @return void
+	 */
+	public function test_validate_product_legacy_mode_computes_price_server_side_when_js_price_missing() {
+		$product    = $this->create_simple_product();
+		$product_id = $product->get_id();
+
+		$meta_id = $this->insert_ppom_meta(
+			array(
+				$this->build_select_field(
+					'size',
+					'Size',
+					array(
+						array( 'option' => 'Small', 'price' => '' ),
+						array( 'option' => 'Large', 'price' => '5.00' ),
+					)
+				),
+			),
+			$product_id
+		);
+
+		$this->set_ppom_option( 'ppom_legacy_price', 'yes' );
+
+		$_POST['ppom'] = array(
+			'fields' => array(
+				'id'   => (string) $meta_id,
+				'size' => 'Large',
+			),
+		);
+
+		$result = ProductHandler::validate_product( true, $product_id, 1 );
+
+		$this->assertTrue( $result );
+		$this->assertNotEmpty( $_POST['ppom']['ppom_option_price'] );
+
+		$decoded = json_decode( $_POST['ppom']['ppom_option_price'], true );
+		$this->assertIsArray( $decoded );
+		$this->assertCount( 1, $decoded );
+		$this->assertSame( 'variable', $decoded[0]['apply'] );
+		$this->assertEquals( '5.00', $decoded[0]['price'] );
+		$this->assertSame( 'size', $decoded[0]['data_name'] );
+	}
+
+	/**
+	 * When ppom_option_price is already populated, validate_product() must
+	 * leave it untouched and pass validation normally.
+	 *
+	 * @return void
+	 */
+	public function test_validate_product_legacy_mode_leaves_existing_option_price_intact() {
+		$product    = $this->create_simple_product();
+		$product_id = $product->get_id();
+
+		$meta_id = $this->insert_ppom_meta(
+			array(
+				$this->build_select_field(
+					'size',
+					'Size',
+					array(
+						array( 'option' => 'Large', 'price' => '5.00' ),
+					)
+				),
+			),
+			$product_id
+		);
+
+		$this->set_ppom_option( 'ppom_legacy_price', 'yes' );
+
+		$existing_price = wp_json_encode( array( array( 'apply' => 'variable', 'price' => '5.00', 'data_name' => 'size' ) ) );
+
+		$_POST['ppom'] = array(
+			'fields'           => array(
+				'id'   => (string) $meta_id,
+				'size' => 'Large',
+			),
+			'ppom_option_price' => $existing_price,
+		);
+
+		$result = ProductHandler::validate_product( true, $product_id, 1 );
+
+		$this->assertTrue( $result );
+		$this->assertSame( $existing_price, $_POST['ppom']['ppom_option_price'] );
+	}
 }


### PR DESCRIPTION
### Summary
Checked if `$_POST['ppom']['ppom_option_price']` is empty, computed it from the fields, and updated the `ppom_option_price` with the computed value.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/547