### PR TITLE
fix: do not multiply option prices by quantities from other fields

### DIFF
--- a/js/price/ppom-price.js
+++ b/js/price/ppom-price.js
@@ -175,6 +175,9 @@ function ppom_update_option_prices() {
 	let show_per_unit_price = false;
 	// unlink order quantity controlled by variation quantities
 	let unlink_order_qty = false;
+	// order quantity is driven by priced quantity fields, so other options
+	// are one-off charges and must not scale with it
+	let qty_set_by_priced_quantities = false;
 
 	// console.log(ppom_all_option_prices);
 
@@ -279,6 +282,10 @@ function ppom_update_option_prices() {
 		// since v18.0 if no price set, no need to use base price
 		if ( option.price == '' || option.price == 0 ) {
 			return;
+		}
+
+		if ( option.unlink_qty !== 'on' ) {
+			qty_set_by_priced_quantities = true;
 		}
 
 		const variation_price = option.price;
@@ -455,8 +462,10 @@ function ppom_update_option_prices() {
 			return;
 		}
 
-		const option_price_with_qty =
-			ppom_get_order_quantity() * parseFloat( option.price );
+		const option_qty = qty_set_by_priced_quantities
+			? 1
+			: ppom_get_order_quantity();
+		const option_price_with_qty = option_qty * parseFloat( option.price );
 		// Totals the options
 		ppom_option_total += option_price_with_qty;
 
@@ -471,7 +480,7 @@ function ppom_update_option_prices() {
 			' ' +
 			jQuery( price_tag ).html() +
 			' x ' +
-			ppom_get_order_quantity();
+			option_qty;
 
 		ppom_add_price_item_in_table(
 			option_label_with_qty,

--- a/src/Cart/LegacyCartLinePricing.php
+++ b/src/Cart/LegacyCartLinePricing.php
@@ -234,9 +234,6 @@ final class LegacyCartLinePricing {
 			if ( ! $ppom_quantities_include_base ) {
 				// $ppom_item_org_price = ($ppom_item_org_price * $ppom_total_quantities);
 				$ppom_item_org_price = 0;
-
-				// when base price is NOT included the quantity is updated so it must be multiplied by options
-				$total_option_price = ( $total_option_price * $ppom_total_quantities );
 			}
 		}
 

--- a/src/Pricing/Engine.php
+++ b/src/Pricing/Engine.php
@@ -301,12 +301,10 @@ final class Engine {
 			// ppom_pa($options);
 
 
-			$field_price     = '';
+			$field_price = '';
+			// Option prices are one-off charges per line item; quantity fields
+			// must not multiply other fields' option prices.
 			$option_quantity = 1;
-
-			if ( Helpers::reset_cart_quantity_to_one( $product_id ) ) {
-				$option_quantity = self::price_get_total_quantities( $ppom_fields_post, $product_id );
-			}
 
 			switch ( $field_type ) {
 

--- a/src/WooCommerce/Cart/CartHandler.php
+++ b/src/WooCommerce/Cart/CartHandler.php
@@ -187,7 +187,7 @@ final class CartHandler {
 		if ( $ppom_quantities_price > 0 && ! $ppom_quantities_include_base ) {
 			return array(
 				'ppom_item_org_price' => 0,
-				'total_option_price'  => $total_option_price * $ppom_total_quantities,
+				'total_option_price'  => $total_option_price,
 			);
 		}
 

--- a/tests/e2e/fixtures/fields.js
+++ b/tests/e2e/fixtures/fields.js
@@ -74,6 +74,27 @@ function buildPalettesField( { options = [], ...args } ) {
 	} );
 }
 
+function buildQuantitiesField( { options = [], ...args } ) {
+	return buildField( 'quantities', {
+		view_control: 'simple_view',
+		default_price: '',
+		min_qty: '',
+		max_qty: '',
+		required: '',
+		...args,
+		options: options.map( ( option ) =>
+			buildOption( option.label, option.value, {
+				min: '',
+				max: '',
+				stock: '',
+				default: '',
+				weight: '',
+				...option.overrides,
+			} )
+		),
+	} );
+}
+
 function buildCheckboxField( { options = [], checked = [], ...args } ) {
 	return buildField( 'checkbox', {
 		...args,
@@ -129,6 +150,7 @@ export {
 	buildImageField,
 	buildPalettesField,
 	buildPriceMatrixField,
+	buildQuantitiesField,
 	buildSelectField,
 	buildTextField,
 	buildTextareaField,

--- a/tests/e2e/fixtures/index.js
+++ b/tests/e2e/fixtures/index.js
@@ -11,6 +11,7 @@ export {
 	buildCheckboxField,
 	buildFileField,
 	buildHtmlField,
+	buildQuantitiesField,
 	buildSelectField,
 	buildTextField,
 	buildTextareaField,

--- a/tests/e2e/specs/quantities-option-price.spec.js
+++ b/tests/e2e/specs/quantities-option-price.spec.js
@@ -105,6 +105,9 @@ test.describe( 'Select option price with quantities field', () => {
 		page,
 		requestUtils,
 	} ) => {
+		// Room for the slow add-to-cart navigation plus the cart poll below.
+		test.setTimeout( 240000 );
+
 		const product = await setupProduct( requestUtils );
 
 		await page.goto( `/?p=${ product.id }` );
@@ -117,22 +120,25 @@ test.describe( 'Select option price with quantities field', () => {
 
 		// Base 10 + quantities 100 x 2 + select 1200 = 1410.00 (minor units).
 		// Polled with a short per-request timeout: the wp-env Store API
-		// occasionally hangs on a single request.
+		// occasionally hangs on a single request. Sentinel return values keep
+		// env failures distinguishable from a wrong total in the report.
 		await expect
 			.poll(
 				async () => {
-					try {
-						const response = await page.request.get(
-							'/?rest_route=/wc/store/v1/cart',
-							{ timeout: 15000 }
-						);
-						const cart = await response.json();
-						return cart.totals?.total_items;
-					} catch {
-						return null;
+					const response = await page.request
+						.get( '/?rest_route=/wc/store/v1/cart', {
+							timeout: 15000,
+						} )
+						.catch( () => null );
+
+					if ( ! response || ! response.ok() ) {
+						return 'cart-request-failed';
 					}
+
+					const cart = await response.json();
+					return cart.totals?.total_items ?? 'totals-missing';
 				},
-				{ timeout: 90000 }
+				{ timeout: 120000, intervals: [ 3000 ] }
 			)
 			.toBe( '141000' );
 	} );

--- a/tests/e2e/specs/quantities-option-price.spec.js
+++ b/tests/e2e/specs/quantities-option-price.spec.js
@@ -1,0 +1,139 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+import {
+	attachPpomGroupToProducts,
+	buildQuantitiesField,
+	buildSelectField,
+	createPpomGroup,
+	createSimpleProduct,
+} from '../fixtures/index.js';
+
+/**
+ * Regression for Codeinwp/ppom-pro#547.
+ *
+ * A priced quantities field drives the order quantity. Select option prices
+ * are one-off charges and must not be multiplied by that quantity — neither
+ * in the frontend price table nor in the server-side cart total.
+ */
+test.describe( 'Select option price with quantities field', () => {
+	async function setupProduct( requestUtils ) {
+		const product = await createSimpleProduct( requestUtils, {
+			regular_price: '10.00',
+		} );
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: 'Quantities Option Price',
+			settings: { dynamic_price_hide: 'all_option' },
+			fields: [
+				buildQuantitiesField( {
+					title: 'Years',
+					dataName: 'years',
+					options: [
+						{
+							label: 'year1',
+							value: '_year1',
+							overrides: { price: '100' },
+						},
+					],
+				} ),
+				buildSelectField( {
+					title: 'Membership',
+					dataName: 'membership',
+					options: [
+						{
+							label: 'one time fee',
+							value: 'one_time_fee',
+							overrides: { price: '1200' },
+						},
+						{
+							label: 'monthly',
+							value: 'monthly',
+							overrides: { price: '100' },
+						},
+					],
+				} ),
+			],
+		} );
+		await attachPpomGroupToProducts( requestUtils, {
+			ppomId,
+			productIds: [ product.id ],
+		} );
+
+		return product;
+	}
+
+	async function fillOptions( page ) {
+		await page
+			.locator( 'select#membership' )
+			.selectOption( { value: 'one time fee' } );
+
+		const qty = page.locator( 'input.ppom-quantity[data-label="year1"]' );
+		await qty.fill( '2' );
+		await qty.dispatchEvent( 'change' );
+	}
+
+	test( 'price table does not multiply the select option by the quantities total', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const product = await setupProduct( requestUtils );
+
+		await page.goto( `/?p=${ product.id }` );
+		await fillOptions( page );
+
+		const table = page.locator( '#ppom-price-container' );
+
+		// Quantities line scales with its own quantity: 100 x 2.
+		await expect(
+			table.locator( 'tr.ppom-quantities-price' )
+		).toContainText( 'x 2' );
+
+		// Select option is charged once: 1200 x 1, not 1200 x 2.
+		const selectRow = table.locator( 'tr.ppom-variable-price' );
+		await expect( selectRow ).toContainText( 'x 1' );
+		await expect( selectRow ).toContainText( '1,200.00' );
+
+		// Option total: 100 x 2 + 1200 = 1,400.
+		await expect(
+			table.locator( 'tr.ppom-option-total-price' )
+		).toContainText( '1,400.00' );
+	} );
+
+	test( 'cart total charges the select option once', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const product = await setupProduct( requestUtils );
+
+		await page.goto( `/?p=${ product.id }` );
+		await fillOptions( page );
+
+		// Slow wp-env: the submit navigation can exceed the default timeout.
+		await page
+			.locator( 'button.single_add_to_cart_button' )
+			.click( { timeout: 60000 } );
+
+		// Base 10 + quantities 100 x 2 + select 1200 = 1410.00 (minor units).
+		// Polled with a short per-request timeout: the wp-env Store API
+		// occasionally hangs on a single request.
+		await expect
+			.poll(
+				async () => {
+					try {
+						const response = await page.request.get(
+							'/?rest_route=/wc/store/v1/cart',
+							{ timeout: 15000 }
+						);
+						const cart = await response.json();
+						return cart.totals?.total_items;
+					} catch {
+						return null;
+					}
+				},
+				{ timeout: 90000 }
+			)
+			.toBe( '141000' );
+	} );
+} );

--- a/tests/unit/src/WooCommerce/test-cart-handler.php
+++ b/tests/unit/src/WooCommerce/test-cart-handler.php
@@ -190,11 +190,11 @@ class Test_Cart_Handler extends PPOM_Test_Case {
 	/**
 	 * @return void
 	 */
-	public function test_apply_legacy_quantities_exclude_base_adjustment_zeros_base_and_scales_options() {
+	public function test_apply_legacy_quantities_exclude_base_adjustment_zeros_base_keeps_options() {
 		$adj = CartHandler::apply_legacy_quantities_exclude_base_adjustment( 10, false, 50, 3, 4 );
 
 		$this->assertSame( 0, $adj['ppom_item_org_price'] );
-		$this->assertSame( 12, $adj['total_option_price'] );
+		$this->assertSame( 3, $adj['total_option_price'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes Codeinwp/ppom-pro#547 — a Select field option price was multiplied by the total quantity of a priced quantities field (e.g. a \$1200 membership charged \$2400 when 2 units were picked in another field). Option prices are one-off charges per line item and must not scale with those quantities.

Three multiplication sites removed, all pricing paths now agree:

- `js/price/ppom-price.js` — frontend price table: variable options use quantity 1 when a priced, linked quantities field drives the order quantity (new `qty_set_by_priced_quantities` flag). Plain WC quantity behaviour unchanged.
- `src/Pricing/Engine.php` (modern mode, default) — removed `option_quantity = total quantities` when cart quantity resets to one.
- `src/Cart/LegacyCartLinePricing.php` + `CartHandler::apply_legacy_quantities_exclude_base_adjustment` (legacy mode) — removed `total_option_price × total_quantities`; base-price zeroing kept.

Out of scope: bulkquantity+select combo (keeps WC cart qty = N, frontend and cart stay consistent) and the opt-in `ppom-price-v2.js` script (no quantities support).

## Testing

- Full PHPUnit suite: 441 tests green (one legacy-reducer expectation updated to the unscaled value).
- New e2e spec `tests/e2e/specs/quantities-option-price.spec.js` (+ `buildQuantitiesField` fixture):
  - price table shows quantities line `100 x 2` and select `1200 x 1`, option total 1,400.00
  - Store API cart total after add-to-cart = 1410.00 (base 10 + 100×2 + 1200×1); pre-fix 2610.00
- Manually reproduced with the meta group from the issue report before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)