### PR TITLE
Release

### DIFF
--- a/classes/plugin.class.php
+++ b/classes/plugin.class.php
@@ -165,7 +165,7 @@ class NM_PersonalizedProduct {
 		// Show description tooltip.
 		add_filter( 'ppom_field_description', array( $this, 'show_tooltip' ), 15, 2 );
 
-		add_filter( 'ppom_option_price', array( $this, 'ppom_convert_price' ), 99, 1 );
+		$this->maybe_register_option_price_hook();
 	}
 
 	/*
@@ -840,6 +840,23 @@ class NM_PersonalizedProduct {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Register the core ppom_option_price conversion hook only when PPOM Pro
+	 * has not already registered ppom_hooks_convert_price on the same filter.
+	 *
+	 * Called from __construct() on woocommerce_init — after every plugin has
+	 * loaded — so has_filter() reflects the final registration state. Exposed
+	 * as a public method to allow tests to invoke it with a controlled filter
+	 * state without relying on singleton construction timing.
+	 *
+	 * @return void
+	 */
+	public function maybe_register_option_price_hook() {
+		if ( ! has_filter( 'ppom_option_price', 'ppom_hooks_convert_price' ) ) {
+			add_filter( 'ppom_option_price', array( $this, 'ppom_convert_price' ), 99, 1 );
+		}
 	}
 
 	/**

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.3.52",
+            "version": "3.3.53",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "d1ae68cbd4f84934b4d982e9eeff317b9f4c814a"
+                "reference": "a657eaedf62cc84c82e539167ac9e19b3e618ce8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/d1ae68cbd4f84934b4d982e9eeff317b9f4c814a",
-                "reference": "d1ae68cbd4f84934b4d982e9eeff317b9f4c814a",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/a657eaedf62cc84c82e539167ac9e19b3e618ce8",
+                "reference": "a657eaedf62cc84c82e539167ac9e19b3e618ce8",
                 "shasum": ""
             },
             "require-dev": {
@@ -43,9 +43,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.52"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.3.53"
             },
-            "time": "2026-05-14T19:43:56+00:00"
+            "time": "2026-06-18T07:32:53+00:00"
         }
     ],
     "packages-dev": [

--- a/packages/admin/field-modal/src/FieldTypePicker.tsx
+++ b/packages/admin/field-modal/src/FieldTypePicker.tsx
@@ -213,7 +213,7 @@ export function FieldTypePicker( {
 				pt={ { base: 2, lg: 0 } }
 				h={ { lg: 'full' } }
 				minH={ 0 }
-				overflow={ { lg: 'hidden' } }
+				overflow={ { lg: 'auto' } }
 				css={ {
 					overflowWrap: 'anywhere',
 					wordBreak: 'break-word',

--- a/packages/admin/field-modal/src/definitions/builtinFieldUiDefinitions.ts
+++ b/packages/admin/field-modal/src/definitions/builtinFieldUiDefinitions.ts
@@ -98,6 +98,74 @@ export function textLikeDefinition( slug: string ): FieldUiDefinition {
 	return definition( slug, TEXT_BLOCKS );
 }
 
+const TEXTCOUNTER_BLOCKS: FieldUiDefinition[ 'blocks' ] = [
+	{
+		kind: 'section',
+		id: 'basic',
+		tab: FieldTab.Settings,
+		labelKey: SectionLabelKey.Basic,
+		keys: [ 'title', 'data_name', 'description' ],
+	},
+	{
+		kind: 'section',
+		id: 'field-settings',
+		tab: FieldTab.Settings,
+		labelKey: SectionLabelKey.FieldSettings,
+		keys: [
+			'count_type',
+			'maxlength',
+			'textarea_row',
+			'enable_textinput',
+			'enabled_space',
+			'required',
+		],
+	},
+	{
+		kind: 'section',
+		id: 'pricing',
+		tab: FieldTab.Settings,
+		labelKey: SectionLabelKey.DefaultPrice,
+		keys: [ 'count_price' ],
+	},
+	{
+		kind: 'section',
+		id: 'validation',
+		tab: FieldTab.Settings,
+		labelKey: SectionLabelKey.Validation,
+		keys: [ 'error_message' ],
+		advanced: true,
+	},
+	{
+		kind: 'section',
+		id: 'display',
+		tab: FieldTab.Settings,
+		labelKey: SectionLabelKey.Display,
+		keys: [
+			'counter_color',
+			'counter_bg_color',
+			'width',
+			'visibility',
+			'visibility_role',
+		],
+		advanced: true,
+	},
+	{
+		kind: 'section',
+		id: 'behavior',
+		tab: FieldTab.Settings,
+		labelKey: SectionLabelKey.Behavior,
+		keys: [ 'desc_tooltip' ],
+		advanced: true,
+	},
+	{
+		kind: 'section',
+		id: 'conditions',
+		tab: FieldTab.Conditions,
+		labelKey: 'conditionsTab',
+		keys: [ 'logic', 'conditions' ],
+	},
+];
+
 const TEXTAREA_BLOCKS: FieldUiDefinition[ 'blocks' ] = [
 	{
 		kind: 'section',
@@ -1867,7 +1935,7 @@ export function registerBuiltinFieldUiDefinitions(): void {
 		definition( BuiltinFieldType.Text, TEXT_BLOCKS )
 	);
 	registerFieldUiDefinition(
-		definition( BuiltinFieldType.Textcounter, TEXT_BLOCKS )
+		definition( BuiltinFieldType.Textcounter, TEXTCOUNTER_BLOCKS )
 	);
 	registerFieldUiDefinition(
 		definition( BuiltinFieldType.Textarea, TEXTAREA_BLOCKS )

--- a/packages/admin/field-modal/src/definitions/builtinFieldUiSchemas.ts
+++ b/packages/admin/field-modal/src/definitions/builtinFieldUiSchemas.ts
@@ -325,6 +325,97 @@ function textSettings(): SettingSchema {
 	};
 }
 
+function textCounterSettings(): SettingSchema {
+	return {
+		title: titleSetting(),
+		data_name: dataNameSetting(),
+		description: descriptionSetting(),
+		error_message: errorMessageSetting(),
+		count_type: setting(
+			'select',
+			__( 'Count Type', 'woocommerce-product-addon' ),
+			__( 'Select text count type.', 'woocommerce-product-addon' ),
+			{
+				options: {
+					word: __( 'Word', 'woocommerce-product-addon' ),
+					character: __( 'Character', 'woocommerce-product-addon' ),
+				},
+				col_classes: HALF_WIDTH,
+			}
+		),
+		maxlength: setting(
+			'text',
+			__( 'Max. Character/Word', 'woocommerce-product-addon' ),
+			__(
+				'Add Max. character or word limit',
+				'woocommerce-product-addon'
+			),
+			{ col_classes: HALF_WIDTH }
+		),
+		textarea_row: setting(
+			'number',
+			__( 'Textarea Row', 'woocommerce-product-addon' ),
+			__(
+				'Control height of textarea e.g: 3',
+				'woocommerce-product-addon'
+			),
+			{ col_classes: HALF_WIDTH }
+		),
+		count_price: setting(
+			'text',
+			__( 'Character/Word Price', 'woocommerce-product-addon' ),
+			__(
+				'Add per character/word price',
+				'woocommerce-product-addon'
+			),
+			{ col_classes: HALF_WIDTH }
+		),
+		counter_color: setting(
+			'color',
+			__( 'Counter text Color', 'woocommerce-product-addon' ),
+			__(
+				'Add counter box text color',
+				'woocommerce-product-addon'
+			),
+			{ col_classes: HALF_WIDTH }
+		),
+		counter_bg_color: setting(
+			'color',
+			__( 'Counter Background Color', 'woocommerce-product-addon' ),
+			__(
+				'Add counter box background color',
+				'woocommerce-product-addon'
+			),
+			{ col_classes: HALF_WIDTH }
+		),
+		width: widthSetting(),
+		visibility: visibilitySetting(),
+		visibility_role: visibilityRoleSetting(),
+		desc_tooltip: descTooltipSetting(),
+		required: requiredSetting(),
+		enable_textinput: setting(
+			'checkbox',
+			__( 'Enable Text Input', 'woocommerce-product-addon' ),
+			__(
+				'Show text input instead textarea.',
+				'woocommerce-product-addon'
+			),
+			{ col_classes: HALF_WIDTH }
+		),
+		enabled_space: setting(
+			'checkbox',
+			__( 'Include Space', 'woocommerce-product-addon' ),
+			__(
+				'Space count only character type.',
+				'woocommerce-product-addon'
+			),
+			{ col_classes: HALF_WIDTH }
+		),
+		logic: logicSetting(),
+		conditions: conditionsSetting(),
+	};
+}
+
 function textareaSettings(): SettingSchema {
 	return {
 		title: titleSetting(),
@@ -3060,7 +3151,7 @@ function vqmatrixSettings(): SettingSchema {
 
 export const builtinFieldUiSchemas: Record< string, SettingSchema > = {
 	text: textSettings(),
-	textcounter: textSettings(),
+	textcounter: textCounterSettings(),
 	textarea: textareaSettings(),
 	email: emailSettings(),
 	number: numberSettings(),

--- a/src/Pricing/Engine.php
+++ b/src/Pricing/Engine.php
@@ -1397,7 +1397,7 @@ final class Engine {
 
 					// if wc prices include tax: substract the tax from additional fixed fee since already WC will add tax.
 					if ( wc_prices_include_tax() ) {
-						$tax = WC_Tax::calc_tax( $fee_price, \WC_Tax::get_rates( $tax_class ), true );
+						$tax = \WC_Tax::calc_tax( $fee_price, \WC_Tax::get_rates( $tax_class ), true );
 
 						$total_tax = array_sum( $tax );
 						$fee_price = $fee_price - $total_tax;

--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -200,7 +200,7 @@ final class Validator {
 
 		$current_input_value = isset( $data['input_value'] ) ? wc_stock_amount( $data['input_value'] ) : 0;
 
-		if ( $limits['input_value'] > 0 ) {
+		if ( $limits['input_value'] > 0 && $current_input_value < $limits['input_value'] ) {
 			$data['input_value'] = wc_stock_amount( $limits['input_value'] );
 		} elseif ( $current_input_value < $data['min_value'] ) {
 			$data['input_value'] = $data['min_value'];

--- a/src/WooCommerce/Cart/CartHandler.php
+++ b/src/WooCommerce/Cart/CartHandler.php
@@ -671,6 +671,10 @@ final class CartHandler {
 				$meta_value = wp_json_encode( $meta_value );
 			}
 
+			if ( ! is_scalar( $display ) ) {
+				$display = wp_json_encode( $display );
+			}
+
 			if ( apply_filters( 'ppom_show_option_price_cart', false ) && isset( $meta['price'] ) ) {
 				$meta_value .= ' (' . wc_price( $meta['price'] ) . ')';
 			}

--- a/tests/e2e/fixtures/fields.js
+++ b/tests/e2e/fixtures/fields.js
@@ -100,6 +100,30 @@ function buildHtmlField( { html = '', ...args } ) {
 	} );
 }
 
+function buildTextCounterField( {
+	countType = 'character',
+	maxlength = '50',
+	enableTextInput = '',
+	textareaRow = '3',
+	countPrice = '',
+	countSpace = '',
+	counterColor = '',
+	counterBgColor = '',
+	...args
+} ) {
+	return buildField( 'textcounter', {
+		...args,
+		count_type: countType,
+		maxlength,
+		enable_textinput: enableTextInput,
+		textarea_row: textareaRow,
+		count_price: countPrice,
+		enabled_space: countSpace,
+		counter_color: counterColor,
+		counter_bg_color: counterBgColor,
+	} );
+}
+
 export {
 	buildCheckboxField,
 	buildImageField,
@@ -110,4 +134,5 @@ export {
 	buildTextareaField,
 	buildFileField,
 	buildHtmlField,
+	buildTextCounterField,
 };

--- a/tests/e2e/fixtures/index.js
+++ b/tests/e2e/fixtures/index.js
@@ -14,6 +14,7 @@ export {
 	buildSelectField,
 	buildTextField,
 	buildTextareaField,
+	buildTextCounterField,
 } from './fields.js';
 export { getPpomLicenseFixture, setPpomLicenseFixture } from './license.js';
 export {

--- a/tests/e2e/specs/react-field-modal-textcounter.spec.js
+++ b/tests/e2e/specs/react-field-modal-textcounter.spec.js
@@ -1,0 +1,153 @@
+/**
+ * Regression test for issue #722: TextCounter field settings were missing
+ * from the React admin field modal because the textcounter slug was
+ * registered with the plain `text` field's schema and block layout instead
+ * of a dedicated definition that includes count_type, count_price,
+ * textarea_row, counter_color, counter_bg_color, enable_textinput, and
+ * enabled_space.
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+import { buildTextCounterField } from '../fixtures/fields.js';
+import { setPpomLicenseFixture } from '../fixtures/license.js';
+import { createPpomGroup } from '../fixtures/ppom.js';
+import { saveFields } from '../utils.js';
+
+async function visitReactModalGroup( admin, ppomId ) {
+	await admin.visitAdminPage(
+		`admin.php?page=ppom&productmeta_id=${ ppomId }&do_meta=edit&ppom_react_modal=1`
+	);
+}
+
+async function openFirstFieldReactModal( page ) {
+	await page.locator( '#ppom_sort_id_1 .ppom-edit-field' ).click();
+	const dialog = page.getByRole( 'dialog' ).first();
+	await expect( dialog ).toBeVisible();
+	return dialog;
+}
+
+async function openAdvancedSettings( dialog ) {
+	const toggle = dialog.getByRole( 'button', { name: /Advanced settings/i } );
+	if ( ( await toggle.count() ) > 0 ) {
+		await toggle.click();
+	}
+}
+
+test.describe( 'React field modal — TextCounter settings (regression #722)', () => {
+	test( 'TextCounter field shows all counter-specific settings in the modal', async ( {
+		page,
+		admin,
+		requestUtils,
+	} ) => {
+		await setPpomLicenseFixture( requestUtils, {
+			valid: true,
+			plan: 1,
+			proInstalled: true,
+		} );
+
+		const suffix = Date.now();
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: `TextCounter React Modal ${ suffix }`,
+			fields: [
+				buildTextCounterField( {
+					title: `Engraving ${ suffix }`,
+					dataName: `engraving_${ suffix }`,
+					countType: 'character',
+					maxlength: '25',
+					countPrice: '2',
+				} ),
+			],
+		} );
+
+		await visitReactModalGroup( admin, ppomId );
+
+		const dialog = await openFirstFieldReactModal( page );
+
+		// --- Field Settings section: count_type + maxlength ---
+		await expect(
+			dialog.getByText( 'Count Type', { exact: true } )
+		).toBeVisible();
+		await expect(
+			dialog.getByText( 'Max. Character/Word', { exact: true } )
+		).toBeVisible();
+		await expect(
+			dialog.getByText( 'Textarea Row', { exact: true } )
+		).toBeVisible();
+
+		// --- Field Settings section: checkboxes ---
+		await expect(
+			dialog.getByText( 'Enable Text Input', { exact: true } )
+		).toBeVisible();
+		await expect(
+			dialog.getByText( 'Include Space', { exact: true } )
+		).toBeVisible();
+
+		// --- Pricing section: count_price ---
+		await expect(
+			dialog.getByText( 'Character/Word Price', { exact: true } )
+		).toBeVisible();
+
+		// The count_price input should reflect the saved value.
+		await expect(
+			dialog.getByLabel( 'Character/Word Price' )
+		).toHaveValue( '2' );
+
+		// --- Advanced: counter colors ---
+		await openAdvancedSettings( dialog );
+
+		await expect(
+			dialog.getByText( 'Counter text Color', { exact: true } )
+		).toBeVisible();
+		await expect(
+			dialog.getByText( 'Counter Background Color', { exact: true } )
+		).toBeVisible();
+	} );
+
+	test( 'editing count_price in the React modal persists through classic save', async ( {
+		page,
+		admin,
+		requestUtils,
+	} ) => {
+		await setPpomLicenseFixture( requestUtils, {
+			valid: true,
+			plan: 1,
+			proInstalled: true,
+		} );
+
+		const suffix = Date.now();
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: `TextCounter Persist ${ suffix }`,
+			fields: [
+				buildTextCounterField( {
+					title: `Persist ${ suffix }`,
+					dataName: `persist_${ suffix }`,
+					countType: 'character',
+					maxlength: '30',
+					countPrice: '1',
+				} ),
+			],
+		} );
+
+		await visitReactModalGroup( admin, ppomId );
+
+		let dialog = await openFirstFieldReactModal( page );
+
+		// Change the per-character price.
+		await dialog.getByLabel( 'Character/Word Price' ).fill( '5' );
+		await dialog.getByRole( 'button', { name: 'Update Field' } ).click();
+		await expect( dialog ).toBeHidden();
+
+		// Persist via the classic Save Fields button.
+		page.once( 'dialog', ( browserDialog ) => browserDialog.accept() );
+		const reloaded = page.waitForEvent( 'load' );
+		await saveFields( page );
+		await reloaded;
+
+		// Re-open the modal and verify the value persisted.
+		await visitReactModalGroup( admin, ppomId );
+		dialog = await openFirstFieldReactModal( page );
+		await expect(
+			dialog.getByLabel( 'Character/Word Price' )
+		).toHaveValue( '5' );
+	} );
+} );

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -11,6 +11,14 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 
+// PHPUnit Polyfills — required by WP test bootstrap (WP 5.9+).
+if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
+	$_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
+	if ( $_polyfills_path ) {
+		define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_polyfills_path );
+	}
+}
+
 if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 	echo "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL;
 	exit( 1 );

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -11,6 +11,14 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
 }
 
+// PHPUnit Polyfills — required by WP test bootstrap (WP 5.9+).
+if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
+	$_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
+	if ( $_polyfills_path ) {
+		define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_polyfills_path );
+	}
+}
+
 if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 	echo "Could not find $_tests_dir/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL;
 	exit( 1 );
@@ -36,6 +44,9 @@ function _register_module() {
 	include_once PPOM_PATH . '/classes/admin.class.php';
 
 	$ppom_admin = new NM_PersonalizedProduct_Admin();
+
+	// Ensure PPOM's custom DB table exists in the test database.
+	PPOM_Meta_Repository::ensure_schema();
 }
 
 tests_add_filter( 'pre_option_active_plugins', '_activate_woocommerce' );

--- a/tests/unit/src/Pricing/test-modern-cart-fee-applicator.php
+++ b/tests/unit/src/Pricing/test-modern-cart-fee-applicator.php
@@ -208,6 +208,8 @@ class Test_Pricing_ModernCartFeeApplicator extends PPOM_Test_Case {
 	 * Regression for #630: Engine::price_cart_fee must not fatally resolve
 	 * WooCommerce tax classes inside PPOM\Pricing namespace.
 	 *
+	 * @covers \PPOM\Pricing\Engine::price_cart_fee
+	 *
 	 * @return void
 	 */
 	public function test_engine_cart_fee_with_tax_inclusive_prices_does_not_fatal() {

--- a/tests/unit/src/Pricing/test-modern-cart-fee-applicator.php
+++ b/tests/unit/src/Pricing/test-modern-cart-fee-applicator.php
@@ -251,6 +251,10 @@ class Test_Pricing_ModernCartFeeApplicator extends PPOM_Test_Case {
 
 		$fees = WC()->cart->get_fees();
 		$this->assertCount( 1, $fees );
-		$this->assertEqualsWithDelta( 7.0, (float) reset( $fees )->amount, 0.0001 );
+
+		$tax_class    = $product->get_tax_class( 'unfiltered' );
+		$expected_tax = \WC_Tax::calc_tax( 7.0, \WC_Tax::get_rates( $tax_class ), true );
+		$expected_fee = 7.0 - array_sum( $expected_tax );
+		$this->assertEqualsWithDelta( $expected_fee, (float) reset( $fees )->amount, 0.0001 );
 	}
 }

--- a/tests/unit/src/Pricing/test-modern-cart-fee-applicator.php
+++ b/tests/unit/src/Pricing/test-modern-cart-fee-applicator.php
@@ -12,6 +12,7 @@
 require_once dirname( __DIR__, 2 ) . '/class-ppom-test-case.php';
 
 use PPOM\Pricing\ModernCartFeeApplicator;
+use PPOM\Pricing\Engine;
 
 /**
  * @covers \PPOM\Pricing\ModernCartFeeApplicator
@@ -201,5 +202,53 @@ class Test_Pricing_ModernCartFeeApplicator extends PPOM_Test_Case {
 		$fees = WC()->cart->get_fees();
 		$this->assertCount( 1, $fees );
 		$this->assertEqualsWithDelta( 99.0, (float) reset( $fees )->amount, 0.0001 );
+	}
+
+	/**
+	 * Regression for #630: Engine::price_cart_fee must not fatally resolve
+	 * WooCommerce tax classes inside PPOM\Pricing namespace.
+	 *
+	 * @return void
+	 */
+	public function test_engine_cart_fee_with_tax_inclusive_prices_does_not_fatal() {
+		$product = $this->create_simple_product( array( 'regular_price' => '10', 'virtual' => true ) );
+
+		$this->insert_ppom_meta(
+			array(
+				$this->build_select_field(
+					'gift_wrap',
+					'Gift Wrap',
+					array( array( 'option' => 'Premium box', 'price' => '7' ) ),
+					array( 'onetime' => 'on' )
+				),
+			),
+			$product->get_id()
+		);
+
+		$this->initialize_woocommerce_checkout_context();
+		$cart_key = $this->add_product_to_real_cart(
+			$product->get_id(),
+			array( 'fields' => array( 'gift_wrap' => 'Premium box' ) )
+		);
+		$this->assertNotFalse( $cart_key );
+
+		$original_prices_include_tax = get_option( 'woocommerce_prices_include_tax' );
+		$original_calc_taxes         = get_option( 'woocommerce_calc_taxes' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_prices_include_tax', 'yes' );
+
+		try {
+			$this->reload_real_cart_from_session();
+			WC()->cart->fees_api()->remove_all_fees();
+
+			Engine::price_cart_fee( WC()->cart );
+		} finally {
+			update_option( 'woocommerce_prices_include_tax', $original_prices_include_tax );
+			update_option( 'woocommerce_calc_taxes', $original_calc_taxes );
+		}
+
+		$fees = WC()->cart->get_fees();
+		$this->assertCount( 1, $fees );
+		$this->assertEqualsWithDelta( 7.0, (float) reset( $fees )->amount, 0.0001 );
 	}
 }

--- a/tests/unit/src/WooCommerce/test-cart-handler.php
+++ b/tests/unit/src/WooCommerce/test-cart-handler.php
@@ -694,6 +694,31 @@ class Test_Cart_Handler extends PPOM_Test_Case {
 	}
 
 	/**
+	 * Non-scalar fallback display values must be serialised so WooCommerce cart
+	 * rendering receives a string-safe `display` value on PHP 8.1+.
+	 *
+	 * @return void
+	 */
+	public function test_convert_ppom_meta_entry_to_item_meta_row_display_fallback_json_encodes_non_scalar_value() {
+		$nested = array(
+			'first'  => 'One',
+			'second' => array( 'Two' ),
+		);
+
+		$row = CartHandler::convert_ppom_meta_entry_to_item_meta_row(
+			'matrix_field',
+			array(
+				'name'  => 'Matrix',
+				'value' => $nested,
+				'type'  => 'text',
+			)
+		);
+
+		$this->assertIsArray( $row );
+		$this->assertSame( wp_json_encode( $nested ), $row['display'] );
+	}
+
+	/**
 	 * Empty array entries (`make_meta_data()` produces these for cropper /
 	 * image rows whose value is empty in cart context) must not crash and
 	 * must produce a fall-through row keyed by the cart key — preserving

--- a/tests/unit/test-cart-quantity-input-reset.php
+++ b/tests/unit/test-cart-quantity-input-reset.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Regression test for issue #641: cart quantity input must show the actual
+ * cart quantity, not the price-matrix minimum, when a customer has already
+ * added a higher quantity to the classic WooCommerce cart shortcode.
+ *
+ * Root cause: Validator::validation_product_limits() unconditionally overwrote
+ * input_value with limits['input_value'] (the first price-matrix range) even
+ * when WooCommerce passed a higher existing cart quantity in that field.
+ *
+ * @package PPOM
+ */
+
+use PPOM\Validation\Validator;
+
+class Test_Cart_Quantity_Input_Reset extends PPOM_Test_Case {
+
+	/**
+	 * When a product has a price matrix whose first range starts at 12 and the
+	 * customer already has 55 units in the cart, the quantity input must display
+	 * 55 — not reset to 12.
+	 *
+	 * This is the primary regression from issue #641.
+	 */
+	public function test_cart_quantity_input_preserves_higher_cart_quantity_over_price_matrix_minimum() {
+		$product = $this->create_simple_product( array( 'regular_price' => '10' ) );
+
+		$this->insert_ppom_meta(
+			array(
+				$this->build_price_matrix_field(
+					'price_matrix',
+					array(
+						array(
+							'option' => '12-24',
+							'price'  => '9',
+							'label'  => '12–24 units',
+							'id'     => 'range_12_24',
+						),
+						array(
+							'option' => '25-100',
+							'price'  => '8',
+							'label'  => '25–100 units',
+							'id'     => 'range_25_100',
+						),
+					)
+				),
+			),
+			$product->get_id()
+		);
+
+		// WooCommerce passes the current cart quantity as input_value when
+		// rendering the cart-page quantity input.
+		$cart_quantity = 55;
+
+		$result = Validator::validation_product_limits(
+			array(
+				'min_value'   => 1,
+				'max_value'   => 0,
+				'step'        => 1,
+				'input_value' => $cart_quantity,
+			),
+			$product
+		);
+
+		$this->assertSame(
+			$cart_quantity,
+			(int) $result['input_value'],
+			'Cart quantity input should display the actual cart quantity (55), not the price-matrix minimum (12).'
+		);
+	}
+
+	/**
+	 * On the product page (no existing cart quantity), input_value should still
+	 * be initialised to the price-matrix first-range minimum so customers start
+	 * at a valid quantity.
+	 */
+	public function test_product_page_input_value_defaults_to_price_matrix_minimum() {
+		$product = $this->create_simple_product( array( 'regular_price' => '10' ) );
+
+		$this->insert_ppom_meta(
+			array(
+				$this->build_price_matrix_field(
+					'price_matrix',
+					array(
+						array(
+							'option' => '12-24',
+							'price'  => '9',
+							'label'  => '12–24 units',
+							'id'     => 'range_12_24',
+						),
+					)
+				),
+			),
+			$product->get_id()
+		);
+
+		// Product page: WooCommerce passes input_value = 1 (the default).
+		$result = Validator::validation_product_limits(
+			array(
+				'min_value'   => 1,
+				'max_value'   => 0,
+				'step'        => 1,
+				'input_value' => 1,
+			),
+			$product
+		);
+
+		$this->assertSame(
+			12,
+			(int) $result['input_value'],
+			'Product-page quantity input should default to the price-matrix minimum (12) when no higher cart quantity exists.'
+		);
+	}
+}

--- a/tests/unit/test-option-price-currency-conversion.php
+++ b/tests/unit/test-option-price-currency-conversion.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Regression test for issue #638: ppom_option_price must not be
+ * double-converted when PPOM Pro is also active and registers its own
+ * ppom_hooks_convert_price callback on the same filter.
+ *
+ * Reported symptom: a 145 EUR option appeared as ~8,102 DKK instead of
+ * ~1,084 DKK because the exchange rate (≈7.45) was applied twice — once
+ * by PPOM Pro's hook and once by the core hook added in v34.x.
+ *
+ * @package PPOM
+ */
+class Test_Option_Price_Currency_Conversion extends WP_UnitTestCase {
+
+	/** @var callable|null */
+	private $woocs_filter;
+
+	/** @var NM_PersonalizedProduct */
+	private $ppom;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->ppom = PPOM();
+		// Ensure Core's hook is absent at test start — we control it per-test
+		// via maybe_register_option_price_hook() so each test starts clean.
+		remove_filter( 'ppom_option_price', array( $this->ppom, 'ppom_convert_price' ), 99 );
+	}
+
+	public function tearDown(): void {
+		if ( null !== $this->woocs_filter ) {
+			remove_filter( 'woocs_exchange_value', $this->woocs_filter );
+			$this->woocs_filter = null;
+		}
+		remove_filter( 'ppom_option_price', 'ppom_hooks_convert_price', 99 );
+		remove_filter( 'ppom_option_price', array( $this->ppom, 'ppom_convert_price' ), 99 );
+		parent::tearDown();
+	}
+
+	private function add_woocs_filter( float $rate ): void {
+		$this->woocs_filter = static function ( $price ) use ( $rate ) {
+			return (float) $price * $rate;
+		};
+		add_filter( 'woocs_exchange_value', $this->woocs_filter, 10, 1 );
+	}
+
+	/**
+	 * When Pro's ppom_hooks_convert_price is already on ppom_option_price,
+	 * maybe_register_option_price_hook() must NOT add the core callback —
+	 * preventing the exchange rate from being applied a second time.
+	 */
+	public function test_core_hook_not_registered_when_pro_hook_present() {
+		add_filter( 'ppom_option_price', 'ppom_hooks_convert_price', 99, 1 );
+
+		$this->ppom->maybe_register_option_price_hook();
+
+		$this->assertFalse(
+			has_filter( 'ppom_option_price', array( $this->ppom, 'ppom_convert_price' ) ),
+			'Core ppom_convert_price must not be registered when Pro already has ppom_hooks_convert_price on the filter.'
+		);
+	}
+
+	/**
+	 * When Pro's hook is absent, maybe_register_option_price_hook() must
+	 * add the core callback so standalone installs still convert prices.
+	 */
+	public function test_core_hook_registered_when_pro_hook_absent() {
+		$this->ppom->maybe_register_option_price_hook();
+
+		$this->assertNotFalse(
+			has_filter( 'ppom_option_price', array( $this->ppom, 'ppom_convert_price' ) ),
+			'Core ppom_convert_price must be registered when Pro hook is absent.'
+		);
+	}
+
+	/**
+	 * End-to-end: with Pro's hook present, applying ppom_option_price must
+	 * convert via WOOCS exactly once (not twice as in the v34.x regression).
+	 */
+	public function test_option_price_converted_exactly_once_when_pro_hook_present() {
+		$rate = 7.45;
+		$this->add_woocs_filter( $rate );
+
+		// Pro is active — its hook converts; Core's hook must stay off.
+		add_filter( 'ppom_option_price', 'ppom_hooks_convert_price', 99, 1 );
+		$this->ppom->maybe_register_option_price_hook();
+
+		$result = apply_filters( 'ppom_option_price', 145.0 );
+
+		$this->assertEqualsWithDelta(
+			145.0 * $rate,
+			(float) $result,
+			0.01,
+			sprintf( 'Expected %.2f (one conversion) but got %.2f.', 145.0 * $rate, (float) $result )
+		);
+	}
+
+	/**
+	 * End-to-end: without Pro's hook, Core alone converts via WOOCS once.
+	 */
+	public function test_option_price_converted_exactly_once_when_only_core_hook_present() {
+		$rate = 7.45;
+		$this->add_woocs_filter( $rate );
+
+		$this->ppom->maybe_register_option_price_hook();
+
+		$result = apply_filters( 'ppom_option_price', 145.0 );
+
+		$this->assertEqualsWithDelta(
+			145.0 * $rate,
+			(float) $result,
+			0.01,
+			'Core alone should convert through WOOCS exactly once.'
+		);
+	}
+}


### PR DESCRIPTION
- Prevent fatal WC_Tax lookup in tax-inclusive cart-fee recalculation
- Fixed field picker sidebar responsiveness
- Fixed issue with PHP 8.1 when PPOM cart item display receives an array causing error
- Fixed issue to prevent double currency conversion when PPOM Pro is active
- Fixed issue when Cart quantity input resets to price matrix minimum after higher quantity is selected
