### PR TITLE
fix: build conditionally_hidden payload from actual visual state

### DIFF
--- a/js/ppom-conditions-v2.js
+++ b/js/ppom-conditions-v2.js
@@ -756,10 +756,11 @@ function ppom_fields_hidden_conditionally() {
 	// console.log("Condionally Hidden", ppom_hidden_fields);
 	// jQuery("#conditionally_hidden").val(ppom_hidden_fields);
 
-	const datanames = jQuery(
-		`.ppom-field-wrapper[class*="ppom-locked-"]`
-	).map( ( i, h ) =>
-		ppom_hidden_fields.push( jQuery( h ).data( 'data_name' ) )
+	// Use the actual visual state: per-source `ppom-locked-*` classes go
+	// stale when rules span multiple source fields, but `ppom-c-hide` always
+	// reflects what the customer sees.
+	const datanames = jQuery( `.ppom-field-wrapper.ppom-c-hide` ).map(
+		( i, h ) => ppom_hidden_fields.push( jQuery( h ).data( 'data_name' ) )
 	);
 	jQuery( '#conditionally_hidden' ).val( ppom_hidden_fields );
 	// console.log(ppom_hidden_fields);

--- a/tests/e2e/specs/multi-source-conditions-cart.spec.js
+++ b/tests/e2e/specs/multi-source-conditions-cart.spec.js
@@ -1,0 +1,136 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+import {
+	attachPpomGroupToProducts,
+	buildSelectField,
+	buildTextField,
+	createPpomGroup,
+	createSimpleProduct,
+} from '../fixtures/index.js';
+
+/**
+ * Regression for Codeinwp/ppom-pro#541.
+ *
+ * A field whose condition rules span two different source fields was visible
+ * on the product page but missing from the cart: the `conditionally_hidden`
+ * payload was built from per-source `ppom-locked-*` classes, and the lock of
+ * the non-matching source went stale when the other source's rule matched.
+ */
+test.describe( 'Multi-source conditions and the cart payload', () => {
+	test( 'field with rules across two source fields reaches the cart', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		// Room for the slow add-to-cart navigation plus the cart poll below.
+		test.setTimeout( 240000 );
+
+		const token = `${ Date.now() }_${ Math.floor( Math.random() * 1e6 ) }`;
+		const configAId = `config_a_${ token }`;
+		const configBId = `config_b_${ token }`;
+		const widthId = `width_${ token }`;
+
+		const product = await createSimpleProduct( requestUtils );
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: `Multi Source Conditions ${ token }`,
+			fields: [
+				buildSelectField( {
+					title: `Config A ${ token }`,
+					dataName: configAId,
+					options: [
+						{ label: 'Other', value: 'other_a' },
+						{ label: 'Config-G', value: 'config_g' },
+					],
+				} ),
+				buildSelectField( {
+					title: `Config B ${ token }`,
+					dataName: configBId,
+					options: [
+						{ label: 'Other', value: 'other_b' },
+						{ label: 'Config-A', value: 'config_a' },
+					],
+				} ),
+				buildTextField( {
+					title: 'Width (mm)',
+					dataName: widthId,
+					logic: 'on',
+					conditions: {
+						visibility: 'Show',
+						bound: 'Any',
+						rules: [
+							{
+								elements: configAId,
+								operators: 'is',
+								element_values: 'Config-G',
+							},
+							{
+								elements: configBId,
+								operators: 'is',
+								element_values: 'Config-A',
+							},
+						],
+					},
+				} ),
+			],
+		} );
+		await attachPpomGroupToProducts( requestUtils, {
+			ppomId,
+			productIds: [ product.id ],
+		} );
+
+		await page.goto( `/?p=${ product.id }` );
+
+		const width = page.getByLabel( 'Width (mm)' );
+		await expect( width ).toBeHidden();
+
+		// Match only the FIRST source rule — the second source's lock used to
+		// go stale here and keep the field in the hidden payload.
+		await page
+			.locator( `select[name="ppom[fields][${ configAId }]"]` )
+			.selectOption( { label: 'Config-G' } );
+		await expect( width ).toBeVisible();
+
+		await width.fill( '500' );
+
+		// The posted payload must agree with what the customer sees.
+		await expect( page.locator( '#conditionally_hidden' ) ).not.toHaveValue(
+			new RegExp( widthId )
+		);
+
+		await page
+			.locator( 'button.single_add_to_cart_button' )
+			.click( { timeout: 60000 } );
+
+		// The width value must reach the cart item meta. Polled with a short
+		// per-request timeout: the wp-env Store API occasionally hangs.
+		await expect
+			.poll(
+				async () => {
+					const response = await page.request
+						.get( '/?rest_route=/wc/store/v1/cart', {
+							timeout: 15000,
+						} )
+						.catch( () => null );
+
+					if ( ! response || ! response.ok() ) {
+						return 'cart-request-failed';
+					}
+
+					const cart = await response.json();
+					const item = cart.items?.[ 0 ];
+					if ( ! item ) {
+						return 'cart-empty';
+					}
+
+					const widthMeta = ( item.item_data || [] ).find(
+						( meta ) => meta.value === '500'
+					);
+					return widthMeta ? 'width-in-cart' : 'width-missing';
+				},
+				{ timeout: 120000, intervals: [ 3000 ] }
+			)
+			.toBe( 'width-in-cart' );
+	} );
+} );


### PR DESCRIPTION
## Summary

Fixes Codeinwp/ppom-pro#541 — a field with condition rules spanning two different source fields showed correctly on the product page but never appeared in the cart.

Root cause: the `#conditionally_hidden` payload (consumed by cart/checkout to skip hidden fields) was built from wrappers matching `[class*="ppom-locked-"]`. The evaluator adds a `ppom-locked-<source>` class per source field but on show only removes the lock of the source whose rule matched. With `bound: Any` rules across two mutually-exclusive sources (the reporter's insert-config OR tray-config setup), the non-matching source's lock went stale — the field was visible on the page (`ppom-c-hide` removed) yet still listed as conditionally hidden, so the cart skipped it. Single-source conditions never hit this, matching the report exactly.

Change: derive the payload from `.ppom-field-wrapper.ppom-c-hide` — the actual visual state — in `ppom_fields_hidden_conditionally()` (`js/ppom-conditions-v2.js`). One source of truth: what the customer sees hidden is what's reported hidden. This also stops visible Hide-visibility fields (which get `ppom-locked-*` classes at render) from being mis-listed at page load.

## Testing

- New e2e spec `tests/e2e/specs/multi-source-conditions-cart.spec.js`: text field with `bound: Any` rules across two source selects; matches only the first source's rule, asserts the field is visible, absent from `#conditionally_hidden`, and that its value reaches the cart item meta via the Store API.
- Red/green verified: without the fix the payload contains the visible field and its value never reaches the cart — the customer's exact symptom.
- Full existing conditions e2e suite (7 tests: is/not/Hide/Any/All/any+empty/pro-contains) green — no regressions from the payload change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)