### PR TITLE
fix: skip the premium support link when no valid license exists

### DIFF
--- a/src/Core/Bootstrap/SdkCompatAndMetadataRegistration.php
+++ b/src/Core/Bootstrap/SdkCompatAndMetadataRegistration.php
@@ -109,6 +109,10 @@ final class SdkCompatAndMetadataRegistration implements RegisterHooks {
 		add_filter(
 			'woocommerce_product_addon_float_widget_metadata',
 			function () {
+				// `tsdk_support_link()` returns false without a valid license;
+				// translating that spews warnings on translated locales (#543).
+				$support_link = defined( 'PPOM_PRO_PATH' ) ? tsdk_support_link( PPOM_PRO_PATH . '/ppom.php' ) : false;
+
 				return array(
 					'logo'                 => PPOM_URL . '/images/help.svg',
 					'nice_name'            => 'PPOM',
@@ -117,7 +121,7 @@ final class SdkCompatAndMetadataRegistration implements RegisterHooks {
 					'has_upgrade_menu'     => ! defined( 'PPOM_PRO_PATH' ),
 					'upgrade_link'         => tsdk_utmify( tsdk_translate_link( PPOM_UPGRADE_URL ), 'float_widget' ),
 					'documentation_link'   => 'https://rviv.ly/C1cmSQ',
-					'premium_support_link' => defined( 'PPOM_PRO_PATH' ) ? tsdk_translate_link( (string) tsdk_support_link( PPOM_PRO_PATH . '/ppom.php' ) ) : '',
+					'premium_support_link' => $support_link ? tsdk_translate_link( $support_link ) : '',
 					'feature_request_link' => tsdk_translate_link( 'https://store.themeisle.com/suggest-a-feature/' ),
 				);
 			}

--- a/src/Core/Bootstrap/SdkCompatAndMetadataRegistration.php
+++ b/src/Core/Bootstrap/SdkCompatAndMetadataRegistration.php
@@ -109,8 +109,6 @@ final class SdkCompatAndMetadataRegistration implements RegisterHooks {
 		add_filter(
 			'woocommerce_product_addon_float_widget_metadata',
 			function () {
-				// `tsdk_support_link()` returns false without a valid license;
-				// translating that spews warnings on translated locales (#543).
 				$support_link = defined( 'PPOM_PRO_PATH' ) ? tsdk_support_link( PPOM_PRO_PATH . '/ppom.php' ) : false;
 
 				return array(


### PR DESCRIPTION
### Summary

`tsdk_support_link()` returns `false` when no valid license exists. Casting that to a string and passing it through `tsdk_translate_link()` made the SDK parse an empty URL, which:

- logged `Undefined array key` PHP warnings on every admin request for translated locales (e.g. `de_DE`)
- stored garbage values like `:///de` as the premium support link

This PR only translates the support link when one actually exists; otherwise the metadata value stays empty.

Fixes Codeinwp/ppom-pro#543
(https://github.com/Codeinwp/ppom-pro/issues/543#event-27611668180)

### Test instructions

1. Run the free plugin without a valid PPOM Pro license.
2. Switch the site locale to `de_DE` (or any translated locale).
3. Load any admin page — no `Undefined array key` warnings should be logged, and no malformed support link (`:///de`) should be stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)