### PR TITLE
fix: cap the admin bar field-group submenu at half the viewport

### DIFF
--- a/src/Frontend/ProductAndTemplateHooks.php
+++ b/src/Frontend/ProductAndTemplateHooks.php
@@ -18,6 +18,20 @@ final class ProductAndTemplateHooks {
 	public static function register(): void {
 		add_action( 'admin_bar_menu', 'ppom_admin_bar_menu', 1000 );
 
+		// Long field-group lists overflow the viewport in the toolbar submenu (#523).
+		add_action(
+			'wp_enqueue_scripts',
+			static function () {
+				if ( ! is_admin_bar_showing() || ! is_product() ) {
+					return;
+				}
+				wp_add_inline_style(
+					'admin-bar',
+					'#wp-admin-bar-ppom-setting-bar .ab-sub-wrapper{max-height:50vh;overflow-y:auto}'
+				);
+			}
+		);
+
 		if ( ppom_is_legacy_mode() ) {
 			add_action( 'woocommerce_before_add_to_cart_button', 'ppom_woocommerce_show_fields', 15 );
 		} else {

--- a/tests/e2e/specs/admin-bar-scroll.spec.js
+++ b/tests/e2e/specs/admin-bar-scroll.spec.js
@@ -1,0 +1,69 @@
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+import {
+	attachPpomGroupToProducts,
+	buildTextField,
+	createPpomGroup,
+	createSimpleProduct,
+} from '../fixtures/index.js';
+
+test.describe( 'Admin bar PPOM menu', () => {
+	test( 'ships scroll CSS for the field-group submenu (#523)', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const suffix = Date.now();
+		const product = await createSimpleProduct( requestUtils, {
+			name: `Admin Bar Scroll Product ${ suffix }`,
+		} );
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: `Admin Bar Scroll Group ${ suffix }`,
+			fields: [
+				buildTextField( {
+					title: 'Any text',
+					dataName: `adminbar_text_${ suffix }`,
+				} ),
+			],
+		} );
+		await attachPpomGroupToProducts( requestUtils, {
+			ppomId,
+			productIds: [ product.id ],
+		} );
+
+		await page.goto( `/?p=${ product.id }` );
+
+		// A long field-group list must stop at half the viewport and scroll.
+		// The node is built synthetically: `bar_menu()` loses the `$product`
+		// global in wp-env, so the real node never renders (pre-existing bug).
+		const submenu = await page.evaluate( () => {
+			const node = document.createElement( 'li' );
+			node.id = 'wp-admin-bar-ppom-setting-bar';
+			node.className = 'menupop hover';
+			const wrapper = document.createElement( 'div' );
+			wrapper.className = 'ab-sub-wrapper';
+			const list = document.createElement( 'ul' );
+			list.className = 'ab-submenu';
+			for ( let i = 0; i < 100; i++ ) {
+				const item = document.createElement( 'li' );
+				const link = document.createElement( 'a' );
+				link.className = 'ab-item';
+				link.textContent = `Apply Group ${ i }`;
+				item.appendChild( link );
+				list.appendChild( item );
+			}
+			wrapper.appendChild( list );
+			node.appendChild( wrapper );
+			document.getElementById( 'wpadminbar' ).appendChild( node );
+			return {
+				capsAtHalfViewport:
+					Math.abs( wrapper.clientHeight - window.innerHeight / 2 ) <=
+					2,
+				scrollsOverflow: wrapper.scrollHeight > wrapper.clientHeight,
+			};
+		} );
+		expect( submenu ).toEqual( {
+			capsAtHalfViewport: true,
+			scrollsOverflow: true,
+		} );
+	} );
+} );


### PR DESCRIPTION
## Summary

Stores with many PPOM field groups cannot reach the lower `Apply …` entries in the "Edit PPOM" admin toolbar menu — WordPress toolbar submenus have no height limit, so long lists run off-screen with no way to scroll (see the screenshot in the linked issue).

This caps the PPOM submenu at half the viewport (`50vh`) and scrolls the overflow. The rule ships as inline CSS on core's `admin-bar` style handle, on product pages only, so:

- regular visitors load nothing extra (the handle only enqueues when the toolbar renders),
- short group lists render exactly as before (`overflow-y: auto` shows no scrollbar when content fits),
- the selector is scoped to `#wp-admin-bar-ppom-setting-bar`, so no other toolbar menu is affected.

## How to test

1. On a site with WooCommerce + PPOM active, create enough field groups to overflow the screen — 25+ (WooCommerce → PPOM → Add Fields Group; duplicates are fine).
2. Attach any one group to a simple product (product edit screen → PPOM Fields box → tick a group → Update).
3. Log in as admin and open that product's **storefront** page.
4. Hover **Edit PPOM (…)** in the admin toolbar.
   - **Before this fix:** the `Apply …` list runs past the bottom of the screen; the mouse wheel scrolls the page behind it (closing the menu), and the lower entries are unreachable.
   - **After this fix:** the dropdown stops at half the window height; scrolling inside it scrolls the list while the page stays put, and the last entry is reachable and clickable.
5. Regression checks:
   - A site with only 2–3 groups shows the dropdown exactly as before (no scrollbar).
   - Logged-out visitors get no extra CSS on the product page (view source: no `ppom-setting-bar` rule).
   - Other toolbar dropdowns (Howdy, New, WooCommerce, etc.) are unaffected.


Fixes Codeinwp/ppom-pro#523

