### PR TITLE
Fixed nonce handling for file uploads

### DIFF
--- a/classes/frontend-scripts.class.php
+++ b/classes/frontend-scripts.class.php
@@ -607,6 +607,7 @@ class PPOM_FRONTEND_SCRIPTS {
 					'plupload_runtime'       => ( ppom_if_browser_is_ie() ) ? 'html5,html4' : 'html5,silverlight,html4,browserplus,gear',
 					'ppom_file_upload_nonce' => wp_create_nonce( 'ppom_uploading_file_action' ),
 					'ppom_file_delete_nonce' => wp_create_nonce( 'ppom_deleting_file_action' ),
+					'wp_rest_nonce'          => wp_create_nonce( 'wp_rest' ),
 					'rest_url'               => rest_url( 'ppom/v1/nonces/file/' ),
 					'invalid_file_type'      => __( 'Invalid file type', 'woocommerce-product-addon' ),
 					// translators: %s is max file size.

--- a/js/file-upload.js
+++ b/js/file-upload.js
@@ -41,7 +41,7 @@ const Cropped_Data_Captured = false;
 
 // Track nonce refresh state to avoid duplicate requests
 let nonceRefreshPromise = null;
-let lastNonceRefreshTime = 0;
+let lastNonceRefreshTime = Date.now();
 const NONCE_CACHE_DURATION = 300000; // 5 minutes in milliseconds
 
 /**
@@ -72,6 +72,7 @@ async function ppom_refresh_file_nonces() {
 		credentials: 'same-origin',
 		headers: {
 			'Content-Type': 'application/json',
+			'X-WP-Nonce': ppom_file_vars.wp_rest_nonce,
 		},
 	} )
 		.then( ( response ) => {

--- a/tests/unit/test-rest-and-admin.php
+++ b/tests/unit/test-rest-and-admin.php
@@ -571,6 +571,84 @@ class Test_Rest_And_Admin extends PPOM_Test_Case {
 	}
 
 	/**
+	 * Test that the refreshed nonces are valid for the authenticated user.
+	 *
+	 * @return void
+	 */
+	public function testGetFileNoncesRefreshedNonceIsValidForAuthenticatedUser() {
+		// Simulate page load: user is logged in and the page-load nonce is created for them.
+		$user_id = $this->create_shop_manager_user();
+		wp_set_current_user( $user_id );
+
+		$response = $this->dispatch_ppom_rest_request(
+			'GET',
+			'/ppom/v1/nonces/file/',
+			array(),
+			'secret-key',
+			false
+		);
+		$data     = $response->get_data();
+
+		$this->assertSame( 'success', $data['status'] );
+
+		$upload_nonce_valid = wp_verify_nonce(
+			$data['ppom_file_upload_nonce'],
+			'ppom_uploading_file_action'
+		);
+		$this->assertNotFalse(
+			$upload_nonce_valid,
+			'Refreshed upload nonce must be valid for the logged-in user'
+		);
+
+		$delete_nonce_valid = wp_verify_nonce(
+			$data['ppom_file_delete_nonce'],
+			'ppom_deleting_file_action'
+		);
+		$this->assertNotFalse(
+			$delete_nonce_valid,
+			'Refreshed delete nonce must be valid for the logged-in user'
+		);
+	}
+
+	/**
+	 * Test that an unauthenticated request returns a nonce that does not verify for a logged-in user.
+	 *
+	 * @return void
+	 */
+	public function testGetFileNoncesUnauthenticatedRequestFailsVerificationForLoggedInUser() {
+		$user_id = $this->create_shop_manager_user();
+		wp_set_current_user( $user_id );
+		$page_load_nonce = wp_create_nonce( 'ppom_uploading_file_action' );
+
+		wp_set_current_user( 0 );
+		$response = $this->dispatch_ppom_rest_request(
+			'GET',
+			'/ppom/v1/nonces/file/',
+			array(),
+			'secret-key',
+			false
+		);
+		$data     = $response->get_data();
+		$this->assertSame( 'success', $data['status'] );
+
+		$anonymous_nonce = $data['ppom_file_upload_nonce'];
+
+		wp_set_current_user( $user_id );
+
+		$valid = wp_verify_nonce( $anonymous_nonce, 'ppom_uploading_file_action' );
+		$this->assertFalse(
+			(bool) $valid,
+			'A nonce generated for user 0 must not verify as valid for a logged-in user'
+		);
+
+		$page_load_valid = wp_verify_nonce( $page_load_nonce, 'ppom_uploading_file_action' );
+		$this->assertNotFalse(
+			$page_load_valid,
+			'Page-load nonce must remain valid for the same logged-in user'
+		);
+	}
+
+	/**
 	 * Ensure unauthenticated GET requests are rejected with rest_forbidden.
 	 *
 	 * @return void


### PR DESCRIPTION
### Summary
Passed X-Wp-Nonce to REST endpoint to get refreshed nonce for file upload. This fixes the bug where the REST endpoint was returning a nonce for user 0 (unauthenticated) instead of the logged-in user.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/652, https://github.com/Codeinwp/woocommerce-product-addon/issues/660