### PR TITLE
Preserved cart quantity after quantity update

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -194,6 +194,14 @@ final class Validator {
 			$data['min_value'] = $limits['step'];
 		}
 
+		if ( empty( $data['input_value'] ) ) {
+ 			if ( ! empty( $data['min_value'] ) ) {
+ 				$data['input_value'] = $data['min_value'];
+ 			} else {
+ 				$data['input_value'] = 1;
+ 			}
+ 		}
+
 		return $data;
 	}
 

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -194,8 +194,6 @@ final class Validator {
 			$data['min_value'] = $limits['step'];
 		}
 
-		$data['input_value'] = $data['min_value'];
-
 		return $data;
 	}
 


### PR DESCRIPTION
### Summary
Set the default input value if none is provided.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/612