### PR TITLE
Improved condition handling

### DIFF
--- a/classes/ppom.class.php
+++ b/classes/ppom.class.php
@@ -495,12 +495,12 @@ class PPOM_Meta {
 		$inline_js = '';
 
 		if ( ! $this->is_exists() ) {
-			return null;
+			return '';
 		}
 
 		// Meta created without any fields
 		if ( ! $this->ppom_settings ) {
-			return null;
+			return '';
 		}
 
 		if ( $this->has_multiple_meta() ) {

--- a/js/ppom-conditions-v2.js
+++ b/js/ppom-conditions-v2.js
@@ -414,15 +414,20 @@ function ppom_check_conditions( data_name, callback ) {
 			// console.log(`${t} ***** ${element_data_name} total_cond ${total_cond} == matched ${matched} ==> ${matched_conditions[element_data_name]} ==> visibility ${event_type}`);
 
 			if ( matched_conditions[ element_data_name ] > 0 && binding === 'Any' ) {
-				jQuery( `[data-data_name="${ element_data_name }"]` ).removeClass( function( index, className ) {
-					return ( className.match(/\bppom-locked-\S+/g) || []).join(' ');
-				});
+				const $wrapper = jQuery( this );
+				if ( visibility !== 'hide' ) {
+					$wrapper.removeClass( function ( _index, className ) {
+						return ( className.match(/\bppom-locked-\S+/g) || [] ).join( ' ' );
+					} );
+				} else {
+ 					$wrapper.addClass( `ppom-locked-${ data_name }` );
+ 				}
 
 				if ( visibility === 'hide' ) {
-					jQuery( this ).addClass( 'ppom-c-hide' ).removeClass( 'ppom-c-show' );
-				} else {
-					jQuery( this ).removeClass( 'ppom-c-hide' );
-				}
+ 					$wrapper.addClass( 'ppom-c-hide' ).removeClass( 'ppom-c-show' );
+ 				} else {
+ 					$wrapper.removeClass( 'ppom-c-hide' );
+ 				}
 
 				if ( typeof callback === 'function' ) {
 					callback( element_data_name, event_type );
@@ -450,16 +455,33 @@ function ppom_check_conditions( data_name, callback ) {
 				! is_matched ||
 				matched_conditions[ element_data_name ] !== total_cond
 			) {
-				if ( visibility === 'hide' ) {
-					event_type = 'ppom_field_shown';
-					jQuery( this ).removeClass(
-						`ppom-locked-${ data_name } ppom-c-hide`
-					);
-				} else {
-					event_type = 'ppom_field_hidden';
-					jQuery( this ).addClass(
-						`ppom-locked-${ data_name } ppom-c-hide`
-					);
+				if ( binding === 'Any' ) {
+					const classes = ((jQuery(this).attr("class") || "").match(/\bppom-cond-[^\s]+/g,) || [])
+								.map((cls) => cls.replace("ppom-cond-", "ppom-locked-"))
+								.join(" ");
+					console.log(classes);
+
+					if ( visibility === 'hide' ) {
+						jQuery( this ).removeClass(
+							`${ classes } ppom-c-hide`
+						);
+					} else {
+						jQuery( this ).addClass(
+							`${ classes } ppom-c-hide`
+						);
+					}
+				} else if ( binding === 'All' ) {
+					if ( visibility === 'hide' ) {
+						event_type = 'ppom_field_shown';
+						jQuery( this ).removeClass(
+							`ppom-locked-${ data_name } ppom-c-hide`
+						);
+					} else {
+						event_type = 'ppom_field_hidden';
+						jQuery( this ).addClass(
+							`ppom-locked-${ data_name } ppom-c-hide`
+						);
+					}
 				}
 
 				if ( typeof callback === 'function' ) {

--- a/js/ppom-conditions-v2.js
+++ b/js/ppom-conditions-v2.js
@@ -459,7 +459,6 @@ function ppom_check_conditions( data_name, callback ) {
 					const classes = ((jQuery(this).attr("class") || "").match(/\bppom-cond-[^\s]+/g,) || [])
 								.map((cls) => cls.replace("ppom-cond-", "ppom-locked-"))
 								.join(" ");
-					console.log(classes);
 
 					if ( visibility === 'hide' ) {
 						jQuery( this ).removeClass(
@@ -742,7 +741,7 @@ function ppom_set_default_option( field_id ) {
 				const opt_id =
 					product_id + '-' + field.data_name + '-' + options.id;
 
-				const default_checked = field.checked.split( '\r\n' );
+				const default_checked = field.checked?.split( '\r\n' );
 				if ( jQuery.inArray( options.option, default_checked ) > -1 ) {
 					jQuery( '#' + opt_id ).prop( 'checked', true );
 				}

--- a/js/ppom-conditions-v2.js
+++ b/js/ppom-conditions-v2.js
@@ -413,12 +413,21 @@ function ppom_check_conditions( data_name, callback ) {
 					: 'ppom_field_shown';
 			// console.log(`${t} ***** ${element_data_name} total_cond ${total_cond} == matched ${matched} ==> ${matched_conditions[element_data_name]} ==> visibility ${event_type}`);
 
-			if (
-				( matched_conditions[ element_data_name ] > 0 &&
-					binding === 'Any' ) ||
-				( matched_conditions[ element_data_name ] == total_cond &&
-					binding === 'All' )
-			) {
+			if ( matched_conditions[ element_data_name ] > 0 && binding === 'Any' ) {
+				jQuery( `[data-data_name="${ element_data_name }"]` ).removeClass( function( index, className ) {
+					return ( className.match(/\bppom-locked-\S+/g) || []).join(' ');
+				});
+
+				if ( visibility === 'hide' ) {
+					jQuery( this ).addClass( 'ppom-c-hide' ).removeClass( 'ppom-c-show' );
+				} else {
+					jQuery( this ).removeClass( 'ppom-c-hide' );
+				}
+
+				if ( typeof callback === 'function' ) {
+					callback( element_data_name, event_type );
+				}
+			} else if ( matched_conditions[ element_data_name ] == total_cond && binding === 'All') {
 				// remove/add locked classes for all dependent fields
 				cond_elements.forEach( ( cond_dataname ) => {
 					if ( visibility === 'hide' ) {

--- a/tests/e2e/specs/conditions.spec.js
+++ b/tests/e2e/specs/conditions.spec.js
@@ -294,6 +294,99 @@ test.describe( 'Conditions', () => {
 		await expect( output ).toBeVisible();
 	} );
 
+	test( 'free: bound=Any + visibility=Hide removes the target when any rule matches', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		await ensureFreeTier( requestUtils );
+
+		const x1 = { label: 'X1', value: 'x1' };
+		const x2 = { label: 'X2', value: 'x2' };
+		const y1 = { label: 'Y1', value: 'y1' };
+		const y2 = { label: 'Y2', value: 'y2' };
+		const token = uniqueToken();
+		const firstId = `ctrl_a_${ token }`;
+		const secondId = `ctrl_b_${ token }`;
+		const targetId = `target_${ token }`;
+		const product = await createSimpleProduct( requestUtils );
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: `Conditions Hide+Any ${ token }`,
+			fields: [
+				buildSelectField( {
+					title: `Control A ${ token }`,
+					dataName: firstId,
+					options: [ x1, x2 ],
+				} ),
+				buildSelectField( {
+					title: `Control B ${ token }`,
+					dataName: secondId,
+					options: [ y1, y2 ],
+				} ),
+				buildTextField( {
+					title: 'Target field',
+					dataName: targetId,
+					logic: 'on',
+					conditions: {
+						visibility: 'Hide',
+						bound: 'Any',
+						rules: [
+							{
+								elements: firstId,
+								operators: 'is',
+								element_values: x2.label,
+							},
+							{
+								elements: secondId,
+								operators: 'is',
+								element_values: y2.label,
+							},
+						],
+					},
+				} ),
+			],
+		} );
+
+		await attachPpomGroupToProducts( requestUtils, {
+			ppomId,
+			productIds: [ product.id ],
+		} );
+
+		await page.goto( `/?p=${ product.id }` );
+
+		const target = page.getByLabel( 'Target field' );
+		const hiddenField = page.locator( '#conditionally_hidden' );
+
+		// Both controls default to first option → no rules match → target visible.
+		await expect( target ).toBeVisible();
+		await expect( hiddenField ).toHaveValue( '' );
+
+		// Match first rule: Control A = X2 → target should hide.
+		await selectByName( page, firstId ).selectOption( { label: x2.label } );
+		await expect( target ).toBeHidden();
+		await expect( hiddenField ).toHaveValue( targetId );
+
+		// Reset Control A → no rules match → target visible again.
+		await selectByName( page, firstId ).selectOption( { label: x1.label } );
+		await expect( target ).toBeVisible();
+		await expect( hiddenField ).toHaveValue( '' );
+
+		// Match second rule: Control B = Y2 → target should hide.
+		await selectByName( page, secondId ).selectOption( { label: y2.label } );
+		await expect( target ).toBeHidden();
+		await expect( hiddenField ).toHaveValue( targetId );
+
+		// Match both rules: ensure target stays hidden and #conditionally_hidden doesn't duplicate.
+		await selectByName( page, firstId ).selectOption( { label: x2.label } );
+		await expect( target ).toBeHidden();
+		await expect( hiddenField ).toHaveValue( targetId );
+
+		// Reset both → target visible.
+		await selectByName( page, firstId ).selectOption( { label: x1.label } );
+		await selectByName( page, secondId ).selectOption( { label: y1.label } );
+		await expect( target ).toBeVisible();
+		await expect( hiddenField ).toHaveValue( '' );
+	} );
+
 	test( 'free: bound=All only shows when every rule matches', async ( {
 		page,
 		requestUtils,


### PR DESCRIPTION
### Summary
Removed all `ppom-locked-*` classes from the conditional fields when setting the rule for any matches. This will make sure that the fields will be shown when any of the conditions are matched.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/ppom-pro/issues/714