### PR TITLE
fix: preserve cart quantity when above price-matrix minimum (issue #641)

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -200,7 +200,7 @@ final class Validator {
 
 		$current_input_value = isset( $data['input_value'] ) ? wc_stock_amount( $data['input_value'] ) : 0;
 
-		if ( $limits['input_value'] > 0 ) {
+		if ( $limits['input_value'] > 0 && $current_input_value < $limits['input_value'] ) {
 			$data['input_value'] = wc_stock_amount( $limits['input_value'] );
 		} elseif ( $current_input_value < $data['min_value'] ) {
 			$data['input_value'] = $data['min_value'];

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -11,6 +11,14 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 
+// PHPUnit Polyfills — required by WP test bootstrap (WP 5.9+).
+if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
+	$_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
+	if ( $_polyfills_path ) {
+		define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_polyfills_path );
+	}
+}
+
 if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 	echo "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL;
 	exit( 1 );
@@ -36,6 +44,9 @@ function _register_module() {
 	include_once PPOM_PATH . '/classes/admin.class.php';
 
 	$ppom_admin = new NM_PersonalizedProduct_Admin();
+
+	// Ensure PPOM's custom DB table exists in the test database.
+	PPOM_Meta_Repository::ensure_schema();
 }
 
 tests_add_filter( 'pre_option_active_plugins', '_activate_woocommerce' );

--- a/tests/unit/test-cart-quantity-input-reset.php
+++ b/tests/unit/test-cart-quantity-input-reset.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Regression test for issue #641: cart quantity input must show the actual
+ * cart quantity, not the price-matrix minimum, when a customer has already
+ * added a higher quantity to the classic WooCommerce cart shortcode.
+ *
+ * Root cause: Validator::validation_product_limits() unconditionally overwrote
+ * input_value with limits['input_value'] (the first price-matrix range) even
+ * when WooCommerce passed a higher existing cart quantity in that field.
+ *
+ * @package PPOM
+ */
+
+use PPOM\Validation\Validator;
+
+class Test_Cart_Quantity_Input_Reset extends PPOM_Test_Case {
+
+	/**
+	 * When a product has a price matrix whose first range starts at 12 and the
+	 * customer already has 55 units in the cart, the quantity input must display
+	 * 55 — not reset to 12.
+	 *
+	 * This is the primary regression from issue #641.
+	 */
+	public function test_cart_quantity_input_preserves_higher_cart_quantity_over_price_matrix_minimum() {
+		$product = $this->create_simple_product( array( 'regular_price' => '10' ) );
+
+		$this->insert_ppom_meta(
+			array(
+				$this->build_price_matrix_field(
+					'price_matrix',
+					array(
+						array(
+							'option' => '12-24',
+							'price'  => '9',
+							'label'  => '12–24 units',
+							'id'     => 'range_12_24',
+						),
+						array(
+							'option' => '25-100',
+							'price'  => '8',
+							'label'  => '25–100 units',
+							'id'     => 'range_25_100',
+						),
+					)
+				),
+			),
+			$product->get_id()
+		);
+
+		// WooCommerce passes the current cart quantity as input_value when
+		// rendering the cart-page quantity input.
+		$cart_quantity = 55;
+
+		$result = Validator::validation_product_limits(
+			array(
+				'min_value'   => 1,
+				'max_value'   => 0,
+				'step'        => 1,
+				'input_value' => $cart_quantity,
+			),
+			$product
+		);
+
+		$this->assertSame(
+			$cart_quantity,
+			(int) $result['input_value'],
+			'Cart quantity input should display the actual cart quantity (55), not the price-matrix minimum (12).'
+		);
+	}
+
+	/**
+	 * On the product page (no existing cart quantity), input_value should still
+	 * be initialised to the price-matrix first-range minimum so customers start
+	 * at a valid quantity.
+	 */
+	public function test_product_page_input_value_defaults_to_price_matrix_minimum() {
+		$product = $this->create_simple_product( array( 'regular_price' => '10' ) );
+
+		$this->insert_ppom_meta(
+			array(
+				$this->build_price_matrix_field(
+					'price_matrix',
+					array(
+						array(
+							'option' => '12-24',
+							'price'  => '9',
+							'label'  => '12–24 units',
+							'id'     => 'range_12_24',
+						),
+					)
+				),
+			),
+			$product->get_id()
+		);
+
+		// Product page: WooCommerce passes input_value = 1 (the default).
+		$result = Validator::validation_product_limits(
+			array(
+				'min_value'   => 1,
+				'max_value'   => 0,
+				'step'        => 1,
+				'input_value' => 1,
+			),
+			$product
+		);
+
+		$this->assertSame(
+			12,
+			(int) $result['input_value'],
+			'Product-page quantity input should default to the price-matrix minimum (12) when no higher cart quantity exists.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes cart quantity input resetting to the price-matrix minimum after a customer has selected a higher quantity in the classic WooCommerce cart
- Root cause: `Validator::validation_product_limits()` unconditionally overwrote `input_value` with the first price-matrix range start whenever `limits['input_value'] > 0`
- One-line fix: added `&& $current_input_value < $limits['input_value']` guard so the matrix default only applies when the existing cart quantity is below the minimum

## Test plan

- [x] Add a product with a price matrix (e.g. first range starts at 12)
- [x] Add a quantity above the minimum (e.g. 55) to the cart
- [x] Open the cart page — confirm the quantity input shows 55, not 12
- [x] On the product page, confirm the quantity input defaults to the matrix minimum (12) for a fresh add-to-cart
- [x] Run unit tests: `WP_TESTS_DIR=/private/tmp/wordpress-tests-lib/tests/phpunit WP_TESTS_PHPUNIT_POLYFILLS_PATH=/private/tmp/PHPUnit-Polyfills-2.0.1 phpunit --no-coverage tests/unit/test-cart-quantity-input-reset.php`

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)