### PR TITLE
fix: stop transient DB read failures from deleting product PPOM assignments

### DIFF
--- a/bin/wp-env/mu-plugins/ppom-e2e-bootstrap.php
+++ b/bin/wp-env/mu-plugins/ppom-e2e-bootstrap.php
@@ -31,6 +31,49 @@ if ( ! defined( 'PPOM_E2E_LICENSE_FILTER_PRIORITY' ) ) {
 	define( 'PPOM_E2E_LICENSE_FILTER_PRIORITY', PHP_INT_MAX - 10 );
 }
 
+if ( ! defined( 'PPOM_E2E_BREAK_GROUP_READS_OPTION' ) ) {
+	define( 'PPOM_E2E_BREAK_GROUP_READS_OPTION', 'ppom_e2e_break_group_reads' );
+}
+
+/**
+ * Rewrite SELECTs on the PPOM field-group table to a nonexistent table so they
+ * error out, simulating a transient DB read failure (lock/timeout/dropped
+ * connection) for E2E coverage of issue #679.
+ *
+ * @param string $query SQL query.
+ * @return string
+ */
+function ppom_e2e_break_group_reads_query( $query ) {
+	global $wpdb;
+
+	if ( ! defined( 'PPOM_TABLE_META' ) ) {
+		return $query;
+	}
+
+	$table = $wpdb->prefix . PPOM_TABLE_META;
+
+	if ( 0 === stripos( ltrim( $query ), 'SELECT' ) && false !== strpos( $query, $table ) ) {
+		return str_replace( $table, $table . '_e2e_missing', $query );
+	}
+
+	return $query;
+}
+
+/**
+ * Arm the group-read failure simulation when the fixture option is on.
+ *
+ * Registered at plugins_loaded so PPOM_TABLE_META exists and every later
+ * front-end read (wp_enqueue_scripts → PPOM_Meta) goes through the filter.
+ *
+ * @return void
+ */
+function ppom_e2e_maybe_arm_group_read_failure() {
+	if ( get_option( PPOM_E2E_BREAK_GROUP_READS_OPTION ) ) {
+		add_filter( 'query', 'ppom_e2e_break_group_reads_query' );
+	}
+}
+add_action( 'plugins_loaded', 'ppom_e2e_maybe_arm_group_read_failure', 20 );
+
 /**
  * Ensure product fixture pages render through WooCommerce's product template.
  *
@@ -1392,6 +1435,116 @@ add_action( 'wp_ajax_ppom_e2e_read_license_fixture', 'ppom_e2e_read_license_fixt
 add_action( 'wp_ajax_nopriv_ppom_e2e_read_license_fixture', 'ppom_e2e_read_license_fixture' );
 
 /**
+ * Toggle the simulated transient failure of PPOM field-group reads.
+ *
+ * @return void
+ */
+function ppom_e2e_set_group_read_failure() {
+	ppom_e2e_require_capability();
+	ppom_e2e_require_nonce();
+
+	$enabled_raw = isset( $_POST['enabled'] ) ? sanitize_text_field( wp_unslash( $_POST['enabled'] ) ) : '';
+	$enabled     = in_array( $enabled_raw, array( '1', 'true', 'yes' ), true );
+
+	if ( $enabled ) {
+		update_option( PPOM_E2E_BREAK_GROUP_READS_OPTION, '1', false );
+	} else {
+		delete_option( PPOM_E2E_BREAK_GROUP_READS_OPTION );
+	}
+
+	wp_send_json_success(
+		array(
+			'enabled' => $enabled,
+		)
+	);
+}
+add_action( 'wp_ajax_ppom_e2e_set_group_read_failure', 'ppom_e2e_set_group_read_failure' );
+add_action( 'wp_ajax_nopriv_ppom_e2e_set_group_read_failure', 'ppom_e2e_set_group_read_failure' );
+
+/**
+ * Read a product's raw PPOM assignment post meta (for E2E assertions).
+ *
+ * @return void
+ */
+function ppom_e2e_get_product_ppom_assignment() {
+	ppom_e2e_require_capability();
+	ppom_e2e_require_nonce();
+
+	$product_id = isset( $_POST['product_id'] ) ? absint( wp_unslash( $_POST['product_id'] ) ) : 0;
+
+	if ( $product_id <= 0 ) {
+		wp_send_json_error(
+			array(
+				'message' => 'A valid product_id is required.',
+			),
+			400
+		);
+	}
+
+	if ( ! defined( 'PPOM_PRODUCT_META_KEY' ) ) {
+		wp_send_json_error(
+			array(
+				'message' => 'PPOM product meta key constant is unavailable.',
+			),
+			500
+		);
+	}
+
+	$raw = get_post_meta( $product_id, PPOM_PRODUCT_META_KEY, true );
+
+	wp_send_json_success(
+		array(
+			'exists'   => metadata_exists( 'post', $product_id, PPOM_PRODUCT_META_KEY ),
+			'meta_ids' => array_values( array_filter( array_map( 'absint', (array) $raw ) ) ),
+		)
+	);
+}
+add_action( 'wp_ajax_ppom_e2e_get_product_ppom_assignment', 'ppom_e2e_get_product_ppom_assignment' );
+add_action( 'wp_ajax_nopriv_ppom_e2e_get_product_ppom_assignment', 'ppom_e2e_get_product_ppom_assignment' );
+
+/**
+ * Hard-delete PPOM field-group rows, leaving product assignments untouched.
+ *
+ * Simulates a genuinely deleted group so E2E can assert the stale-assignment
+ * cleanup in PPOM_Meta::get_fields() still runs on confirmed absence.
+ *
+ * @return void
+ */
+function ppom_e2e_delete_ppom_group_rows() {
+	ppom_e2e_require_capability();
+	ppom_e2e_require_nonce();
+
+	$ppom_ids = ppom_e2e_decode_json_request( 'ppom_ids', array() );
+
+	if ( is_wp_error( $ppom_ids ) ) {
+		ppom_e2e_send_wp_error( $ppom_ids );
+	}
+
+	$ppom_ids = is_array( $ppom_ids )
+		? array_values( array_unique( array_filter( array_map( 'absint', $ppom_ids ) ) ) )
+		: array();
+
+	if ( empty( $ppom_ids ) ) {
+		wp_send_json_error(
+			array(
+				'message' => 'At least one valid ppom_id is required.',
+			),
+			400
+		);
+	}
+
+	$deleted = ppom_meta_repository()->delete_by_ids( $ppom_ids );
+
+	wp_send_json_success(
+		array(
+			'deleted_rows' => false !== $deleted ? (int) $deleted : 0,
+		)
+	);
+}
+add_action( 'wp_ajax_ppom_e2e_delete_ppom_group_rows', 'ppom_e2e_delete_ppom_group_rows' );
+add_action( 'wp_ajax_nopriv_ppom_e2e_delete_ppom_group_rows', 'ppom_e2e_delete_ppom_group_rows' );
+
+/**
  * Reset PPOM E2E fixture state.
  *
  * @return void
@@ -1419,6 +1572,7 @@ function ppom_e2e_reset_state() {
 
 	delete_option( PPOM_E2E_META_IDS_OPTION );
 	delete_option( PPOM_E2E_LICENSE_FIXTURE_OPTION );
+	delete_option( PPOM_E2E_BREAK_GROUP_READS_OPTION );
 	update_option( 'woocommerce_coming_soon', 'no', false );
 	update_option( 'woocommerce_store_pages_only', 'no', false );
 

--- a/classes/ppom.class.php
+++ b/classes/ppom.class.php
@@ -351,7 +351,12 @@ class PPOM_Meta {
 			if ( ! empty( $valid_ids ) ) {
 				$this->meta_id = $this->has_multiple_meta() ? $valid_ids : (int) reset( $valid_ids );
 				update_post_meta( self::$product_id, PPOM_PRODUCT_META_KEY, $valid_ids );
-			} else {
+			} elseif ( 0 === $repo->count_rows_by_productmeta_ids( array_map( 'absint', (array) $this->meta_id ) ) ) {
+				// Deleting the assignment is only safe once the groups are
+				// confirmed gone: the row read above returns empty both when the
+				// groups were deleted and when the query transiently failed
+				// (DB under load, lock/timeout, dropped connection), and acting
+				// on the latter permanently drops a valid product↔group link.
 				$this->meta_id = null;
 				delete_post_meta( self::$product_id, PPOM_PRODUCT_META_KEY );
 			}

--- a/src/Data/FieldGroupRepository.php
+++ b/src/Data/FieldGroupRepository.php
@@ -87,6 +87,39 @@ final class FieldGroupRepository {
 	}
 
 	/**
+	 * Definitive existence check for a set of field-group IDs.
+	 *
+	 * Unlike {@see get_rows_by_productmeta_ids()}, a failed query is reported
+	 * as `null` instead of an empty result, so callers can tell "rows are
+	 * confirmed absent" apart from "the read failed this request".
+	 *
+	 * @param array<int> $productmeta_ids Numeric IDs.
+	 * @return int|null Number of matching rows, or null when the query failed.
+	 */
+	public function count_rows_by_productmeta_ids( array $productmeta_ids ): ?int {
+		$productmeta_ids = array_values(
+			array_filter(
+				array_map( 'absint', $productmeta_ids )
+			)
+		);
+
+		if ( array() === $productmeta_ids ) {
+			return 0;
+		}
+
+		global $wpdb;
+		$table        = $this->table_name();
+		$placeholders = implode( ', ', array_fill( 0, count( $productmeta_ids ), '%d' ) );
+		$count        = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE productmeta_id IN ({$placeholders})", $productmeta_ids ) );
+
+		if ( null === $count || '' !== $wpdb->last_error ) {
+			return null;
+		}
+
+		return (int) $count;
+	}
+
+	/**
 	 * @param int $productmeta_id Field-group ID.
 	 * @return string|null JSON `the_meta` column.
 	 */

--- a/tests/e2e/fixtures/index.js
+++ b/tests/e2e/fixtures/index.js
@@ -5,7 +5,10 @@ export {
 	createLegacyPpomGroup,
 	createPpomGroup,
 	createSimpleTextGroup,
+	deletePpomGroupRows,
 	getPpomAttachRowMeta,
+	getProductPpomAssignment,
+	setPpomGroupReadFailure,
 } from './ppom.js';
 export {
 	buildCheckboxField,

--- a/tests/e2e/fixtures/ppom.js
+++ b/tests/e2e/fixtures/ppom.js
@@ -135,6 +135,36 @@ async function getPpomAttachRowMeta( requestUtils, { ppomId } ) {
 	} );
 }
 
+async function setPpomGroupReadFailure( requestUtils, { enabled } ) {
+	return postBootstrapAction(
+		requestUtils,
+		'ppom_e2e_set_group_read_failure',
+		{
+			enabled: enabled ? '1' : '0',
+		}
+	);
+}
+
+async function getProductPpomAssignment( requestUtils, { productId } ) {
+	return postBootstrapAction(
+		requestUtils,
+		'ppom_e2e_get_product_ppom_assignment',
+		{
+			product_id: productId,
+		}
+	);
+}
+
+async function deletePpomGroupRows( requestUtils, { ppomIds } ) {
+	return postBootstrapAction(
+		requestUtils,
+		'ppom_e2e_delete_ppom_group_rows',
+		{
+			ppom_ids: ppomIds,
+		}
+	);
+}
+
 export {
 	attachPpomGroupToCategories,
 	attachPpomGroupToProducts,
@@ -142,5 +172,8 @@ export {
 	createLegacyPpomGroup,
 	createPpomGroup,
 	createSimpleTextGroup,
+	deletePpomGroupRows,
 	getPpomAttachRowMeta,
+	getProductPpomAssignment,
+	setPpomGroupReadFailure,
 };

--- a/tests/e2e/specs/transient-read-failure.spec.js
+++ b/tests/e2e/specs/transient-read-failure.spec.js
@@ -1,0 +1,102 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from "@wordpress/e2e-test-utils-playwright";
+
+import {
+	attachPpomGroupToProducts,
+	createSimpleProduct,
+	createSimpleTextGroup,
+	deletePpomGroupRows,
+	getProductPpomAssignment,
+	setPpomGroupReadFailure,
+} from "../fixtures/index.js";
+
+/**
+ * Issue #679: a transient failure of the field-group read on a front-end
+ * product load must not permanently delete the product's `_product_meta_id`
+ * assignment. Only a confirmed absence of the group rows may clean it up.
+ *
+ * @see https://github.com/Codeinwp/woocommerce-product-addon/issues/679
+ */
+test.describe("PPOM assignment vs transient field-group read failures", () => {
+	test.afterEach(async ({ requestUtils }) => {
+		// Never leak the failure simulation into other specs.
+		await setPpomGroupReadFailure(requestUtils, { enabled: false });
+	});
+
+	test("assignment survives a failed group read and the form self-heals", async ({
+		page,
+		requestUtils,
+	}) => {
+		const product = await createSimpleProduct(requestUtils, {
+			name: "Transient Failure Product",
+		});
+		const { ppomId } = await createSimpleTextGroup(requestUtils, {
+			groupName: "Transient Failure Group",
+			fieldsNumber: 1,
+		});
+		await attachPpomGroupToProducts(requestUtils, {
+			ppomId,
+			productIds: [product.id],
+		});
+
+		// Sanity: the form renders while reads are healthy.
+		await page.goto(`/?p=${product.id}`);
+		await expect(page.locator(`.ppom-id-${ppomId}`).first()).toBeVisible();
+
+		// Simulate the transient DB failure and load the product page once —
+		// this single storefront request used to delete the assignment.
+		await setPpomGroupReadFailure(requestUtils, { enabled: true });
+		await page.goto(`/?p=${product.id}`);
+		await expect(page.locator(`.ppom-id-${ppomId}`)).toHaveCount(0);
+
+		// Reads recover.
+		await setPpomGroupReadFailure(requestUtils, { enabled: false });
+
+		// The stored assignment must have survived the failed read…
+		const assignment = await getProductPpomAssignment(requestUtils, {
+			productId: product.id,
+		});
+		expect(assignment.exists).toBe(true);
+		expect(assignment.meta_ids).toContain(ppomId);
+
+		// …and the form must come back without any admin intervention.
+		await page.goto(`/?p=${product.id}`);
+		await expect(page.locator(`.ppom-id-${ppomId}`).first()).toBeVisible();
+	});
+
+	test("confirmed-deleted group still cleans up the stale assignment", async ({
+		page,
+		requestUtils,
+	}) => {
+		const product = await createSimpleProduct(requestUtils, {
+			name: "Stale Cleanup Product",
+		});
+		const { ppomId } = await createSimpleTextGroup(requestUtils, {
+			groupName: "Stale Cleanup Group",
+			fieldsNumber: 1,
+		});
+		await attachPpomGroupToProducts(requestUtils, {
+			ppomId,
+			productIds: [product.id],
+		});
+
+		// Sanity: the form renders before the group row disappears.
+		await page.goto(`/?p=${product.id}`);
+		await expect(page.locator(`.ppom-id-${ppomId}`).first()).toBeVisible();
+
+		// Hard-delete the group row while the assignment stays behind, then
+		// load the product page so get_fields() reconciles the stored ids.
+		await deletePpomGroupRows(requestUtils, { ppomIds: [ppomId] });
+		await page.goto(`/?p=${product.id}`);
+		await expect(page.locator(`.ppom-id-${ppomId}`)).toHaveCount(0);
+
+		// Confirmed absence must still remove the stale assignment.
+		const assignment = await getProductPpomAssignment(requestUtils, {
+			productId: product.id,
+		});
+		expect(assignment.exists).toBe(false);
+		expect(assignment.meta_ids).toEqual([]);
+	});
+});

--- a/tests/unit/test-ppom-meta-multi-group.php
+++ b/tests/unit/test-ppom-meta-multi-group.php
@@ -169,6 +169,73 @@ class Test_PPOM_Meta_Multi_Group extends PPOM_Test_Case {
 	}
 
 	/**
+	 * get_fields() must NOT delete the product's assignment when the field-group
+	 * read fails transiently (DB under load, lock/timeout, dropped connection).
+	 * A failed read returns the same empty result as "rows deleted", and the
+	 * cleanup used to treat both as "group gone" and permanently drop the
+	 * product↔group link on a single front-end page load.
+	 *
+	 * @see https://github.com/Codeinwp/woocommerce-product-addon/issues/679
+	 *
+	 * @return void
+	 */
+	public function test_get_fields_keeps_assignment_when_group_read_fails_transiently() {
+		global $wpdb;
+
+		$product = $this->create_simple_product();
+
+		$meta_a = $this->insert_ppom_meta(
+			array( $this->build_text_field( 'a_field', 'A' ) )
+		);
+		$meta_b = $this->insert_ppom_meta(
+			array( $this->build_text_field( 'b_field', 'B' ) )
+		);
+
+		update_post_meta(
+			$product->get_id(),
+			PPOM_PRODUCT_META_KEY,
+			array( $meta_a, $meta_b )
+		);
+
+		$ppom_table  = \PPOM\Data\FieldGroupRepository::instance()->table_name();
+		$break_reads = static function ( $query ) use ( $ppom_table ) {
+			// Point SELECTs on the PPOM table at a table that does not exist so
+			// they error out, mimicking a transient read failure.
+			if ( 0 === stripos( ltrim( $query ), 'SELECT' ) && false !== strpos( $query, $ppom_table ) ) {
+				return str_replace( $ppom_table, $ppom_table . '_missing_for_test', $query );
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $break_reads );
+		$suppress = $wpdb->suppress_errors( true );
+
+		try {
+			$ppom = new PPOM_Meta( $product->get_id() );
+			// The form cannot render this request…
+			$this->assertSame( array(), (array) $ppom->fields );
+		} finally {
+			remove_filter( 'query', $break_reads );
+			$wpdb->suppress_errors( $suppress );
+		}
+
+		// …but the assignment must survive the failed read.
+		$stored = get_post_meta( $product->get_id(), PPOM_PRODUCT_META_KEY, true );
+		$this->assertIsArray( $stored );
+		$this->assertSame(
+			array( $meta_a, $meta_b ),
+			array_values( array_map( 'intval', $stored ) )
+		);
+
+		// Once reads recover, the form comes back on its own.
+		$ppom       = new PPOM_Meta( $product->get_id() );
+		$data_names = array_column( (array) $ppom->fields, 'data_name' );
+		$this->assertContains( 'a_field', $data_names );
+		$this->assertContains( 'b_field', $data_names );
+	}
+
+	/**
 	 * single_meta_id() must not crash when meta_id ends up as an associative
 	 * array (e.g. preserved keys from a Pro filter on `ppom_product_meta_id`).
 	 * The legacy `$arr[0]` access raised a PHP notice / fatal under strict


### PR DESCRIPTION
## Summary

Fixes #679 — a product's PPOM assignment (`_product_meta_id`) was permanently deleted when the field-group read transiently returned empty on a front-end product load.

`PPOM_Meta::get_fields()` reconciles the stored assignment against `FieldGroupRepository::get_rows_by_productmeta_ids()`, a raw `$wpdb` read that returns `[]` both when the rows are genuinely gone **and** when the query fails (DB under load, lock/timeout, dropped connection). On the multi-meta path (always used by Pro), a single failed read triggered `delete_post_meta()` and irreversibly dropped a valid product<->group link — the field group itself stayed intact, matching the customer report.

## Fix

Rather than removing the stale-cleanup entirely (existing unit tests codify it as intended behavior), the delete is now gated on a **definitive existence check**:

- New `FieldGroupRepository::count_rows_by_productmeta_ids()`: a `COUNT(*)` that returns `null` when `$wpdb->last_error` shows the query failed, an `int` otherwise.
- `get_fields()` only deletes the assignment when that check returns exactly `0` (groups confirmed absent). On a failed read the assignment is left intact — the form skips one render and self-heals once reads recover.
- The partial-prune branch is unchanged: a partial result implies the read succeeded, so pruning confirmed-missing ids stays safe.

## Testing

- **Unit:** new `test_get_fields_keeps_assignment_when_group_read_fails_transiently` simulates failed reads via the `query` filter (SELECTs on the PPOM table pointed at a nonexistent table). Verified it **fails on `development` without the fix** (assignment deleted) and passes with it. Full suite: 444 tests green, including the existing stale-cleanup tests.
- **E2E (Playwright):** new `transient-read-failure.spec.js` plus bootstrap MU-plugin actions/fixtures to simulate the failure, read a product's raw assignment, and hard-delete group rows:
  1. assignment survives a failed group read on the storefront and the form self-heals without admin intervention (verified red on unfixed code);
  2. a genuinely deleted group still gets its stale assignment cleaned up on the next product load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)