### PR TITLE
Improved product meta settings UI

### DIFF
--- a/classes/fields.class.php
+++ b/classes/fields.class.php
@@ -138,6 +138,18 @@ class PPOM_Fields_Meta {
 						wp_json_encode( $css_code_editor )
 					)
 				);
+
+				// CSS Example Editor (read-only).
+				$css_example_editor                              = $css_code_editor;
+				$css_example_editor['codemirror']['readOnly']    = 'nocursor';
+				$css_example_editor['codemirror']['lineNumbers'] = false;
+				wp_add_inline_script(
+					'code-editor',
+					sprintf(
+						'jQuery( function() { wp.codeEditor.initialize( "ppom-css-example-editor", %s ); } );',
+						wp_json_encode( $css_example_editor )
+					)
+				);
 			}
 
 			// Js Code Editor Files
@@ -155,6 +167,19 @@ class PPOM_Fields_Meta {
 						wp_json_encode( $js_code_editor )
 					)
 				);
+
+				// JS Example Editor (read-only).
+				$js_example_editor                              = $js_code_editor;
+				$js_example_editor['codemirror']['readOnly']    = 'nocursor';
+				$js_example_editor['codemirror']['lineNumbers'] = false;
+				wp_add_inline_script(
+					'code-editor',
+					sprintf(
+						'jQuery( function() { wp.codeEditor.initialize( "ppom-js-example-editor", %s ); } );',
+						wp_json_encode( $js_example_editor )
+					)
+				);
+
 			}
 		}
 

--- a/css/ppom-admin.css
+++ b/css/ppom-admin.css
@@ -405,10 +405,6 @@ ul.ppom-options-container li {
     6- Basic Settings Section CSS
 */
 
-.ppom-basic-setting-section select {
-    height: 34px !important;
-}
-
 .ppom-basic-setting-section textarea {
     min-height: 140px;
     max-height: 140px;
@@ -428,7 +424,7 @@ ul.ppom-options-container li {
 }
 
 .ppom-wrapper .CodeMirror {
-    height: 139px !important;
+    height: 200px;
 }
 
 /*.CodeMirror pre {*/
@@ -1426,6 +1422,7 @@ a.ppom-attach-upsell-upgrade {
 
 .ppom-wrapper label {
     cursor: auto;
+    font-weight: 600;
 }
 
 .ppom-upsell-modal{
@@ -1894,4 +1891,149 @@ div.ppom-banner .themeisle-sale {
 
 .ppom-banner .themeisle-sale .themeisle-sale-action a {
     text-decoration: none;
+}
+
+.ppom-admin-tabs-css .ppom-admin-tab-content .ppom-form-control {
+    height: 38px;
+    padding: 8px 12px;
+    font-size: 14px;
+}
+
+.ppom-admin-tabs-css .ppom-admin-tab-content .form-group .row {
+    align-items: center;
+}
+
+.ppom-badge {
+    background: #f0f0f0;
+    color: #333;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-family: monospace;
+    margin-left: 4px;
+    text-transform: uppercase;
+}
+
+.ppom-pro-badge {
+    background: transparent;
+    border: 1px solid #c45c1a;
+    color: #c45c1a;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 20px;
+    margin-left: 4px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+}
+
+.ppom-editor-wrapper {
+    position: relative;
+}
+
+.ppom-editor-wrapper.ppom-locked {
+    position: relative;
+}
+
+.ppom-editor-wrapper.ppom-locked textarea {
+    pointer-events: none;
+    user-select: none;
+    filter: blur(3px);
+}
+
+.ppom-locked-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(16, 29, 48, 0.92);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+    pointer-events: none;
+}
+
+.ppom-lock-icon {
+    background: #c45c1a1a;
+    border: 2px solid #ff0000;
+    border-radius: 12px;
+    padding: 12px;
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.ppom-lock-text {
+    color: #ffffff;
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+
+.ppom-lock-subtext {
+    color: #9ca3af;
+    font-size: 14px;
+}
+
+.ppom-style-usage-example {
+    margin-top: 10px;
+}
+
+.ppom-style-usage-example.ppom-locked-example {
+    background: #f5f5f5c7;
+    padding: 15px;
+    border: 2px solid #c9c6c6;
+    border-radius: 10px;
+    pointer-events: none;
+    height: 300px;
+}
+
+.ppom-js-example-code {
+    width: 100%;
+    min-height: 120px;
+    font-family: monospace;
+    font-size: 13px;
+}
+
+.ppom-style-usage-example .CodeMirror {
+    height: 90px;
+    border: 1px solid #2c3338;
+    border-radius: 4px;
+    margin: 10px 0;
+}
+
+.ppom-style-usage-example.css-example .CodeMirror {
+    height: 120px;
+}
+.ppom-css-usage-example .CodeMirror {
+    height: 120px;
+}
+
+.ppomppom-style-usage-example .CodeMirror-scroll {
+    min-height: 120px;
+}
+
+.ppom-style-usage-example .CodeMirror-gutters {
+    display: none;
+}
+
+.ppom-style-usage-example .CodeMirror-cursors {
+    display: none !important;
+}
+
+.ppom-style-usage-example strong {
+    text-transform: uppercase;
+}
+
+.ppom-info-icon {
+    font-size: 16px;
+    display: inline-flex;
+    align-items: center;
 }

--- a/css/ppom-admin.css
+++ b/css/ppom-admin.css
@@ -2012,11 +2012,8 @@ div.ppom-banner .themeisle-sale {
 .ppom-style-usage-example.css-example .CodeMirror {
     height: 120px;
 }
-.ppom-css-usage-example .CodeMirror {
-    height: 120px;
-}
 
-.ppomppom-style-usage-example .CodeMirror-scroll {
+.ppom-style-usage-example .CodeMirror-scroll {
     min-height: 120px;
 }
 

--- a/templates/admin/ppom-fields.php
+++ b/templates/admin/ppom-fields.php
@@ -26,6 +26,7 @@ $product_meta         = array();
 $ppom_field_index     = 1;
 $is_edit_screen       = false;
 $is_new_group         = false;
+$is_legacy_user       = ppom_is_legacy_user();
 
 if ( isset( $_REQUEST['action'] ) && $_REQUEST['action'] == 'new' ) {
 	$is_edit_screen = true;
@@ -525,8 +526,8 @@ $fields_groups = array(
 												title="<?php _e( 'For your reference.', 'woocommerce-product-addon' ); ?>"><i
 													class="dashicons dashicons-editor-help"></i></span>
 									</label>
-									<input type="text" class="form-control" maxlength="50" name="productmeta_name"
-											value="<?php echo $productmeta_name; ?>">
+									<input type="text" class="form-control ppom-form-control" maxlength="50" name="productmeta_name"
+											value="<?php echo esc_attr( $productmeta_name ); ?>" placeholder="<?php esc_attr_e( 'Enter meta group name', 'woocommerce-product-addon' ); ?>">
 								</div>
 							</div>
 							<div class="col-md-6 col-sm-12">
@@ -536,7 +537,7 @@ $fields_groups = array(
 												title="<?php _e( 'Control how price table will be shown for options or disable.', 'woocommerce-product-addon' ); ?>"><i
 													class="dashicons dashicons-editor-help"></i></span>
 									</label>
-									<select name="dynamic_price_hide" class="form-control">
+									<select name="dynamic_price_hide" class="form-control ppom-form-control">
 										<option value="no"><?php _e( 'Select Option', 'woocommerce-product-addon' ); ?></option>
 										<option value="hide" <?php selected( $dynamic_price_hide, 'hide' ); ?>><?php _e( 'Do Not Show Price Table', 'woocommerce-product-addon' ); ?></option>
 										<option value="option_sum" <?php selected( $dynamic_price_hide, 'option_sum' ); ?>><?php _e( "Show Only Option's Total", 'woocommerce-product-addon' ); ?></option>
@@ -561,9 +562,12 @@ $fields_groups = array(
 
 					<!--Style Tab-->
 					<input type="radio" name="css-tabs" id="ppom-style-tab">
-					<label for="ppom-style-tab" class="ppom-tab-label">Style</label>
+					<label for="ppom-style-tab" class="ppom-tab-label">
+						<?php esc_html_e( 'Style', 'woocommerce-product-addon' ); ?>
+						<span class="ppom-badge"><?php esc_html_e( 'css/js', 'woocommerce-product-addon' ); ?></span>
+					</label>
 					<div class="ppom-admin-tab-content">
-						<?php if ( ppom_is_legacy_user() ) : ?>
+						<?php if ( $is_legacy_user ) : ?>
 							<div class="row">
 								<div class="col-md-12 col-sm-12">
 									<div class="notice notice-info">
@@ -588,27 +592,88 @@ $fields_groups = array(
 							<div class="col-md-6 col-sm-12">
 								<div class="form-group">
 									<label><?php _e( 'Custom CSS', 'woocommerce-product-addon' ); ?>
+										<?php if ( $is_legacy_user ) : ?>
+											<span class="ppom-pro-badge">
+												<svg width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="#ff0000">
+													<path d="M19 11H5C3.89543 11 3 11.8954 3 13V20C3 21.1046 3.89543 22 5 22H19C20.1046 22 21 21.1046 21 20V13C21 11.8954 20.1046 11 19 11Z" stroke="#ff0000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+													<path d="M7 11V7C7 5.67392 7.52678 4.40215 8.46447 3.46447C9.40215 2.52678 10.6739 2 12 2C13.3261 2 14.5979 2.52678 15.5355 3.46447C16.4732 4.40215 17 5.67392 17 7V11" stroke="#ff0000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+												</svg>
+												<?php esc_html_e( 'PRO', 'woocommerce-product-addon' ); ?>
+											</span>
+										<?php endif; ?>
 										<span class="ppom-helper-icon" data-ppom-tooltip="ppom_tooltip"
 												title="<?php _e( 'Add your own CSS.', 'woocommerce-product-addon' ); ?>"><i
 													class="dashicons dashicons-editor-help"></i></span>
 									</label>
-									<textarea id="ppom-css-editor" class="form-control" name="productmeta_style"><?php echo wp_unslash( $productmeta_style ); ?></textarea>
+									<div class="ppom-editor-wrapper<?php echo $is_legacy_user ? ' ppom-locked' : ''; ?>">
+										<?php if ( $is_legacy_user ) : ?>
+										<div class="ppom-locked-overlay">
+											<div class="ppom-lock-icon">
+												<svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="#ff0000">
+													<path d="M19 11H5C3.89543 11 3 11.8954 3 13V20C3 21.1046 3.89543 22 5 22H19C20.1046 22 21 21.1046 21 20V13C21 11.8954 20.1046 11 19 11Z" stroke="#ff0000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+													<path d="M7 11V7C7 5.67392 7.52678 4.40215 8.46447 3.46447C9.40215 2.52678 10.6739 2 12 2C13.3261 2 14.5979 2.52678 15.5355 3.46447C16.4732 4.40215 17 5.67392 17 7V11" stroke="#ff0000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+												</svg>
+											</div>
+											<div class="ppom-lock-text"><?php esc_html_e( 'Locked on free plan', 'woocommerce-product-addon' ); ?></div>
+											<div class="ppom-lock-subtext"><?php esc_html_e( 'Upgrade to add CSS', 'woocommerce-product-addon' ); ?></div>
+										</div>
+										<?php endif; ?>
+										<textarea id="ppom-css-editor" class="form-control"
+												name="productmeta_css"><?php echo esc_textarea( wp_unslash( $productmeta_style ) ); ?></textarea>
+									</div>
 									<br>
-									<p><?php esc_html_e( 'Use', 'woocommerce-product-addon' ); ?> <code>selector</code> <?php esc_html_e( 'to target block wrapper.', 'woocommerce-product-addon' ); ?></p>
-									<p><?php esc_html_e( 'Example:', 'woocommerce-product-addon' ); ?></p>
-									<pre className="ppom-css-editor-help"><?php echo esc_html( "selector {\n    background: #000;\n}\nselector img {\n    border-radius: 100%;\n}" ); ?></pre>
-									<p><?php esc_html_e( 'You can also use other CSS syntax here, such as media queries.', 'woocommerce-product-addon' ); ?></p>
+									<div class="ppom-style-usage-example css-example<?php echo $is_legacy_user ? ' ppom-locked-example' : ''; ?>">
+										<p>
+											<span class="ppom-info-icon dashicons dashicons-info-outline"></span>
+											<strong><?php esc_html_e( 'How to use', 'woocommerce-product-addon' ); ?></strong></p>
+										<p><?php esc_html_e( 'Use', 'woocommerce-product-addon' ); ?> <code>selector</code> <?php esc_html_e( 'to target block wrapper.', 'woocommerce-product-addon' ); ?></p>
+										<p><?php esc_html_e( 'Example:', 'woocommerce-product-addon' ); ?></p>
+										<textarea id="ppom-css-example-editor" class="ppom-css-example-code" readonly><?php echo esc_textarea( "selector {\n    background: #000;\n}\nselector img {\n    border-radius: 100%;\n}" ); ?></textarea>
+										<p><?php esc_html_e( 'You can also use other CSS syntax here, such as media queries.', 'woocommerce-product-addon' ); ?></p>
+									</div>
 								</div>
 							</div>
 							<div class="col-md-6 col-sm-12">
 								<div class="form-group">
 									<label><?php _e( 'Custom Javascipt', 'woocommerce-product-addon' ); ?>
+										<?php if ( $is_legacy_user ) : ?>
+											<span class="ppom-pro-badge">
+												<svg width="12" height="12" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="#ff0000">
+													<path d="M19 11H5C3.89543 11 3 11.8954 3 13V20C3 21.1046 3.89543 22 5 22H19C20.1046 22 21 21.1046 21 20V13C21 11.8954 20.1046 11 19 11Z" stroke="#ff0000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+													<path d="M7 11V7C7 5.67392 7.52678 4.40215 8.46447 3.46447C9.40215 2.52678 10.6739 2 12 2C13.3261 2 14.5979 2.52678 15.5355 3.46447C16.4732 4.40215 17 5.67392 17 7V11" stroke="#ff0000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+												</svg>
+												<?php esc_html_e( 'PRO', 'woocommerce-product-addon' ); ?>
+											</span>
+										<?php endif; ?>
 										<span class="ppom-helper-icon" data-ppom-tooltip="ppom_tooltip"
 												title="<?php _e( 'Add your own javascipt script.', 'woocommerce-product-addon' ); ?>"><i
 													class="dashicons dashicons-editor-help"></i></span>
 									</label>
-									<textarea id="ppom-js-editor" class="form-control"
-												name="productmeta_js"><?php echo wp_unslash( $productmeta_js ); ?></textarea>
+									<div class="ppom-editor-wrapper<?php echo $is_legacy_user ? ' ppom-locked' : ''; ?>">
+										<?php if ( $is_legacy_user ) : ?>
+										<div class="ppom-locked-overlay">
+											<div class="ppom-lock-icon">
+												<svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="#ff0000">
+													<path d="M19 11H5C3.89543 11 3 11.8954 3 13V20C3 21.1046 3.89543 22 5 22H19C20.1046 22 21 21.1046 21 20V13C21 11.8954 20.1046 11 19 11Z" stroke="#ff0000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+													<path d="M7 11V7C7 5.67392 7.52678 4.40215 8.46447 3.46447C9.40215 2.52678 10.6739 2 12 2C13.3261 2 14.5979 2.52678 15.5355 3.46447C16.4732 4.40215 17 5.67392 17 7V11" stroke="#ff0000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+												</svg>
+											</div>
+											<div class="ppom-lock-text"><?php esc_html_e( 'Locked on free plan', 'woocommerce-product-addon' ); ?></div>
+											<div class="ppom-lock-subtext"><?php esc_html_e( 'Upgrade to add JavaScript', 'woocommerce-product-addon' ); ?></div>
+										</div>
+										<?php endif; ?>
+										<textarea id="ppom-js-editor" class="form-control"
+												name="productmeta_js"><?php echo esc_textarea( wp_unslash( $productmeta_js ) ); ?></textarea>
+									</div>
+									<br>
+									<div class="ppom-style-usage-example<?php echo $is_legacy_user ? ' ppom-locked-example' : ''; ?>">
+										<p>
+											<span class="ppom-info-icon dashicons dashicons-info-outline"></span>
+											<strong><?php esc_html_e( 'How to use', 'woocommerce-product-addon' ); ?></strong></p>
+										<p><?php esc_html_e( 'Write plain JavaScript to control field behaviour. The code runs after the field is rendered on the page.', 'woocommerce-product-addon' ); ?></p>
+										<p><?php esc_html_e( 'Example:', 'woocommerce-product-addon' ); ?></p>
+										<textarea id="ppom-js-example-editor" class="ppom-js-example-code" readonly><?php echo esc_textarea( "document.querySelector('.ppom-wrapper')\n  .addEventListener('change', function(e) {\n    console.log(e.target.value);\n});" ); ?></textarea>
+									</div>
 								</div>
 							</div>
 						</div>

--- a/templates/admin/ppom-fields.php
+++ b/templates/admin/ppom-fields.php
@@ -619,7 +619,7 @@ $fields_groups = array(
 										</div>
 										<?php endif; ?>
 										<textarea id="ppom-css-editor" class="form-control"
-												name="productmeta_css"><?php echo esc_textarea( wp_unslash( $productmeta_style ) ); ?></textarea>
+												name="productmeta_style"><?php echo esc_textarea( wp_unslash( $productmeta_style ) ); ?></textarea>
 									</div>
 									<br>
 									<div class="ppom-style-usage-example css-example<?php echo $is_legacy_user ? ' ppom-locked-example' : ''; ?>">


### PR DESCRIPTION
### Summary
Improve the input field styling and style tab in product meta settting page.

### Will affect visual aspect of the product
YES

### Screenshots
<img width="1716" height="667" alt="image" src="https://github.com/user-attachments/assets/2d7dbf46-3594-4e83-a025-bedad5af475b" />

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/ppom-pro/issues/635