### PR TITLE
Fixed textarea placeholder not displayed

### DIFF
--- a/templates/frontend/inputs/textarea.php
+++ b/templates/frontend/inputs/textarea.php
@@ -58,6 +58,9 @@ if ( $postid && is_numeric( $postid ) && $rich_editor != 'on' ) {
 	if ( $rich_editor == 'on' ) {
 		wp_editor( $textarea_value, $fm->data_name(), $wp_editor_setting );
 	} else {
+		if ( $textarea_value != '' ) {
+			$textarea_value = str_replace( '<br />', "\n", $textarea_value );
+		}
 		?>
 		<textarea
 				name="<?php echo esc_attr( $fm->form_name() ); ?>"
@@ -72,14 +75,7 @@ if ( $postid && is_numeric( $postid ) && $rich_editor != 'on' ) {
 			echo $key . '="' . $val . '"';
 		}
 		?>
-		>
-		<?php
-		if ( $textarea_value != '' ) {
-			$textarea_value = str_replace( '<br />', "\n", $textarea_value );
-			echo esc_html( $textarea_value );
-		}
-		?>
-		</textarea>
+		><?php echo esc_html( $textarea_value ); ?></textarea>
 
 	<?php } ?>
 

--- a/tests/e2e/fixtures/fields.js
+++ b/tests/e2e/fixtures/fields.js
@@ -27,6 +27,10 @@ function buildTextField( args ) {
 	return buildField( 'text', args );
 }
 
+function buildTextareaField( args ) {
+	return buildField( 'textarea', args );
+}
+
 function buildImageField( args ) {
 	return buildField( 'image', {
 		images: [],
@@ -103,6 +107,7 @@ export {
 	buildPriceMatrixField,
 	buildSelectField,
 	buildTextField,
+	buildTextareaField,
 	buildFileField,
 	buildHtmlField,
 };

--- a/tests/e2e/fixtures/index.js
+++ b/tests/e2e/fixtures/index.js
@@ -13,6 +13,7 @@ export {
 	buildHtmlField,
 	buildSelectField,
 	buildTextField,
+	buildTextareaField,
 } from './fields.js';
 export { getPpomLicenseFixture, setPpomLicenseFixture } from './license.js';
 export {

--- a/tests/e2e/specs/textarea.spec.js
+++ b/tests/e2e/specs/textarea.spec.js
@@ -1,0 +1,190 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+import {
+	attachPpomGroupToProducts,
+	buildTextareaField,
+	createPpomGroup,
+	createSimpleProduct,
+} from '../fixtures/index.js';
+
+test.describe( 'Textarea', () => {
+	/**
+	 * Test that placeholder is visible when textarea is empty and hidden when text is entered.
+	 */
+	test( 'placeholder should be visible when empty and hidden when filled', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const fieldId = 'textarea_placeholder_test';
+		const placeholderText = 'Enter your message here...';
+		const testText = 'This is some test content';
+
+		const product = await createSimpleProduct( requestUtils );
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: 'Textarea Placeholder Test',
+			fields: [
+				buildTextareaField( {
+					title: 'Message',
+					dataName: fieldId,
+					placeholder: placeholderText,
+				} ),
+			],
+		} );
+
+		await attachPpomGroupToProducts( requestUtils, {
+			ppomId,
+			productIds: [ product.id ],
+		} );
+
+		await page.goto( `/?ppom_e2e_product_page=${ product.id }` );
+
+		const textarea = page.locator(
+			`textarea[name="ppom[fields][${ fieldId }]"]`
+		);
+
+		await expect( textarea ).toBeVisible();
+
+		await expect( textarea ).toHaveAttribute(
+			'placeholder',
+			placeholderText
+		);
+
+		await expect( textarea ).toHaveValue( '' );
+
+		const placeholderVisible = await textarea.evaluate( ( el ) => {
+			const style = window.getComputedStyle( el, '::placeholder' );
+			return style.opacity !== '0' && style.display !== 'none';
+		} );
+		expect( placeholderVisible ).toBe( true );
+
+		await textarea.fill( testText );
+
+		await expect( textarea ).toHaveValue( testText );
+
+		const placeholderHiddenWithContent = await textarea.evaluate(
+			( el ) => {
+				return el.value !== '';
+			}
+		);
+		expect( placeholderHiddenWithContent ).toBe( true );
+
+		await textarea.clear();
+
+		await expect( textarea ).toHaveValue( '' );
+
+		const placeholderVisibleAfterClear = await textarea.evaluate(
+			( el ) => {
+				const style = window.getComputedStyle( el, '::placeholder' );
+				return style.opacity !== '0' && style.display !== 'none';
+			}
+		);
+		expect( placeholderVisibleAfterClear ).toBe( true );
+	} );
+
+	/**
+	 * Test that textarea with whitespace-only content is treated as empty for validation
+	 * but doesn't break placeholder visibility.
+	 */
+	test( 'placeholder behavior with whitespace-only content', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const fieldId = 'textarea_whitespace_test';
+		const placeholderText = 'Enter details...';
+
+		const product = await createSimpleProduct( requestUtils );
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: 'Textarea Whitespace Test',
+			fields: [
+				buildTextareaField( {
+					title: 'Details',
+					dataName: fieldId,
+					placeholder: placeholderText,
+				} ),
+			],
+		} );
+
+		await attachPpomGroupToProducts( requestUtils, {
+			ppomId,
+			productIds: [ product.id ],
+		} );
+
+		await page.goto( `/?ppom_e2e_product_page=${ product.id }` );
+
+		const textarea = page.locator(
+			`textarea[name="ppom[fields][${ fieldId }]"]`
+		);
+
+		await expect( textarea ).toBeVisible();
+
+		await expect( textarea ).toHaveValue( '' );
+
+		await textarea.fill( '   \n\t   ' );
+
+		const hasWhitespace = await textarea.evaluate(
+			( el ) => el.value.trim() === '' && el.value !== ''
+		);
+		expect( hasWhitespace ).toBe( true );
+
+		await textarea.clear();
+		await expect( textarea ).toHaveValue( '' );
+	} );
+
+	/**
+	 * Test textarea with default value - placeholder should not be visible when there's a default value.
+	 */
+	test( 'placeholder should not be visible with default value', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const fieldId = 'textarea_default_value_test';
+		const placeholderText = 'Enter your text...';
+		const defaultValue = 'This is the default content';
+
+		const product = await createSimpleProduct( requestUtils );
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: 'Textarea Default Value Test',
+			fields: [
+				buildTextareaField( {
+					title: 'Content',
+					dataName: fieldId,
+					placeholder: placeholderText,
+					default_value: defaultValue,
+				} ),
+			],
+		} );
+
+		await attachPpomGroupToProducts( requestUtils, {
+			ppomId,
+			productIds: [ product.id ],
+		} );
+
+		await page.goto( `/?ppom_e2e_product_page=${ product.id }` );
+
+		const textarea = page.locator(
+			`textarea[name="ppom[fields][${ fieldId }]"]`
+		);
+
+		await expect( textarea ).toBeVisible();
+
+		await expect( textarea ).toHaveValue( defaultValue );
+
+		await expect( textarea ).toHaveAttribute(
+			'placeholder',
+			placeholderText
+		);
+
+		await textarea.clear();
+
+		await expect( textarea ).toHaveValue( '' );
+
+		const placeholderVisible = await textarea.evaluate( ( el ) => {
+			const style = window.getComputedStyle( el, '::placeholder' );
+			return style.opacity !== '0' && style.display !== 'none';
+		} );
+		expect( placeholderVisible ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
### Summary
Fixed textarea placeholder is not showing when the field is empty.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/618