### PR TITLE
fix: prevent double currency conversion when PPOM Pro is active (#638)

### DIFF
--- a/classes/plugin.class.php
+++ b/classes/plugin.class.php
@@ -165,7 +165,7 @@ class NM_PersonalizedProduct {
 		// Show description tooltip.
 		add_filter( 'ppom_field_description', array( $this, 'show_tooltip' ), 15, 2 );
 
-		add_filter( 'ppom_option_price', array( $this, 'ppom_convert_price' ), 99, 1 );
+		$this->maybe_register_option_price_hook();
 	}
 
 	/*
@@ -840,6 +840,23 @@ class NM_PersonalizedProduct {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Register the core ppom_option_price conversion hook only when PPOM Pro
+	 * has not already registered ppom_hooks_convert_price on the same filter.
+	 *
+	 * Called from __construct() on woocommerce_init — after every plugin has
+	 * loaded — so has_filter() reflects the final registration state. Exposed
+	 * as a public method to allow tests to invoke it with a controlled filter
+	 * state without relying on singleton construction timing.
+	 *
+	 * @return void
+	 */
+	public function maybe_register_option_price_hook() {
+		if ( ! has_filter( 'ppom_option_price', 'ppom_hooks_convert_price' ) ) {
+			add_filter( 'ppom_option_price', array( $this, 'ppom_convert_price' ), 99, 1 );
+		}
 	}
 
 	/**

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -11,6 +11,14 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 
+// PHPUnit Polyfills — required by WP test bootstrap (WP 5.9+).
+if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
+	$_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
+	if ( $_polyfills_path ) {
+		define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_polyfills_path );
+	}
+}
+
 if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 	echo "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL;
 	exit( 1 );

--- a/tests/unit/test-option-price-currency-conversion.php
+++ b/tests/unit/test-option-price-currency-conversion.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Regression test for issue #638: ppom_option_price must not be
+ * double-converted when PPOM Pro is also active and registers its own
+ * ppom_hooks_convert_price callback on the same filter.
+ *
+ * Reported symptom: a 145 EUR option appeared as ~8,102 DKK instead of
+ * ~1,084 DKK because the exchange rate (≈7.45) was applied twice — once
+ * by PPOM Pro's hook and once by the core hook added in v34.x.
+ *
+ * @package PPOM
+ */
+class Test_Option_Price_Currency_Conversion extends WP_UnitTestCase {
+
+	/** @var callable|null */
+	private $woocs_filter;
+
+	/** @var NM_PersonalizedProduct */
+	private $ppom;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->ppom = PPOM();
+		// Ensure Core's hook is absent at test start — we control it per-test
+		// via maybe_register_option_price_hook() so each test starts clean.
+		remove_filter( 'ppom_option_price', array( $this->ppom, 'ppom_convert_price' ), 99 );
+	}
+
+	public function tearDown(): void {
+		if ( null !== $this->woocs_filter ) {
+			remove_filter( 'woocs_exchange_value', $this->woocs_filter );
+			$this->woocs_filter = null;
+		}
+		remove_filter( 'ppom_option_price', 'ppom_hooks_convert_price', 99 );
+		remove_filter( 'ppom_option_price', array( $this->ppom, 'ppom_convert_price' ), 99 );
+		parent::tearDown();
+	}
+
+	private function add_woocs_filter( float $rate ): void {
+		$this->woocs_filter = static function ( $price ) use ( $rate ) {
+			return (float) $price * $rate;
+		};
+		add_filter( 'woocs_exchange_value', $this->woocs_filter, 10, 1 );
+	}
+
+	/**
+	 * When Pro's ppom_hooks_convert_price is already on ppom_option_price,
+	 * maybe_register_option_price_hook() must NOT add the core callback —
+	 * preventing the exchange rate from being applied a second time.
+	 */
+	public function test_core_hook_not_registered_when_pro_hook_present() {
+		add_filter( 'ppom_option_price', 'ppom_hooks_convert_price', 99, 1 );
+
+		$this->ppom->maybe_register_option_price_hook();
+
+		$this->assertFalse(
+			has_filter( 'ppom_option_price', array( $this->ppom, 'ppom_convert_price' ) ),
+			'Core ppom_convert_price must not be registered when Pro already has ppom_hooks_convert_price on the filter.'
+		);
+	}
+
+	/**
+	 * When Pro's hook is absent, maybe_register_option_price_hook() must
+	 * add the core callback so standalone installs still convert prices.
+	 */
+	public function test_core_hook_registered_when_pro_hook_absent() {
+		$this->ppom->maybe_register_option_price_hook();
+
+		$this->assertNotFalse(
+			has_filter( 'ppom_option_price', array( $this->ppom, 'ppom_convert_price' ) ),
+			'Core ppom_convert_price must be registered when Pro hook is absent.'
+		);
+	}
+
+	/**
+	 * End-to-end: with Pro's hook present, applying ppom_option_price must
+	 * convert via WOOCS exactly once (not twice as in the v34.x regression).
+	 */
+	public function test_option_price_converted_exactly_once_when_pro_hook_present() {
+		$rate = 7.45;
+		$this->add_woocs_filter( $rate );
+
+		// Pro is active — its hook converts; Core's hook must stay off.
+		add_filter( 'ppom_option_price', 'ppom_hooks_convert_price', 99, 1 );
+		$this->ppom->maybe_register_option_price_hook();
+
+		$result = apply_filters( 'ppom_option_price', 145.0 );
+
+		$this->assertEqualsWithDelta(
+			145.0 * $rate,
+			(float) $result,
+			0.01,
+			sprintf( 'Expected %.2f (one conversion) but got %.2f.', 145.0 * $rate, (float) $result )
+		);
+	}
+
+	/**
+	 * End-to-end: without Pro's hook, Core alone converts via WOOCS once.
+	 */
+	public function test_option_price_converted_exactly_once_when_only_core_hook_present() {
+		$rate = 7.45;
+		$this->add_woocs_filter( $rate );
+
+		$this->ppom->maybe_register_option_price_hook();
+
+		$result = apply_filters( 'ppom_option_price', 145.0 );
+
+		$this->assertEqualsWithDelta(
+			145.0 * $rate,
+			(float) $result,
+			0.01,
+			'Core alone should convert through WOOCS exactly once.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- PPOM Pro registers `ppom_hooks_convert_price` on the `ppom_option_price` filter; core v34.x introduced a second callback (`ppom_convert_price`) on the same filter, causing the exchange rate to be applied twice (e.g. 145 EUR → ~8,102 DKK instead of ~1,084 DKK)
- Extracts the registration into `maybe_register_option_price_hook()`, which skips adding the core callback when Pro's callback is already present
- Adds a regression test suite covering both the guard logic and end-to-end single-conversion behaviour with and without Pro's hook

## Test plan

- [x] Verified fix on staging site (neve.stefancoti.com) — option prices now convert correctly in DKK/NOK/RON
- [x] `test_core_hook_not_registered_when_pro_hook_present` — guard prevents double registration
- [x] `test_core_hook_registered_when_pro_hook_absent` — standalone installs still convert
- [x] `test_option_price_converted_exactly_once_when_pro_hook_present` — 145 EUR → 1,080.25 DKK (not 8,047 DKK)
- [x] `test_option_price_converted_exactly_once_when_only_core_hook_present` — core alone converts correctly
- [x] Existing callbacks test suite passes (7/7)

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)