### PR TITLE
Skipped HTML fields when show in cart is disabled

### DIFF
--- a/src/Support/Helpers.php
+++ b/src/Support/Helpers.php
@@ -865,6 +865,12 @@ final class Helpers {
 			$meta_data_field = apply_filters( 'ppom_meta_data_field', $meta_data, $key, $field_meta, $product_id );
 			// new filter with cart $value
 			$meta_data_field   = apply_filters( 'ppom_fields_cart_meta', $meta_data_field, $key, $field_meta, $product_id, $ppom_cart_fields );
+
+			// Skip fields that produced no cart meta.
+			if ( empty( $meta_data_field ) ) {
+				continue;
+			}
+
 			$ppom_meta[ $key ] = $meta_data_field;
 
 			$ppom_meta[ $key ]['type'] = $field_type;

--- a/src/WooCommerce/Cart/CartHandler.php
+++ b/src/WooCommerce/Cart/CartHandler.php
@@ -692,9 +692,9 @@ final class CartHandler {
 
 		return array(
 			'name'    => $key,
-			'value'   => $meta,
+			'value'   => wp_json_encode( $meta ),
 			'hidden'  => $hidden,
-			'display' => $display,
+			'display' => is_scalar( $display ) ? $display : wp_json_encode( $display ),
 		);
 	}
 

--- a/tests/unit/class-ppom-test-case.php
+++ b/tests/unit/class-ppom-test-case.php
@@ -660,6 +660,27 @@ abstract class PPOM_Test_Case extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Build a section/HTML field definition.
+	 *
+	 * @param string $data_name Field data name.
+	 * @param string $title     Field title.
+	 * @param array  $overrides Field overrides.
+	 *
+	 * @return array
+	 */
+	protected function build_section_field( $data_name, $title = 'Section', $overrides = array() ) {
+		return array_merge(
+			array(
+				'type'      => 'section',
+				'title'     => $title,
+				'data_name' => $data_name,
+				'html'      => '<p>Static content</p>',
+			),
+			$overrides
+		);
+	}
+
+	/**
 	 * Count PPOM field-group rows.
 	 *
 	 * @return int

--- a/tests/unit/test-cart-and-options.php
+++ b/tests/unit/test-cart-and-options.php
@@ -49,6 +49,68 @@ class Test_Cart_And_Options extends PPOM_Test_Case {
 	}
 
 	/**
+	 * Ensure section/HTML fields with "Show in Cart" disabled produce no cart meta entry.
+	 *
+	 * @return void
+	 */
+	public function testMakeMetaDataSkipsSectionFieldWhenCartDisplayIsOff() {
+		$product = $this->create_simple_product();
+		$meta_id = $this->insert_ppom_meta(
+			array(
+				$this->build_section_field( 'terms_notice', 'Terms Notice', array( 'cart_display' => 'off' ) ),
+			),
+			$product->get_id()
+		);
+
+		$meta = ppom_make_meta_data(
+			array(
+				'data' => $product,
+				'ppom' => array(
+					'fields' => array(
+						'id'           => (string) $meta_id,
+						'terms_notice' => '<p>Static content</p>',
+					),
+				),
+			),
+			'cart'
+		);
+
+		$this->assertArrayNotHasKey( 'terms_notice', $meta );
+	}
+
+	/**
+	 * Ensure section/HTML fields with "Show in Cart" enabled still render in cart meta.
+	 *
+	 * @return void
+	 */
+	public function testMakeMetaDataRendersSectionFieldWhenCartDisplayIsOn() {
+		$product = $this->create_simple_product();
+		$meta_id = $this->insert_ppom_meta(
+			array(
+				$this->build_section_field( 'terms_notice', 'Terms Notice', array( 'cart_display' => 'on' ) ),
+			),
+			$product->get_id()
+		);
+
+		$meta = ppom_make_meta_data(
+			array(
+				'data' => $product,
+				'ppom' => array(
+					'fields' => array(
+						'id'           => (string) $meta_id,
+						'terms_notice' => '<p>Static content</p>',
+					),
+				),
+			),
+			'cart'
+		);
+
+		$this->assertArrayHasKey( 'terms_notice', $meta );
+		$this->assertSame( 'Terms Notice', $meta['terms_notice']['name'] );
+		$this->assertSame( 'Static content', $meta['terms_notice']['value'] );
+	}
+
+	/**
 	 * Ensure checkbox arrays are rendered as a readable comma-separated value.
 	 *
 	 * @return void


### PR DESCRIPTION
### Summary
Skipped rendering HTML fields in the cart when the **"Show in Cart"** option is disabled.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/674