### PR TITLE
Secured product metadata bulk operations

### DIFF
--- a/classes/plugin.class.php
+++ b/classes/plugin.class.php
@@ -350,8 +350,11 @@ class NM_PersonalizedProduct {
 			$pagenum  = $wp_list_table->get_pagenum();
 			$sendback = add_query_arg( 'paged', $pagenum, $sendback );
 
+			if ( empty( $action ) ) {
+				return;
+			}
 
-			$nm_do_action = ( $action == 'nm_delete_meta' ) ? $action : substr( $action, 0, 10 );
+			$nm_do_action = ( 'nm_delete_meta' === $action ) ? $action : substr( $action, 0, 10 );
 
 			if ( 'nm_action_' !== $nm_do_action && 'nm_delete_meta' !== $nm_do_action ) {
 				return;
@@ -369,8 +372,12 @@ class NM_PersonalizedProduct {
 							continue;
 						}
 
-						$meta_id = array( intval( substr( $action, 10 ) ) );
-						update_post_meta( $post_id, PPOM_PRODUCT_META_KEY, $meta_id );
+						$meta_id_value = (int) substr( $action, 10 );
+						if ( $meta_id_value <= 0 ) {
+							continue;
+						}
+
+						update_post_meta( $post_id, PPOM_PRODUCT_META_KEY, array( $meta_id_value ) );
 
 						$updated_ids[] = $post_id;
 						++$nm_updated;

--- a/classes/plugin.class.php
+++ b/classes/plugin.class.php
@@ -353,37 +353,55 @@ class NM_PersonalizedProduct {
 
 			$nm_do_action = ( $action == 'nm_delete_meta' ) ? $action : substr( $action, 0, 10 );
 
+			if ( 'nm_action_' !== $nm_do_action && 'nm_delete_meta' !== $nm_do_action ) {
+				return;
+			}
+
+			check_admin_referer( 'bulk-posts' );
+
 			switch ( $nm_do_action ) {
 				case 'nm_action_':
-					$nm_updated = 0;
+					$nm_updated  = 0;
+					$updated_ids = array();
 					foreach ( $post_ids as $post_id ) {
+
+						if ( ! current_user_can( 'edit_post', $post_id ) ) {
+							continue;
+						}
 
 						$meta_id = array( intval( substr( $action, 10 ) ) );
 						update_post_meta( $post_id, PPOM_PRODUCT_META_KEY, $meta_id );
 
+						$updated_ids[] = $post_id;
 						++$nm_updated;
 					}
 					$sendback = add_query_arg(
 						array(
 							'nm_updated' => $nm_updated,
-							'ids'        => join( ',', $post_ids ),
+							'ids'        => join( ',', $updated_ids ),
 						),
 						$sendback 
 					);
 					break;
 
 				case 'nm_delete_meta':
-					$nm_removed = 0;
+					$nm_removed  = 0;
+					$removed_ids = array();
 					foreach ( $post_ids as $post_id ) {
+
+						if ( ! current_user_can( 'edit_post', $post_id ) ) {
+							continue;
+						}
 
 						delete_post_meta( $post_id, PPOM_PRODUCT_META_KEY );
 
+						$removed_ids[] = $post_id;
 						++$nm_removed;
 					}
 					$sendback = add_query_arg(
 						array(
 							'nm_removed' => $nm_removed,
-							'ids'        => join( ',', $post_ids ),
+							'ids'        => join( ',', $removed_ids ),
 						),
 						$sendback 
 					);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5119,12 +5119,6 @@ parameters:
 			path: src/Pricing/Engine.php
 
 		-
-			message: '#^Call to static method calc_tax\(\) on an unknown class PPOM\\Pricing\\WC_Tax\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Pricing/Engine.php
-
-		-
 			message: '#^Function PPOM_FPP not found\.$#'
 			identifier: function.notFound
 			count: 1


### PR DESCRIPTION
### Summary
Verified the nonce for the bulk action is valid before proceeding with the action. This prevents unauthorized users from performing bulk actions.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/ppom-pro/issues/726