### PR TITLE
fix: qualify global PPOM_FRONTEND_SCRIPTS in [ppom] shortcode callback (#677)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4711,12 +4711,6 @@ parameters:
 			path: src/Hooks/Callbacks.php
 
 		-
-			message: '#^Call to static method load_scripts_by_product_id\(\) on an unknown class PPOM\\Hooks\\PPOM_FRONTEND_SCRIPTS\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Hooks/Callbacks.php
-
-		-
 			message: '#^Constant PPOM_URL not found\.$#'
 			identifier: constant.notFound
 			count: 23

--- a/src/Hooks/Callbacks.php
+++ b/src/Hooks/Callbacks.php
@@ -1027,7 +1027,7 @@ final class Callbacks {
 				return ob_get_clean();
 			}
 
-			\PPOM_FRONTEND_SCRIPTS::load_scripts_by_product_id( $params['product_id'], '', 'shortcode' );
+			\PPOM_FRONTEND_SCRIPTS::load_scripts_by_product_id( (int) $params['product_id'], null, 'shortcode' );
 			?>
 		<form class="cart"
 				action="<?php echo esc_url( apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() ) ); ?>"

--- a/src/Hooks/Callbacks.php
+++ b/src/Hooks/Callbacks.php
@@ -1027,7 +1027,7 @@ final class Callbacks {
 				return ob_get_clean();
 			}
 
-			PPOM_FRONTEND_SCRIPTS::load_scripts_by_product_id( $params['product_id'], '', 'shortcode' );
+			\PPOM_FRONTEND_SCRIPTS::load_scripts_by_product_id( $params['product_id'], '', 'shortcode' );
 			?>
 		<form class="cart"
 				action="<?php echo esc_url( apply_filters( 'woocommerce_add_to_cart_form_action', $product->get_permalink() ) ); ?>"

--- a/tests/unit/test-shortcode-render-regression.php
+++ b/tests/unit/test-shortcode-render-regression.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Regression coverage for the `[ppom]` shortcode renderer.
+ *
+ * Guards against issue #677: the shortcode callback lives in namespace
+ * `PPOM\Hooks`, so an unqualified reference to the legacy global
+ * `PPOM_FRONTEND_SCRIPTS` class resolves to `PPOM\Hooks\PPOM_FRONTEND_SCRIPTS`
+ * and fatals with "Class ... not found" when a `product_id` is supplied.
+ *
+ * @package ppom-pro
+ */
+
+class Test_Shortcode_Render_Regression extends PPOM_Test_Case {
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private function text_field() {
+		return array(
+			'type'       => 'text',
+			'title'      => 'Custom text',
+			'data_name'  => 'custom_text',
+			'visibility' => 'everyone',
+			'status'     => 'on',
+		);
+	}
+
+	/**
+	 * Rendering the shortcode with a valid product_id must not fatal and must
+	 * return the add-to-cart form markup.
+	 *
+	 * @return void
+	 */
+	public function test_render_shortcode_with_product_id_does_not_fatal() {
+		$product = $this->create_simple_product();
+		$this->insert_ppom_meta( array( $this->text_field() ), $product->get_id() );
+
+		$output = \PPOM\Hooks\Callbacks::render_shortcode( array( 'product_id' => (string) $product->get_id() ) );
+
+		$this->assertIsString( $output );
+		$this->assertStringContainsString( '<form class="cart"', $output );
+		$this->assertStringContainsString( 'name="add-to-cart"', $output );
+	}
+
+	/**
+	 * An invalid product_id should render the validation notice rather than fatal.
+	 *
+	 * @return void
+	 */
+	public function test_render_shortcode_with_invalid_product_id_returns_notice() {
+		$output = \PPOM\Hooks\Callbacks::render_shortcode( array( 'product_id' => '999999' ) );
+
+		$this->assertIsString( $output );
+		$this->assertStringContainsString( 'Product ID is not valid', $output );
+	}
+}


### PR DESCRIPTION
### Summary

Fixes #677 — rendering a `[ppom product_id="..."]` shortcode fatals on PPOM 34.x:

```
Fatal error: Uncaught Error: Class "PPOM\Hooks\PPOM_FRONTEND_SCRIPTS" not found
in src/Hooks/Callbacks.php:1030
```

The `[ppom]` shortcode callback was moved into `namespace PPOM\Hooks` during the
v34.0.0 refactor (a8f17ea, #565), but the `PPOM_FRONTEND_SCRIPTS` reference was
left unqualified. Inside the namespace it resolves to the non-existent
`PPOM\Hooks\PPOM_FRONTEND_SCRIPTS` instead of the global class, so the shortcode
path (which requires a non-empty `product_id`) fatals.

**Fix:** qualify the call with a leading backslash so it resolves to the global class.
While making it, PHPStan (which had this error baselined) now resolves the real class
and flagged two pre-existing arg-type issues, so the call also casts `product_id` to
`int` and passes `null` for the optional `ppom_id` (only ever read via `! empty()`,
so behavior is identical). The stale `phpstan-baseline.neon` entry is removed.

Regression introduced in **v34.0.0**; affects 34.0.0–34.0.5. Last good version 33.x
(shortcode handler was procedural, in the global namespace). Matches the customer
report that rolling back to 33.0.13 restored normal behavior.

### Will affect visual aspect of the product
NO

### Test instructions

- On PPOM 34.x, create a page containing `[ppom product_id="<a valid product id>"]`.
- Before the fix: saving/viewing the page fatals with the error above.
- With the fix: the page renders the PPOM fields add-to-cart form without error.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes #677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
