### PR TITLE
fix: guard checkbox default restore against missing checked key

### DIFF
--- a/js/ppom-conditions-v2.js
+++ b/js/ppom-conditions-v2.js
@@ -711,7 +711,8 @@ function ppom_set_default_option( field_id ) {
 				const opt_id =
 					product_id + '-' + field.data_name + '-' + options.id;
 
-				const default_checked = field.checked.split( '\r\n' );
+				// Imported metas can lack the `checked` key entirely.
+				const default_checked = ( field.checked || '' ).split( '\r\n' );
 				if ( jQuery.inArray( options.option, default_checked ) > -1 ) {
 					jQuery( '#' + opt_id ).prop( 'checked', true );
 				}

--- a/js/ppom-conditions.js
+++ b/js/ppom-conditions.js
@@ -237,7 +237,8 @@ function ppom_set_default_option( field_id ) {
 				const opt_id =
 					product_id + '-' + field.data_name + '-' + options.id;
 
-				const default_checked = field.checked.split( '\r\n' );
+				// Imported metas can lack the `checked` key entirely.
+				const default_checked = ( field.checked || '' ).split( '\r\n' );
 				if ( jQuery.inArray( options.option, default_checked ) > -1 ) {
 					jQuery( '#' + opt_id ).prop( 'checked', true );
 				}

--- a/tests/e2e/specs/checkbox-conditions-import.spec.js
+++ b/tests/e2e/specs/checkbox-conditions-import.spec.js
@@ -1,0 +1,134 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+import {
+	attachPpomGroupToProducts,
+	buildCheckboxField,
+	buildSelectField,
+	createPpomGroup,
+	createSimpleProduct,
+} from '../fixtures/index.js';
+
+/**
+ * Regression for Codeinwp/ppom-pro#572.
+ *
+ * The Pro CSV import strips empty meta keys, so re-imported checkbox fields
+ * have no `checked` key at all. The conditions engine crashed on
+ * `field.checked.split()` every time such a field was re-shown, killing
+ * conditional logic after a few show/hide cycles.
+ */
+test.describe( 'Checkbox conditions on import-shaped meta', () => {
+	test( 'conditional checkbox fields keep toggling when meta has no checked key', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const token = `${ Date.now() }_${ Math.floor( Math.random() * 1e6 ) }`;
+		const sourceId = `switch_${ token }`;
+
+		// Simulate the import: checkbox metas without a `checked` key.
+		const cb1 = buildCheckboxField( {
+			title: 'Check One',
+			dataName: `check_1_${ token }`,
+			logic: 'on',
+			conditions: {
+				visibility: 'Show',
+				bound: 'All',
+				rules: [
+					{
+						elements: sourceId,
+						operators: 'is',
+						element_values: 'First',
+					},
+				],
+			},
+			options: [
+				{ label: 'A', value: 'a' },
+				{ label: 'B', value: 'b' },
+			],
+		} );
+		const cb2 = buildCheckboxField( {
+			title: 'Check Two',
+			dataName: `check_2_${ token }`,
+			logic: 'on',
+			conditions: {
+				visibility: 'Show',
+				bound: 'All',
+				rules: [
+					{
+						elements: sourceId,
+						operators: 'is',
+						element_values: 'Second',
+					},
+				],
+			},
+			options: [
+				{ label: 'C', value: 'c' },
+				{ label: 'D', value: 'd' },
+			],
+		} );
+		delete cb1.checked;
+		delete cb2.checked;
+
+		const product = await createSimpleProduct( requestUtils );
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: `Checkbox Conditions Import ${ token }`,
+			fields: [
+				buildSelectField( {
+					title: `Switch ${ token }`,
+					dataName: sourceId,
+					options: [
+						{ label: 'First', value: 'first' },
+						{ label: 'Second', value: 'second' },
+						{ label: 'Third', value: 'third' },
+					],
+				} ),
+				cb1,
+				cb2,
+			],
+		} );
+		await attachPpomGroupToProducts( requestUtils, {
+			ppomId,
+			productIds: [ product.id ],
+		} );
+
+		const pageErrors = [];
+		page.on( 'pageerror', ( error ) => pageErrors.push( error.message ) );
+
+		await page.goto( `/?p=${ product.id }` );
+
+		const source = page.locator(
+			`select[name="ppom[fields][${ sourceId }]"]`
+		);
+		const check1 = page
+			.locator( `input[name="ppom[fields][check_1_${ token }][]"]` )
+			.first();
+		const check2 = page
+			.locator( `input[name="ppom[fields][check_2_${ token }][]"]` )
+			.first();
+
+		// The issue's click sequence: First, Second, Third, First, Second, First.
+		const sequence = [
+			[ 'First', true, false ],
+			[ 'Second', false, true ],
+			[ 'Third', false, false ],
+			[ 'First', true, false ],
+			[ 'Second', false, true ],
+			[ 'First', true, false ],
+		];
+
+		for ( const [ value, cb1Visible, cb2Visible ] of sequence ) {
+			await source.selectOption( { label: value } );
+			await ( cb1Visible
+				? expect( check1 ).toBeVisible()
+				: expect( check1 ).toBeHidden() );
+			await ( cb2Visible
+				? expect( check2 ).toBeVisible()
+				: expect( check2 ).toBeHidden() );
+		}
+
+		// The conditions engine must survive the whole cycle without throwing.
+		expect( pageErrors ).toEqual( [] );
+	} );
+} );


### PR DESCRIPTION
## Summary

Fixes Codeinwp/ppom-pro#572 — conditional logic stopped working on checkbox fields after exporting and re-importing a PPOM group.

Root cause: the Pro CSV importer strips empty meta values, so re-imported checkbox fields have no `checked` key at all. Every time a conditionally hidden checkbox field was re-shown, `ppom_set_default_option()` ran `field.checked.split( '\r\n' )` and threw `TypeError: cannot read 'split' of undefined`, aborting the conditions handler mid-run (before the cascade re-evaluation). After a few show/hide cycles — the exact First→Second→Third→First→Second→First sequence from the report — the conditional logic visibly broke. Radio targets were unaffected because their restore path never calls `.split()`.

Change: guard the split with `( field.checked || '' )` in both conditions engines (`js/ppom-conditions-v2.js` and legacy `js/ppom-conditions.js`). Covers any meta source missing the key, not just CSV import.

## Testing

- New e2e spec `tests/e2e/specs/checkbox-conditions-import.spec.js`: builds checkbox fields with the `checked` key deleted (import-shaped meta), runs the issue's exact click sequence, asserts visibility at every step and that zero JS page errors fired.
- Red/green verified: without the guard the spec fails exactly like the customer report (checkbox stops hiding after the first show/hide cycle); with the guard it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)