### PR TITLE
Shorten unique file name for improved readability

### DIFF
--- a/inc/files.php
+++ b/inc/files.php
@@ -51,10 +51,11 @@ function ppom_create_thumb_for_meta( $file_name, $product_id, $cropped = false, 
 /**
  * @param string $file_name File name.
  * @param string $file_ext Extension.
+ * @param string $dir_path Directory path.
  * @return string
  */
-function ppom_create_unique_file_name( $file_name, $file_ext ) {
-	return \PPOM\Files\Handler::create_unique_file_name( $file_name, $file_ext );
+function ppom_create_unique_file_name( $file_name, $file_ext, $dir_path = '' ) {
+	return \PPOM\Files\Handler::create_unique_file_name( $file_name, $file_ext, $dir_path );
 }
 
 /**

--- a/src/Files/Handler.php
+++ b/src/Files/Handler.php
@@ -145,12 +145,20 @@ final class Handler {
 	 *
 	 * @param string $file_name The file name.
 	 * @param string $file_ext The file extension.
+	 * @param string $dir_path Optional directory path to check for uniqueness.
 	 *
 	 * @return string The new file name.
 	 */
-	public static function create_unique_file_name( $file_name, $file_ext ) {
-		$seed = $file_name . microtime( true ) . wp_rand();
-		return $file_name . '.' . substr( wp_hash( $seed ), 0, 6 ) . '.' . $file_ext;
+	public static function create_unique_file_name( $file_name, $file_ext, $dir_path = '' ) {
+		$seed           = $file_name . microtime( true ) . wp_rand();
+		$generated_name = $file_name . '.' . substr( wp_hash( $seed ), 0, 6 ) . '.' . $file_ext;
+
+		// Ensure the filename is truly unique in the target directory to prevent collisions.
+		if ( ! empty( $dir_path ) ) {
+			$generated_name = wp_unique_filename( $dir_path, $generated_name );
+		}
+
+		return $generated_name;
 	}
 
 	/**
@@ -361,7 +369,7 @@ final class Handler {
 		if ( ! $chunks || $chunk === $chunks - 1 ) {
 
 			// Give a unique name to prevent name collisions.
-			$file_name        = self::create_unique_file_name( $original_name, $file_ext );
+			$file_name        = self::create_unique_file_name( $original_name, $file_ext, $file_dir_path );
 			$unique_file_path = $file_dir_path . $file_name;
 
 			rename( $chunk_file_path, $unique_file_path );

--- a/src/Files/Handler.php
+++ b/src/Files/Handler.php
@@ -149,8 +149,8 @@ final class Handler {
 	 * @return string The new file name.
 	 */
 	public static function create_unique_file_name( $file_name, $file_ext ) {
-		$seed = $file_name . microtime( true ) . mt_rand();
-		return $file_name . '.' . wp_hash( $seed ) . '.' . $file_ext;
+		$seed = $file_name . microtime( true ) . wp_rand();
+		return $file_name . '.' . substr( wp_hash( $seed ), 0, 6 ) . '.' . $file_ext;
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Uses only the first six characters of the hash to shorten the file name.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/ppom-pro/issues/619