### PR TITLE
feat: add TextCounter field with dedicated settings and regression tests

### DIFF
--- a/packages/admin/field-modal/src/definitions/builtinFieldUiDefinitions.ts
+++ b/packages/admin/field-modal/src/definitions/builtinFieldUiDefinitions.ts
@@ -98,6 +98,76 @@ export function textLikeDefinition( slug: string ): FieldUiDefinition {
 	return definition( slug, TEXT_BLOCKS );
 }
 
+const TEXTCOUNTER_BLOCKS: FieldUiDefinition[ 'blocks' ] = [
+	{
+		kind: 'section',
+		id: 'basic',
+		tab: FieldTab.Settings,
+		labelKey: SectionLabelKey.Basic,
+		keys: [ 'title', 'data_name', 'description' ],
+	},
+	{
+		kind: 'section',
+		id: 'field-settings',
+		tab: FieldTab.Settings,
+		labelKey: SectionLabelKey.FieldSettings,
+		keys: [
+			'count_type',
+			'maxlength',
+			'textarea_row',
+			'enable_textinput',
+			'enabled_space',
+			'required',
+		],
+	},
+	{
+		kind: 'section',
+		id: 'pricing',
+		tab: FieldTab.Settings,
+		labelKey: SectionLabelKey.DefaultPrice,
+		keys: [ 'count_price' ],
+	},
+	{
+		kind: 'section',
+		id: 'counter-display',
+		tab: FieldTab.Settings,
+		labelKey: SectionLabelKey.Display,
+		keys: [ 'counter_color', 'counter_bg_color' ],
+		advanced: true,
+	},
+	{
+		kind: 'section',
+		id: 'validation',
+		tab: FieldTab.Settings,
+		labelKey: SectionLabelKey.Validation,
+		keys: [ 'error_message' ],
+		advanced: true,
+	},
+	{
+		kind: 'section',
+		id: 'display',
+		tab: FieldTab.Settings,
+		labelKey: SectionLabelKey.Display,
+		keys: [ 'width', 'visibility', 'visibility_role' ],
+		advanced: true,
+	},
+	{
+		kind: 'section',
+		id: 'behavior',
+		tab: FieldTab.Settings,
+		labelKey: SectionLabelKey.Behavior,
+		keys: [ 'desc_tooltip' ],
+		advanced: true,
+	},
+	{
+		kind: 'section',
+		id: 'conditions',
+		tab: FieldTab.Conditions,
+		labelKey: 'conditionsTab',
+		keys: [ 'logic', 'conditions' ],
+	},
+];
+
 const TEXTAREA_BLOCKS: FieldUiDefinition[ 'blocks' ] = [
 	{
 		kind: 'section',
@@ -1867,7 +1937,7 @@ export function registerBuiltinFieldUiDefinitions(): void {
 		definition( BuiltinFieldType.Text, TEXT_BLOCKS )
 	);
 	registerFieldUiDefinition(
-		definition( BuiltinFieldType.Textcounter, TEXT_BLOCKS )
+		definition( BuiltinFieldType.Textcounter, TEXTCOUNTER_BLOCKS )
 	);
 	registerFieldUiDefinition(
 		definition( BuiltinFieldType.Textarea, TEXTAREA_BLOCKS )

--- a/packages/admin/field-modal/src/definitions/builtinFieldUiDefinitions.ts
+++ b/packages/admin/field-modal/src/definitions/builtinFieldUiDefinitions.ts
@@ -129,14 +129,6 @@ const TEXTCOUNTER_BLOCKS: FieldUiDefinition[ 'blocks' ] = [
 	},
 	{
 		kind: 'section',
-		id: 'counter-display',
-		tab: FieldTab.Settings,
-		labelKey: SectionLabelKey.Display,
-		keys: [ 'counter_color', 'counter_bg_color' ],
-		advanced: true,
-	},
-	{
-		kind: 'section',
 		id: 'validation',
 		tab: FieldTab.Settings,
 		labelKey: SectionLabelKey.Validation,
@@ -148,7 +140,13 @@ const TEXTCOUNTER_BLOCKS: FieldUiDefinition[ 'blocks' ] = [
 		id: 'display',
 		tab: FieldTab.Settings,
 		labelKey: SectionLabelKey.Display,
-		keys: [ 'width', 'visibility', 'visibility_role' ],
+		keys: [
+			'counter_color',
+			'counter_bg_color',
+			'width',
+			'visibility',
+			'visibility_role',
+		],
 		advanced: true,
 	},
 	{

--- a/packages/admin/field-modal/src/definitions/builtinFieldUiSchemas.ts
+++ b/packages/admin/field-modal/src/definitions/builtinFieldUiSchemas.ts
@@ -371,7 +371,7 @@ function textCounterSettings(): SettingSchema {
 			{ col_classes: HALF_WIDTH }
 		),
 		counter_color: setting(
-			'text',
+			'color',
 			__( 'Counter text Color', 'woocommerce-product-addon' ),
 			__(
 				'Add counter box text color',
@@ -380,7 +380,7 @@ function textCounterSettings(): SettingSchema {
 			{ col_classes: HALF_WIDTH }
 		),
 		counter_bg_color: setting(
-			'text',
+			'color',
 			__( 'Counter Background Color', 'woocommerce-product-addon' ),
 			__(
 				'Add counter box background color',

--- a/packages/admin/field-modal/src/definitions/builtinFieldUiSchemas.ts
+++ b/packages/admin/field-modal/src/definitions/builtinFieldUiSchemas.ts
@@ -325,6 +325,97 @@ function textSettings(): SettingSchema {
 	};
 }
 
+function textCounterSettings(): SettingSchema {
+	return {
+		title: titleSetting(),
+		data_name: dataNameSetting(),
+		description: descriptionSetting(),
+		error_message: errorMessageSetting(),
+		count_type: setting(
+			'select',
+			__( 'Count Type', 'woocommerce-product-addon' ),
+			__( 'Select text count type.', 'woocommerce-product-addon' ),
+			{
+				options: {
+					word: __( 'Word', 'woocommerce-product-addon' ),
+					character: __( 'Character', 'woocommerce-product-addon' ),
+				},
+				col_classes: HALF_WIDTH,
+			}
+		),
+		maxlength: setting(
+			'text',
+			__( 'Max. Character/Word', 'woocommerce-product-addon' ),
+			__(
+				'Add Max. character or word limit',
+				'woocommerce-product-addon'
+			),
+			{ col_classes: HALF_WIDTH }
+		),
+		textarea_row: setting(
+			'number',
+			__( 'Textarea Row', 'woocommerce-product-addon' ),
+			__(
+				'Control height of textarea e.g: 3',
+				'woocommerce-product-addon'
+			),
+			{ col_classes: HALF_WIDTH }
+		),
+		count_price: setting(
+			'text',
+			__( 'Character/Word Price', 'woocommerce-product-addon' ),
+			__(
+				'Add per character/word price',
+				'woocommerce-product-addon'
+			),
+			{ col_classes: HALF_WIDTH }
+		),
+		counter_color: setting(
+			'text',
+			__( 'Counter text Color', 'woocommerce-product-addon' ),
+			__(
+				'Add counter box text color',
+				'woocommerce-product-addon'
+			),
+			{ col_classes: HALF_WIDTH }
+		),
+		counter_bg_color: setting(
+			'text',
+			__( 'Counter Background Color', 'woocommerce-product-addon' ),
+			__(
+				'Add counter box background color',
+				'woocommerce-product-addon'
+			),
+			{ col_classes: HALF_WIDTH }
+		),
+		width: widthSetting(),
+		visibility: visibilitySetting(),
+		visibility_role: visibilityRoleSetting(),
+		desc_tooltip: descTooltipSetting(),
+		required: requiredSetting(),
+		enable_textinput: setting(
+			'checkbox',
+			__( 'Enable Text Input', 'woocommerce-product-addon' ),
+			__(
+				'Show text input instead textarea.',
+				'woocommerce-product-addon'
+			),
+			{ col_classes: HALF_WIDTH }
+		),
+		enabled_space: setting(
+			'checkbox',
+			__( 'Include Space', 'woocommerce-product-addon' ),
+			__(
+				'Space count only character type.',
+				'woocommerce-product-addon'
+			),
+			{ col_classes: HALF_WIDTH }
+		),
+		logic: logicSetting(),
+		conditions: conditionsSetting(),
+	};
+}
+
 function textareaSettings(): SettingSchema {
 	return {
 		title: titleSetting(),
@@ -3060,7 +3151,7 @@ function vqmatrixSettings(): SettingSchema {
 
 export const builtinFieldUiSchemas: Record< string, SettingSchema > = {
 	text: textSettings(),
-	textcounter: textSettings(),
+	textcounter: textCounterSettings(),
 	textarea: textareaSettings(),
 	email: emailSettings(),
 	number: numberSettings(),

--- a/tests/e2e/fixtures/fields.js
+++ b/tests/e2e/fixtures/fields.js
@@ -107,6 +107,8 @@ function buildTextCounterField( {
 	textareaRow = '3',
 	countPrice = '',
 	countSpace = '',
+	counterColor = '',
+	counterBgColor = '',
 	...args
 } ) {
 	return buildField( 'textcounter', {
@@ -117,8 +119,8 @@ function buildTextCounterField( {
 		textarea_row: textareaRow,
 		count_price: countPrice,
 		enabled_space: countSpace,
-		counter_color: '',
-		counter_bg_color: '',
+		counter_color: counterColor,
+		counter_bg_color: counterBgColor,
 	} );
 }
 

--- a/tests/e2e/fixtures/fields.js
+++ b/tests/e2e/fixtures/fields.js
@@ -100,6 +100,28 @@ function buildHtmlField( { html = '', ...args } ) {
 	} );
 }
 
+function buildTextCounterField( {
+	countType = 'character',
+	maxlength = '50',
+	enableTextInput = '',
+	textareaRow = '3',
+	countPrice = '',
+	countSpace = '',
+	...args
+} ) {
+	return buildField( 'textcounter', {
+		...args,
+		count_type: countType,
+		maxlength,
+		enable_textinput: enableTextInput,
+		textarea_row: textareaRow,
+		count_price: countPrice,
+		enabled_space: countSpace,
+		counter_color: '',
+		counter_bg_color: '',
+	} );
+}
+
 export {
 	buildCheckboxField,
 	buildImageField,
@@ -110,4 +132,5 @@ export {
 	buildTextareaField,
 	buildFileField,
 	buildHtmlField,
+	buildTextCounterField,
 };

--- a/tests/e2e/fixtures/index.js
+++ b/tests/e2e/fixtures/index.js
@@ -14,6 +14,7 @@ export {
 	buildSelectField,
 	buildTextField,
 	buildTextareaField,
+	buildTextCounterField,
 } from './fields.js';
 export { getPpomLicenseFixture, setPpomLicenseFixture } from './license.js';
 export {

--- a/tests/e2e/specs/react-field-modal-textcounter.spec.js
+++ b/tests/e2e/specs/react-field-modal-textcounter.spec.js
@@ -1,0 +1,153 @@
+/**
+ * Regression test for issue #722: TextCounter field settings were missing
+ * from the React admin field modal because the textcounter slug was
+ * registered with the plain `text` field's schema and block layout instead
+ * of a dedicated definition that includes count_type, count_price,
+ * textarea_row, counter_color, counter_bg_color, enable_textinput, and
+ * enabled_space.
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+import { buildTextCounterField } from '../fixtures/fields.js';
+import { setPpomLicenseFixture } from '../fixtures/license.js';
+import { createPpomGroup } from '../fixtures/ppom.js';
+import { saveFields } from '../utils.js';
+
+async function visitReactModalGroup( admin, ppomId ) {
+	await admin.visitAdminPage(
+		`admin.php?page=ppom&productmeta_id=${ ppomId }&do_meta=edit&ppom_react_modal=1`
+	);
+}
+
+async function openFirstFieldReactModal( page ) {
+	await page.locator( '#ppom_sort_id_1 .ppom-edit-field' ).click();
+	const dialog = page.getByRole( 'dialog' ).first();
+	await expect( dialog ).toBeVisible();
+	return dialog;
+}
+
+async function openAdvancedSettings( dialog ) {
+	const toggle = dialog.getByRole( 'button', { name: /Advanced settings/i } );
+	if ( ( await toggle.count() ) > 0 ) {
+		await toggle.click();
+	}
+}
+
+test.describe( 'React field modal — TextCounter settings (regression #722)', () => {
+	test( 'TextCounter field shows all counter-specific settings in the modal', async ( {
+		page,
+		admin,
+		requestUtils,
+	} ) => {
+		await setPpomLicenseFixture( requestUtils, {
+			valid: true,
+			plan: 1,
+			proInstalled: true,
+		} );
+
+		const suffix = Date.now();
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: `TextCounter React Modal ${ suffix }`,
+			fields: [
+				buildTextCounterField( {
+					title: `Engraving ${ suffix }`,
+					dataName: `engraving_${ suffix }`,
+					countType: 'character',
+					maxlength: '25',
+					countPrice: '2',
+				} ),
+			],
+		} );
+
+		await visitReactModalGroup( admin, ppomId );
+
+		const dialog = await openFirstFieldReactModal( page );
+
+		// --- Field Settings section: count_type + maxlength ---
+		await expect(
+			dialog.getByText( 'Count Type', { exact: true } )
+		).toBeVisible();
+		await expect(
+			dialog.getByText( 'Max. Character/Word', { exact: true } )
+		).toBeVisible();
+		await expect(
+			dialog.getByText( 'Textarea Row', { exact: true } )
+		).toBeVisible();
+
+		// --- Field Settings section: checkboxes ---
+		await expect(
+			dialog.getByText( 'Enable Text Input', { exact: true } )
+		).toBeVisible();
+		await expect(
+			dialog.getByText( 'Include Space', { exact: true } )
+		).toBeVisible();
+
+		// --- Pricing section: count_price ---
+		await expect(
+			dialog.getByText( 'Character/Word Price', { exact: true } )
+		).toBeVisible();
+
+		// The count_price input should reflect the saved value.
+		await expect(
+			dialog.getByLabel( 'Character/Word Price' )
+		).toHaveValue( '2' );
+
+		// --- Advanced: counter colors ---
+		await openAdvancedSettings( dialog );
+
+		await expect(
+			dialog.getByText( 'Counter text Color', { exact: true } )
+		).toBeVisible();
+		await expect(
+			dialog.getByText( 'Counter Background Color', { exact: true } )
+		).toBeVisible();
+	} );
+
+	test( 'editing count_price in the React modal persists through classic save', async ( {
+		page,
+		admin,
+		requestUtils,
+	} ) => {
+		await setPpomLicenseFixture( requestUtils, {
+			valid: true,
+			plan: 1,
+			proInstalled: true,
+		} );
+
+		const suffix = Date.now();
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: `TextCounter Persist ${ suffix }`,
+			fields: [
+				buildTextCounterField( {
+					title: `Persist ${ suffix }`,
+					dataName: `persist_${ suffix }`,
+					countType: 'character',
+					maxlength: '30',
+					countPrice: '1',
+				} ),
+			],
+		} );
+
+		await visitReactModalGroup( admin, ppomId );
+
+		let dialog = await openFirstFieldReactModal( page );
+
+		// Change the per-character price.
+		await dialog.getByLabel( 'Character/Word Price' ).fill( '5' );
+		await dialog.getByRole( 'button', { name: 'Update Field' } ).click();
+		await expect( dialog ).toBeHidden();
+
+		// Persist via the classic Save Fields button.
+		page.once( 'dialog', ( browserDialog ) => browserDialog.accept() );
+		const reloaded = page.waitForEvent( 'load' );
+		await saveFields( page );
+		await reloaded;
+
+		// Re-open the modal and verify the value persisted.
+		await visitReactModalGroup( admin, ppomId );
+		dialog = await openFirstFieldReactModal( page );
+		await expect(
+			dialog.getByLabel( 'Character/Word Price' )
+		).toHaveValue( '5' );
+	} );
+} );


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Add a missing field for Text Counter

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

<img width="2418" height="1840" alt="CleanShot 2026-06-23 at 13 04 44@2x" src="https://github.com/user-attachments/assets/8ea258bf-b144-48f3-8cdf-2f255cf68fc7" />


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check the missing fields.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/ppom-pro/issues/722
<!-- Should look like this: `Closes #1, #2, #3.` . -->
