### PR TITLE
fix: addon prices lost when third parties mutate prices during cart totals

### DIFF
--- a/src/Cart/WooCommerceCartLifecycleHooks.php
+++ b/src/Cart/WooCommerceCartLifecycleHooks.php
@@ -34,6 +34,9 @@ final class WooCommerceCartLifecycleHooks {
 
 			add_filter( 'woocommerce_get_cart_item_from_session', 'ppom_price_controller', 10, 2 );
 
+			// Late priority: re-assert the line price after third-party set_price() calls. See #680.
+			add_action( 'woocommerce_before_calculate_totals', 'ppom_before_calculate_totals', 1000 );
+
 			add_action( 'woocommerce_cart_calculate_fees', 'ppom_price_cart_fee' );
 			add_action( 'ppom_before_calculate_cart_total', 'ppom_hooks_update_cart_weight', 10, 3 );
 		}

--- a/src/Pricing/Engine.php
+++ b/src/Pricing/Engine.php
@@ -109,7 +109,7 @@ final class Engine {
 			$wc_product        = $cart_item['data'];
 			$ppom_fields_post  = $cart_item['ppom']['fields'];
 			$product_quantity  = floatval( $cart_item['quantity'] );
-			$ppom_field_prices = self::get_field_prices( $ppom_fields_post, $product_id, $product_quantity, $variation_id );
+			$ppom_field_prices = self::get_field_prices( $ppom_fields_post, $product_id, $product_quantity, $variation_id, $cart_item );
 			$ppom_discount     = 0;
 			$ppom_pricematrix  = isset( $cart_item['ppom']['price_matrix_found'] ) ? $cart_item['ppom']['price_matrix_found'] : null;
 			// ppom_pa($product_quantity);
@@ -119,7 +119,10 @@ final class Engine {
 			$total_addon_price    = self::price_get_addon_total( $ppom_field_prices );
 			$total_cart_fee_price = self::price_get_cart_fee_total( $ppom_field_prices );
 
-			$product_price = apply_filters( 'ppom_product_price_on_cart', $wc_product->get_price(), $cart_item );
+			// Base on the pristine catalog price, not the mutated in-cart price, so repeated passes never double-count.
+			$pristine      = wc_get_product( $variation_id ? $variation_id : $product_id );
+			$product_price = $pristine ? $pristine->get_price() : $wc_product->get_price();
+			$product_price = apply_filters( 'ppom_product_price_on_cart', $product_price, $cart_item );
 
 			// $context     = 'cart';
 			// $product_price   = Helpers::get_product_price( $product, $variation_id, $context);
@@ -145,8 +148,8 @@ final class Engine {
 
 			$ppom_total_price = $total_addon_price + $product_base_price - $ppom_discount;
 
-			do_action( 'ppom_before_calculate_cart_total', $ppom_field_prices, $ppom_fields_post, $cart_item );
-			$ppom_total_price = apply_filters( 'ppom_cart_line_total', $ppom_total_price, $cart_items, $cart_item );
+			// No ppom_before_calculate_cart_total here: its weight listener is not idempotent and would stack weight each pass.
+			$ppom_total_price = apply_filters( 'ppom_cart_line_total', $ppom_total_price, $cart_item, $cart_item );
 			$cart_item['data']->set_price( $ppom_total_price );
 		}
 	}

--- a/tests/unit/test-third-party-price-mutation.php
+++ b/tests/unit/test-third-party-price-mutation.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * Class Test_Third_Party_Price_Mutation
+ *
+ * Regression for issue #680: a third party (e.g. Kadence Shop Kit Variation
+ * Swatches) that calls set_price() during woocommerce_before_calculate_totals
+ * must not erase the PPOM addon price from the cart line total.
+ *
+ * @package ppom-pro
+ */
+
+require_once __DIR__ . '/class-ppom-test-case.php';
+
+class Test_Third_Party_Price_Mutation extends PPOM_Test_Case {
+
+	/**
+	 * A priced radio addon survives a competing set_price() during totals calculation.
+	 *
+	 * @return void
+	 */
+	public function testAddonPriceSurvivesThirdPartySetPriceDuringTotals() {
+		$product = $this->create_simple_product( array( 'regular_price' => '10' ) );
+
+		$this->insert_ppom_meta(
+			array(
+				array(
+					'type'      => 'radio',
+					'title'     => 'Gift wrap',
+					'data_name' => 'giftwrap',
+					'options'   => array(
+						array( 'option' => 'None', 'price' => '' ),
+						array( 'option' => 'Premium wrap', 'price' => '5' ),
+					),
+				),
+			),
+			$product->get_id()
+		);
+
+		$this->initialize_woocommerce_checkout_context();
+
+		$cart_key = $this->add_product_to_real_cart(
+			$product->get_id(),
+			array(
+				'fields' => array(
+					'giftwrap' => 'Premium wrap',
+				),
+			)
+		);
+
+		$this->assertNotFalse( $cart_key );
+
+		$reloaded = $this->reload_real_cart_from_session();
+
+		$this->assertSame( 15.0, (float) $reloaded[ $cart_key ]['data']->get_price() );
+
+		// Third-party plugin resets every line to the catalog price during totals.
+		add_action(
+			'woocommerce_before_calculate_totals',
+			function ( $cart ) {
+				foreach ( $cart->get_cart() as $cart_item ) {
+					$cart_item['data']->set_price( (float) $cart_item['data']->get_regular_price() );
+				}
+			},
+			20
+		);
+
+		WC()->cart->calculate_totals();
+
+		$this->assertSame( 15.0, (float) WC()->cart->get_total( 'edit' ) );
+	}
+
+	/**
+	 * The ppom_cart_line_total filter receives the cart item as second arg on the
+	 * totals-recalc path, same contract as the session-restore path.
+	 *
+	 * @return void
+	 */
+	public function testCartLineTotalFilterReceivesCartItemDuringTotalsRecalc() {
+		$product = $this->create_simple_product( array( 'regular_price' => '10' ) );
+
+		$this->insert_ppom_meta(
+			array(
+				array(
+					'type'      => 'radio',
+					'title'     => 'Gift wrap',
+					'data_name' => 'giftwrap',
+					'options'   => array(
+						array( 'option' => 'Premium wrap', 'price' => '5' ),
+					),
+				),
+			),
+			$product->get_id()
+		);
+
+		$this->initialize_woocommerce_checkout_context();
+
+		$cart_key = $this->add_product_to_real_cart(
+			$product->get_id(),
+			array(
+				'fields' => array(
+					'giftwrap' => 'Premium wrap',
+				),
+			)
+		);
+
+		$this->assertNotFalse( $cart_key );
+		$this->reload_real_cart_from_session();
+
+		$received = array();
+		add_filter(
+			'ppom_cart_line_total',
+			function ( $total, $cart_item ) use ( &$received ) {
+				$received[] = $cart_item;
+				return $total;
+			},
+			10,
+			2
+		);
+
+		WC()->cart->calculate_totals();
+
+		$this->assertNotEmpty( $received );
+		foreach ( $received as $cart_item ) {
+			$this->assertIsArray( $cart_item );
+			$this->assertSame( 'Premium wrap', $cart_item['ppom']['fields']['giftwrap'] );
+		}
+	}
+
+	/**
+	 * A variation line also survives a competing set_price() during totals,
+	 * recomputing from the variation's own catalog price.
+	 *
+	 * @return void
+	 */
+	public function testVariationAddonPriceSurvivesThirdPartySetPriceDuringTotals() {
+		$created   = $this->create_variable_product_with_variation( array(), array( 'regular_price' => '20' ) );
+		$product   = $created['product'];
+		$variation = $created['variation'];
+
+		$this->insert_ppom_meta(
+			array(
+				array(
+					'type'      => 'radio',
+					'title'     => 'Gift wrap',
+					'data_name' => 'giftwrap',
+					'options'   => array(
+						array( 'option' => 'Premium wrap', 'price' => '5' ),
+					),
+				),
+			),
+			$product->get_id()
+		);
+
+		$this->initialize_woocommerce_checkout_context();
+
+		$cart_key = $this->add_product_to_real_cart(
+			$product->get_id(),
+			array(
+				'fields' => array(
+					'giftwrap' => 'Premium wrap',
+				),
+			),
+			1,
+			$variation->get_id()
+		);
+
+		$this->assertNotFalse( $cart_key );
+
+		$reloaded = $this->reload_real_cart_from_session();
+
+		$this->assertSame( 25.0, (float) $reloaded[ $cart_key ]['data']->get_price() );
+
+		add_action(
+			'woocommerce_before_calculate_totals',
+			function ( $cart ) {
+				foreach ( $cart->get_cart() as $cart_item ) {
+					$cart_item['data']->set_price( (float) $cart_item['data']->get_regular_price() );
+				}
+			},
+			20
+		);
+
+		WC()->cart->calculate_totals();
+
+		$this->assertSame( 25.0, (float) WC()->cart->get_total( 'edit' ) );
+	}
+
+	/**
+	 * The addon price is included in totals within the same request as add-to-cart,
+	 * before any session restore — the wc-ajax=add_to_cart flow (issue #623).
+	 *
+	 * @return void
+	 */
+	public function testAddonPriceAppliesInSameRequestAsAddToCart() {
+		$product = $this->create_simple_product( array( 'regular_price' => '29' ) );
+
+		$this->insert_ppom_meta(
+			array(
+				array(
+					'type'      => 'radio',
+					'title'     => 'Gift wrap',
+					'data_name' => 'giftwrap',
+					'options'   => array(
+						array( 'option' => 'Premium wrap', 'price' => '10' ),
+					),
+				),
+			),
+			$product->get_id()
+		);
+
+		$this->initialize_woocommerce_checkout_context();
+
+		$cart_key = $this->add_product_to_real_cart(
+			$product->get_id(),
+			array(
+				'fields' => array(
+					'giftwrap' => 'Premium wrap',
+				),
+			)
+		);
+
+		$this->assertNotFalse( $cart_key );
+
+		// No session reload: AJAX fragments calculate totals before the session-restore filter runs.
+		WC()->cart->calculate_totals();
+
+		$this->assertSame( 39.0, (float) WC()->cart->get_total( 'edit' ) );
+	}
+
+	/**
+	 * Repeated totals passes must not stack the addon price (no double-count).
+	 *
+	 * @return void
+	 */
+	public function testRepeatedTotalsPassesDoNotDoubleCountAddonPrice() {
+		$product = $this->create_simple_product( array( 'regular_price' => '10' ) );
+
+		$this->insert_ppom_meta(
+			array(
+				array(
+					'type'      => 'radio',
+					'title'     => 'Gift wrap',
+					'data_name' => 'giftwrap',
+					'options'   => array(
+						array( 'option' => 'Premium wrap', 'price' => '5' ),
+					),
+				),
+			),
+			$product->get_id()
+		);
+
+		$this->initialize_woocommerce_checkout_context();
+
+		$cart_key = $this->add_product_to_real_cart(
+			$product->get_id(),
+			array(
+				'fields' => array(
+					'giftwrap' => 'Premium wrap',
+				),
+			)
+		);
+
+		$this->assertNotFalse( $cart_key );
+		$this->reload_real_cart_from_session();
+
+		WC()->cart->calculate_totals();
+		WC()->cart->calculate_totals();
+
+		$this->assertSame( 15.0, (float) WC()->cart->get_total( 'edit' ) );
+	}
+}


### PR DESCRIPTION
### Summary
PPOM set its cart line price only at session restore and never hooked `woocommerce_before_calculate_totals`, so any plugin calling `set_price()` during totals (e.g. Kadence Shop Kit Variation Swatches) replaced the PPOM-adjusted price — option label kept, amount lost.

Fix: register the existing but never-registered `ppom_before_calculate_totals` handler at priority 1000 so PPOM re-asserts its price on every totals pass. In the revived handler: base price comes from a pristine `wc_get_product()` (idempotent, no double-count), `ppom_cart_line_total` and `get_field_prices()` get the same args as the session-restore path, and the weight action is not re-fired (its listener isn't idempotent).

### Will affect visual aspect of the product
NO

### Test instructions
- `phpunit --filter Test_Third_Party_Price_Mutation` — 5 regression tests (competing mutation on simple/variation, filter contract, repeated passes, same-request AJAX with #623's 29+10 numbers).
- Manual, no Kadence needed: mu-plugin hooking `woocommerce_before_calculate_totals` (prio 20) with `set_price( get_regular_price() )`; $10 product + $5 priced radio option → cart line shows $15 (was $10).
- Full free suite passes (448 tests); Pro suite passes against this branch (139); PHPStan/PHPCS clean.

## Check before Pull Request is ready:

* [x] I have written a test and included it in this PR
* [x] I have run all tests and they pass
* [x] The code passes when running the PHP CodeSniffer
* [x] Code meets WordPress Coding Standards for PHP, HTML, CSS and JS
* [x] Security and Sanitization requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes #680. Likely also resolves #623.

