### PR TITLE
Optimize wp.org listing: tags

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === PPOM - Product Addons & Custom Fields for WooCommerce ===
 Contributors: themeisle
-Tags: woocommerce product addons, woocommerce product options, woocommerce product fields, woocommerce product, product addons
+Tags: product addons, woocommerce product addons, woocommerce product options, custom fields, variable products
 Requires at least: 6.2
 Tested up to: 6.9
 Stable tag: 33.0.18


### PR DESCRIPTION
Tag rebuild calibrated against the wp.org WooCommerce-product-addon leaders.

Current 5-tag set has 4 of 5 starting with `woocommerce-product-` — collapses to ~2 stem buckets. The actual category leaders on wp.org (Advanced Product Fields, Flexible Product Fields) use heavy variant clustering on the same prefix, so pure stem-dedup would move us off the proven pattern.

**New set:** `product addons, woocommerce product addons, woocommerce product options, custom fields, variable products`

- Keeps the variant pair that the leaders use (`product addons` + `woocommerce product addons` + `woocommerce product options` are universal across the 3 actual category competitors).
- Drops the most-redundant `woocommerce product fields` and `woocommerce product`.
- Adds `custom fields` and `variable products` — distinct anchors that the leader pattern includes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)