### PR TITLE
Prevented unauthenticated users from accessing the endpoint

### DIFF
--- a/src/Rest/Routes.php
+++ b/src/Rest/Routes.php
@@ -109,7 +109,7 @@ final class Routes {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $p, 'get_ppom_meta_info_product' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( $this, 'check_read_permission' ),
 			)
 		);
 
@@ -119,7 +119,7 @@ final class Routes {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $p, 'get_ppom_meta_by_id' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( $this, 'check_read_permission' ),
 			)
 		);
 
@@ -129,7 +129,7 @@ final class Routes {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $p, 'ppom_save_meta_product' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( $this, 'check_write_permission' ),
 			)
 		);
 
@@ -139,7 +139,7 @@ final class Routes {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $p, 'delete_ppom_fields_product' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( $this, 'check_write_permission' ),
 			)
 		);
 
@@ -149,7 +149,7 @@ final class Routes {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $o, 'get_ppom_meta_info_order' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( $this, 'check_read_permission' ),
 			)
 		);
 
@@ -159,7 +159,7 @@ final class Routes {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $o, 'ppom_update_meta_order' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( $this, 'check_write_permission' ),
 			)
 		);
 
@@ -169,7 +169,7 @@ final class Routes {
 			array(
 				'methods'             => 'POST',
 				'callback'            => array( $o, 'delete_ppom_fields_order' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( $this, 'check_write_permission' ),
 			)
 		);
 	}
@@ -275,6 +275,24 @@ final class Routes {
 	 * @return void
 	 */
 	public function set_headers() {
+	}
+
+	/**
+	 * Checks if the current user can read PPOM REST data.
+	 *
+	 * @return bool
+	 */
+	public function check_read_permission() {
+		return current_user_can( 'edit_products' ); // phpcs:ignore WordPress.WP.Capabilities.Unknown
+	}
+
+	/**
+	 * Checks if the current user can write PPOM REST data.
+	 *
+	 * @return bool
+	 */
+	public function check_write_permission() {
+		return current_user_can( 'manage_woocommerce' ); // phpcs:ignore WordPress.WP.Capabilities.Unknown
 	}
 }
 

--- a/src/Rest/Routes.php
+++ b/src/Rest/Routes.php
@@ -149,7 +149,7 @@ final class Routes {
 			array(
 				'methods'             => 'GET',
 				'callback'            => array( $o, 'get_ppom_meta_info_order' ),
-				'permission_callback' => array( $this, 'check_read_permission' ),
+				'permission_callback' => array( $this, 'check_write_permission' ),
 			)
 		);
 

--- a/tests/unit/class-ppom-test-case.php
+++ b/tests/unit/class-ppom-test-case.php
@@ -29,6 +29,20 @@ abstract class PPOM_Test_Case extends WP_UnitTestCase {
 	protected $original_wc_customer;
 
 	/**
+	 * Test user with edit_products capability for REST read routes.
+	 *
+	 * @var int|null
+	 */
+	protected $ppom_test_read_user;
+
+	/**
+	 * Test user with manage_woocommerce capability for REST write routes.
+	 *
+	 * @var int|null
+	 */
+	protected $ppom_test_write_user;
+
+	/**
 	 * Whether test license filters are registered.
 	 *
 	 * @var bool
@@ -86,6 +100,7 @@ abstract class PPOM_Test_Case extends WP_UnitTestCase {
 		}
 
 		$this->remove_ppom_license_filters();
+		wp_set_current_user( 0 );
 
 		parent::tearDown();
 	}
@@ -705,6 +720,23 @@ abstract class PPOM_Test_Case extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Create a test user with shop_manager role.
+	 *
+	 * @return int User ID.
+	 */
+	protected function create_shop_manager_user() {
+		if ( null === $this->ppom_test_read_user ) {
+			$this->ppom_test_read_user = $this->factory->user->create(
+				array(
+					'role' => 'shop_manager',
+				)
+			);
+		}
+
+		return $this->ppom_test_read_user;
+	}
+
+	/**
 	 * Register the PPOM REST routes for the current test.
 	 *
 	 * @param string $secret_key REST secret key.
@@ -726,15 +758,20 @@ abstract class PPOM_Test_Case extends WP_UnitTestCase {
 	/**
 	 * Dispatch a PPOM REST request through the registered route table.
 	 *
-	 * @param string $method     HTTP method.
-	 * @param string $route      Route path.
-	 * @param array  $params     Request params.
-	 * @param string $secret_key Expected secret key.
+	 * @param string $method          HTTP method.
+	 * @param string $route           Route path.
+	 * @param array  $params          Request params.
+	 * @param string $secret_key      Expected secret key.
+	 * @param bool   $authenticate    Whether to authenticate as appropriate user (default true).
 	 *
 	 * @return WP_REST_Response
 	 */
-	protected function dispatch_ppom_rest_request( $method, $route, $params = array(), $secret_key = 'secret-key' ) {
+	protected function dispatch_ppom_rest_request( $method, $route, $params = array(), $secret_key = 'secret-key', $authenticate = true ) {
 		$this->register_ppom_rest_routes( $secret_key );
+
+		if ( $authenticate ) {
+			wp_set_current_user( $this->create_shop_manager_user() );
+		}
 
 		$response = $this->dispatch_rest_request_to_route( $method, $route, $params );
 		$data     = $response->get_data();

--- a/tests/unit/test-rest-and-admin.php
+++ b/tests/unit/test-rest-and-admin.php
@@ -489,4 +489,141 @@ class Test_Rest_And_Admin extends PPOM_Test_Case {
 		$this->assertSame( "accessories\r\nclothing", $saved_row['productmeta_categories'] );
 		$this->assertSame( serialize( array( 'featured', 'summer' ) ), $saved_row['productmeta_tags'] );
 	}
+
+	/**
+	 * Ensure unauthenticated GET requests are rejected with rest_forbidden.
+	 *
+	 * @return void
+	 */
+	public function testUnauthenticatedGetProductRequestReturnsForbidden() {
+		$product = $this->create_simple_product();
+
+		$this->insert_ppom_meta(
+			array(
+				$this->build_text_field( 'engraving', 'Engraving' ),
+			),
+			$product->get_id()
+		);
+
+		$response = $this->dispatch_ppom_rest_request(
+			'GET',
+			'/ppom/v1/get/product/',
+			array(
+				'product_id' => $product->get_id(),
+			),
+			'secret-key',
+			false
+		);
+
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Ensure unauthenticated POST requests are rejected with rest_forbidden.
+	 *
+	 * @return void
+	 */
+	public function testUnauthenticatedPostProductRequestReturnsForbidden() {
+		$product = $this->create_simple_product();
+
+		$response = $this->dispatch_ppom_rest_request(
+			'POST',
+			'/ppom/v1/set/product/',
+			array(
+				'product_id' => $product->get_id(),
+				'secret_key' => 'secret-key',
+				'fields'     => wp_json_encode(
+					array(
+						$this->build_text_field( 'engraving', 'Engraving' ),
+					)
+				),
+			),
+			'secret-key',
+			false
+		);
+
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Ensure unauthenticated GET order requests are rejected with rest_forbidden.
+	 *
+	 * @return void
+	 */
+	public function testUnauthenticatedGetOrderRequestReturnsForbidden() {
+		$product = $this->create_simple_product();
+
+		$this->insert_ppom_meta(
+			array(
+				$this->build_text_field( 'engraving', 'Engraving' ),
+			),
+			$product->get_id()
+		);
+
+		$order = $this->create_order_with_ppom_item(
+			$product,
+			array(
+				'engraving' => 'Hello',
+			)
+		);
+
+		$response = $this->dispatch_ppom_rest_request(
+			'GET',
+			'/ppom/v1/get/order/',
+			array(
+				'order_id' => $order->get_id(),
+			),
+			'secret-key',
+			false
+		);
+
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Ensure unauthenticated POST order requests are rejected with rest_forbidden.
+	 *
+	 * @return void
+	 */
+	public function testUnauthenticatedPostOrderRequestReturnsForbidden() {
+		$product = $this->create_simple_product();
+
+		$this->insert_ppom_meta(
+			array(
+				$this->build_text_field( 'engraving', 'Engraving' ),
+			),
+			$product->get_id()
+		);
+
+		$order = $this->create_order_with_ppom_item(
+			$product,
+			array(
+				'engraving' => 'Hello',
+			)
+		);
+
+		$response = $this->dispatch_ppom_rest_request(
+			'POST',
+			'/ppom/v1/set/order/',
+			array(
+				'order_id'   => $order->get_id(),
+				'secret_key' => 'secret-key',
+				'fields'     => wp_json_encode(
+					array(
+						$product->get_id() => array(
+							'engraving' => 'Updated',
+						),
+					)
+				),
+			),
+			'secret-key',
+			false
+		);
+
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( 'rest_forbidden', $response->get_data()['code'] );
+	}
 }


### PR DESCRIPTION
### Summary
Checked the current user's capability to access the endpoint.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/541