### PR TITLE
fix: timezone crash

### DIFF
--- a/src/Arrays/Settings.php
+++ b/src/Arrays/Settings.php
@@ -148,8 +148,13 @@ final class Settings {
 
 		$timezone_offsets = array();
 		foreach ( $timezones as $timezone ) {
-			$tz                            = new \DateTimeZone( $timezone );
-			$timezone_offsets[ $timezone ] = $tz->getOffset( new \DateTime() );
+			try {
+				$tz                            = new \DateTimeZone( $timezone );
+				$timezone_offsets[ $timezone ] = $tz->getOffset( new \DateTime() );
+			} catch ( \Exception $e ) {
+				// Skip identifiers returned by listIdentifiers() that the bundled tzdata cannot construct (e.g. America/Ciudad_Juarez on outdated PHP).
+				continue;
+			}
 		}
 
 		// sort timezone by timezone name

--- a/tests/unit/src/Arrays/test-settings.php
+++ b/tests/unit/src/Arrays/test-settings.php
@@ -106,4 +106,74 @@ class Test_Settings extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'Europe/London', $list );
 		$this->assertArrayHasKey( 'America/New_York', $list );
 	}
+
+	/**
+	 * Regression: identifiers returned by listIdentifiers() that the bundled tzdata cannot
+	 * construct (e.g. America/Ciudad_Juarez on outdated PHP) must not bubble an exception.
+	 *
+	 * @return void
+	 */
+	public function test_get_timezone_list_does_not_throw_for_any_region() {
+		$regions = array( 'All', 'AFRICA', 'AMERICA', 'ANTARCTICA', 'ASIA', 'ATLANTIC', 'AUSTRALIA', 'EUROPE', 'INDIAN', 'PACIFIC' );
+
+		foreach ( $regions as $region ) {
+			try {
+				$list = Settings::get_timezone_list( $region, 'no' );
+			} catch ( \Throwable $e ) {
+				$this->fail( "get_timezone_list( '$region', 'no' ) threw: " . $e->getMessage() );
+			}
+
+			$this->assertIsArray( $list );
+			$this->assertNotEmpty( $list, "Expected non-empty timezone list for region '$region'" );
+		}
+	}
+
+	/**
+	 * Every identifier returned must be constructable — the fix filters out any that aren't.
+	 *
+	 * @return void
+	 */
+	public function test_get_timezone_list_only_returns_constructable_identifiers() {
+		$list = Settings::get_timezone_list( 'All', 'no' );
+
+		foreach ( array_keys( $list ) as $identifier ) {
+			try {
+				new \DateTimeZone( $identifier );
+			} catch ( \Exception $e ) {
+				$this->fail( "Returned identifier '$identifier' is not constructable: " . $e->getMessage() );
+			}
+		}
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_get_timezone_list_with_comma_separated_regions() {
+		$list = Settings::get_timezone_list( 'EUROPE,ASIA', 'no' );
+
+		$this->assertArrayHasKey( 'Europe/London', $list );
+		$this->assertArrayHasKey( 'Asia/Tokyo', $list );
+		$this->assertArrayNotHasKey( 'America/New_York', $list );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_get_timezone_list_show_time_toggles_current_time() {
+		$with_time    = Settings::get_timezone_list( 'EUROPE', 'on' );
+		$without_time = Settings::get_timezone_list( 'EUROPE', 'no' );
+
+		$this->assertMatchesRegularExpression( '/\d{1,2}:\d{2}\s?(AM|PM)/', $with_time['Europe/London'] );
+		$this->assertDoesNotMatchRegularExpression( '/\d{1,2}:\d{2}\s?(AM|PM)/', $without_time['Europe/London'] );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_get_timezone_list_entry_format_includes_utc_offset() {
+		$list = Settings::get_timezone_list( 'EUROPE', 'no' );
+
+		$this->assertStringContainsString( '(UTC', $list['Europe/London'] );
+		$this->assertStringContainsString( 'Europe/London', $list['Europe/London'] );
+	}
 }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Fix workflow when the timezone crashes.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Enable Timezone field in a PPOM group and save
2. Visit a product page that uses this field
3. There should be not fata errors in logs: DateTimeZone::__construct(): Unknown or bad timezone (America/Ciudad_Juarez)

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/542
<!-- Should look like this: `Closes #1, #2, #3.` . -->
