### PR TITLE
Computed option price when missing in cart item data

### DIFF
--- a/src/WooCommerce/Cart/CartHandler.php
+++ b/src/WooCommerce/Cart/CartHandler.php
@@ -386,7 +386,7 @@ final class CartHandler {
 		$wc_product = $cart_items['data'];
 		$product_id = Helpers::get_product_id( $wc_product );
 
-		if ( empty( $values['ppom']['ppom_option_price'] ) ) {
+		if ( empty( $values['ppom']['ppom_option_price'] ) && ! empty( $values['ppom']['fields'] ) ) {
 			$computed = Helpers::compute_option_price_from_fields( $values['ppom']['fields'], $product_id );
 			if ( ! empty( $computed ) ) {
 				$values['ppom']['ppom_option_price'] = wp_json_encode( $computed );

--- a/src/WooCommerce/Cart/CartHandler.php
+++ b/src/WooCommerce/Cart/CartHandler.php
@@ -383,12 +383,20 @@ final class CartHandler {
 			return $cart_items;
 		}
 
+		$wc_product = $cart_items['data'];
+		$product_id = Helpers::get_product_id( $wc_product );
+
+		if ( empty( $values['ppom']['ppom_option_price'] ) ) {
+			$computed = Helpers::compute_option_price_from_fields( $values['ppom']['fields'], $product_id );
+			if ( ! empty( $computed ) ) {
+				$values['ppom']['ppom_option_price'] = wp_json_encode( $computed );
+			}
+		}
+
 		if ( ! isset( $values['ppom']['ppom_option_price'] ) ) {
 			return $cart_items;
 		}
 
-		$wc_product     = $cart_items['data'];
-		$product_id     = Helpers::get_product_id( $wc_product );
 		$variation_id   = isset( $cart_items['variation_id'] ) ? absint( $cart_items['variation_id'] ) : 0;
 		$values['ppom'] = Helpers::filter_ppom_payload_by_active_variation( (array) $values['ppom'], $product_id, $variation_id );
 

--- a/tests/unit/src/WooCommerce/test-cart-handler.php
+++ b/tests/unit/src/WooCommerce/test-cart-handler.php
@@ -862,4 +862,52 @@ class Test_Cart_Handler extends PPOM_Test_Case {
 				: ''
 		);
 	}
+
+	/**
+	 * Regression: undercharge when a session-restored cart line arrives with
+	 * `fields` but no `ppom_option_price` (e.g. dropped by a caching layer or a
+	 * client that never attached it). `update_cart_fees()` must recompute the
+	 * addon price server-side from `fields` via `Helpers::compute_option_price_from_fields()`,
+	 * mirroring `ProductHandler::validate_product()`'s equivalent legacy-mode
+	 * fallback, instead of silently pricing the line at the bare product price.
+	 *
+	 * @return void
+	 */
+	public function test_update_cart_fees_computes_price_from_fields_when_option_price_missing() {
+		$product    = $this->create_simple_product( array( 'regular_price' => '10' ) );
+		$product_id = $product->get_id();
+
+		$meta_id = $this->insert_ppom_meta(
+			array(
+				$this->build_select_field(
+					'size',
+					'Size',
+					array(
+						array( 'option' => 'Small', 'price' => '' ),
+						array( 'option' => 'Large', 'price' => '5.00' ),
+					)
+				),
+			),
+			$product_id
+		);
+
+		$cart_items = array(
+			'data'         => $product,
+			'variation_id' => 0,
+			'quantity'     => 1,
+		);
+
+		$values = array(
+			'ppom' => array(
+				'fields' => array(
+					'id'   => (string) $meta_id,
+					'size' => 'Large',
+				),
+			),
+		);
+
+		$result = CartHandler::update_cart_fees( $cart_items, $values );
+
+		$this->assertSame( 15.0, (float) $result['data']->get_price() );
+	}
 }

--- a/tests/unit/src/WooCommerce/test-cart-handler.php
+++ b/tests/unit/src/WooCommerce/test-cart-handler.php
@@ -864,12 +864,8 @@ class Test_Cart_Handler extends PPOM_Test_Case {
 	}
 
 	/**
-	 * Regression: undercharge when a session-restored cart line arrives with
-	 * `fields` but no `ppom_option_price` (e.g. dropped by a caching layer or a
-	 * client that never attached it). `update_cart_fees()` must recompute the
-	 * addon price server-side from `fields` via `Helpers::compute_option_price_from_fields()`,
-	 * mirroring `ProductHandler::validate_product()`'s equivalent legacy-mode
-	 * fallback, instead of silently pricing the line at the bare product price.
+	 * Computes the price from the selected field when the option price is missing,
+	 * ensuring that the cart fee is updated correctly.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
### Summary
Compute the option price from fields only if the `ppom_option_price` is empty. This ensures that the price is calculated correctly based on the selected options.

## Steps
1. Add and select a paid option.
2. The option price is reflected on the product page.
3. Remove the `ppom_option_price` value using the browser's Inspect Element tool, then add the product to the cart. This allows the product to be added with an empty `ppom[ppom_option_price]` value.
4. Verify the option price in the cart.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/651