### PR TITLE
fix: price parsing with currency symbol

### DIFF
--- a/src/Pricing/Engine.php
+++ b/src/Pricing/Engine.php
@@ -888,9 +888,10 @@ final class Engine {
 					continue;
 				}
 
-				$the_price = floatval( $price['price'] );
+				$the_price = self::normalize_price_value( $price['price'] );
+				$qty       = isset( $price['quantity'] ) ? self::normalize_price_value( $price['quantity'] ) : 0;
 
-				$total_addon += ( $the_price * $price['quantity'] );
+				$total_addon += ( $the_price * $qty );
 
 				/*
 				if( $price['type'] == 'quantities' || $price['type'] == 'bulkquantity' ) {
@@ -913,12 +914,40 @@ final class Engine {
 			foreach ( $price_array as $price ) {
 
 				if ( $price['apply'] == 'cart_fee' ) {
-					$total_cart_fee += $price['price'];
+					$total_cart_fee += self::normalize_price_value( $price['price'] );
 				}
 			}
 		}
 
 		return $total_cart_fee;
+	}
+
+	/**
+	 * Coerce a raw addon price value to a float.
+	 *
+	 * Admins occasionally type currency symbols, spaces, or trailing labels
+	 * into the price field (e.g. "$10", "10 USD"). PHP 8+ raises a fatal
+	 * TypeError if such a value is added to an int, so any value that flows
+	 * into pricing arithmetic must be normalized first.
+	 *
+	 * Delegates to wc_format_decimal() so locale separators (e.g. "1.000,50"
+	 * on European stores) and currency symbols are stripped consistently with
+	 * the rest of WooCommerce's price handling.
+	 *
+	 * @param mixed $value Raw price value as stored in field meta.
+	 * @return float
+	 */
+	private static function normalize_price_value( $value ) {
+
+		if ( is_int( $value ) || is_float( $value ) ) {
+			return (float) $value;
+		}
+
+		if ( ! is_scalar( $value ) ) {
+			return 0.0;
+		}
+
+		return (float) wc_format_decimal( (string) $value );
 	}
 
 	// Get total quantities

--- a/tests/unit/src/Pricing/test-pricing-engine.php
+++ b/tests/unit/src/Pricing/test-pricing-engine.php
@@ -145,6 +145,109 @@ class Test_Pricing_Engine extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression for #642 — admin saved a cart-fee addon price as "$10".
+	 *
+	 * Prior to the fix, summing the int accumulator with the string "$10" raised
+	 * a fatal TypeError on PHP 8+, taking down the whole cart/checkout. After
+	 * the fix the leading currency symbol is stripped and the value is parsed
+	 * as 10.
+	 *
+	 * @return void
+	 */
+	public function test_price_get_cart_fee_total_normalizes_currency_prefixed_string() {
+		$total = Engine::price_get_cart_fee_total(
+			array(
+				array( 'apply' => 'cart_fee', 'price' => '$10' ),
+				array( 'apply' => 'cart_fee', 'price' => ' 5.50' ),
+				array( 'apply' => 'cart_fee', 'price' => 'USD 2' ),
+			)
+		);
+
+		$this->assertEqualsWithDelta( 17.5, $total, 0.0001 );
+	}
+
+	/**
+	 * Regression for #642 — trailing junk after the number must not crash.
+	 *
+	 * "10abc" was the second example from the bug report. PHP's float cast
+	 * already handles a trailing non-numeric tail, but we assert it here so a
+	 * future refactor cannot silently break the contract.
+	 *
+	 * @return void
+	 */
+	public function test_price_get_cart_fee_total_truncates_trailing_non_numeric() {
+		$total = Engine::price_get_cart_fee_total(
+			array(
+				array( 'apply' => 'cart_fee', 'price' => '10abc' ),
+			)
+		);
+
+		$this->assertEqualsWithDelta( 10.0, $total, 0.0001 );
+	}
+
+	/**
+	 * Non-scalar / unparseable values must degrade to 0 rather than throw.
+	 *
+	 * @return void
+	 */
+	public function test_price_get_cart_fee_total_handles_unparseable_values() {
+		$total = Engine::price_get_cart_fee_total(
+			array(
+				array( 'apply' => 'cart_fee', 'price' => 'free' ),
+				array( 'apply' => 'cart_fee', 'price' => null ),
+				array( 'apply' => 'cart_fee', 'price' => array( 'unexpected' ) ),
+				array( 'apply' => 'cart_fee', 'price' => 7 ),
+			)
+		);
+
+		$this->assertEqualsWithDelta( 7.0, $total, 0.0001 );
+	}
+
+	/**
+	 * Same regression coverage for the addon-apply path so both helpers stay
+	 * symmetric.
+	 *
+	 * @return void
+	 */
+	public function test_price_get_addon_total_normalizes_currency_prefixed_string() {
+		$total = Engine::price_get_addon_total(
+			array(
+				array(
+					'apply'    => 'addon',
+					'price'    => '$10',
+					'quantity' => 2,
+				),
+				array(
+					'apply'    => 'addon',
+					'price'    => '5abc',
+					'quantity' => 1,
+				),
+			)
+		);
+
+		$this->assertEqualsWithDelta( 25.0, $total, 0.0001 );
+	}
+
+	/**
+	 * A non-numeric quantity must not crash the addon sum either.
+	 *
+	 * @return void
+	 */
+	public function test_price_get_addon_total_handles_non_numeric_quantity() {
+		$total = Engine::price_get_addon_total(
+			array(
+				array(
+					'apply'    => 'addon',
+					'price'    => 4,
+					'quantity' => '3x',
+				),
+			)
+		);
+
+		$this->assertEqualsWithDelta( 12.0, $total, 0.0001 );
+	}
+
+	/**
 	 * @return void
 	 */
 	public function test_get_amount_after_percentage_strips_percent_suffix() {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

- Add a better parsing for pricing.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Go to edit a product and add a PPOM field (e.g. text input), and set the 'Addon price' field to "$10" (or any non-numeric string like "10abc").
- Save and add it to a product and check the front end.
- There should be no fatal error.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/642
<!-- Should look like this: `Closes #1, #2, #3.` . -->
