### PR TITLE
Fix empty value when using conditional select (#337)

### DIFF
--- a/js/ppom-conditions-v2.js
+++ b/js/ppom-conditions-v2.js
@@ -719,11 +719,25 @@ function ppom_set_default_option( field_id ) {
 			} );
 			break;
 
-		case 'select':
-			if ( '' === jQuery( '#' + field.data_name ).val() ) {
-				jQuery( '#' + field.data_name ).val( field.selected );
+		case 'select': {
+			// The hidden-field reset calls val('') on a select with no ''
+			// option, which leaves selectedIndex at -1 and makes val()
+			// return null — so a cleared select must be detected via both.
+			const $select = jQuery( '#' + field.data_name );
+			const current_value = $select.val();
+
+			if ( null === current_value || '' === current_value ) {
+				$select.val( field.selected );
+
+				// No configured default (or it no longer matches an option):
+				// fall back to the first option, matching the state the PHP
+				// renderer produces on initial page load.
+				if ( null === $select.val() ) {
+					$select.prop( 'selectedIndex', 0 );
+				}
 			}
 			break;
+		}
 
 		case 'image':
 			jQuery.each( field.images, function ( index, img ) {

--- a/tests/e2e/specs/conditional-select-default.spec.js
+++ b/tests/e2e/specs/conditional-select-default.spec.js
@@ -1,0 +1,163 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+import {
+	attachPpomGroupToProducts,
+	buildSelectField,
+	createPpomGroup,
+	createSimpleProduct,
+	setPpomLicenseFixture,
+} from '../fixtures/index.js';
+
+/**
+ * Regression coverage for #337: a Select field revealed by conditional
+ * logic must not end up with an empty value — it should show its default
+ * (explicitly configured via `selected`, or the first option otherwise).
+ *
+ * Repro shape mirrors the issue report: Select 1 controls Select 2 via
+ * Show + is, Select 3 is unconditioned.
+ */
+async function ensureFreeTier( requestUtils ) {
+	await setPpomLicenseFixture( requestUtils, {
+		valid: true,
+		plan: 1,
+		proInstalled: false,
+	} );
+}
+
+function uniqueToken() {
+	return `${ Date.now() }_${ Math.floor( Math.random() * 1e6 ) }`;
+}
+
+function selectByName( page, dataName ) {
+	return page.locator( `select[name="ppom[fields][${ dataName }]"]` );
+}
+
+async function createConditionalSelectProduct(
+	requestUtils,
+	{ token, conditionalOverrides = {} }
+) {
+	const controllingId = `select_one_${ token }`;
+	const conditionalId = `select_two_${ token }`;
+	const plainId = `select_three_${ token }`;
+
+	const product = await createSimpleProduct( requestUtils );
+	const { ppomId } = await createPpomGroup( requestUtils, {
+		groupName: `Conditional Select Default ${ token }`,
+		fields: [
+			buildSelectField( {
+				title: `Select One ${ token }`,
+				dataName: controllingId,
+				options: [
+					{ label: '1', value: 'opt_1' },
+					{ label: '2', value: 'opt_2' },
+					{ label: '3', value: 'opt_3' },
+				],
+			} ),
+			buildSelectField( {
+				title: `Select Two ${ token }`,
+				dataName: conditionalId,
+				options: [
+					{ label: '1.1', value: 'opt_1_1' },
+					{ label: '2.1', value: 'opt_2_1' },
+					{ label: '3.1', value: 'opt_3_1' },
+				],
+				logic: 'on',
+				conditions: {
+					visibility: 'Show',
+					bound: 'All',
+					rules: [
+						{
+							elements: controllingId,
+							operators: 'is',
+							element_values: '2',
+						},
+					],
+				},
+				...conditionalOverrides,
+			} ),
+			buildSelectField( {
+				title: `Select Three ${ token }`,
+				dataName: plainId,
+				options: [
+					{ label: '1.1', value: 'opt_1_1' },
+					{ label: '1.2', value: 'opt_1_2' },
+					{ label: '1.3', value: 'opt_1_3' },
+				],
+			} ),
+		],
+	} );
+
+	await attachPpomGroupToProducts( requestUtils, {
+		ppomId,
+		productIds: [ product.id ],
+	} );
+
+	return { product, controllingId, conditionalId, plainId };
+}
+
+test.describe( 'Conditional select default value (#337)', () => {
+	test( 'free: a conditionally revealed Select shows a non-empty value across show/hide cycles', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		await ensureFreeTier( requestUtils );
+
+		const token = uniqueToken();
+		const { product, controllingId, conditionalId } =
+			await createConditionalSelectProduct( requestUtils, { token } );
+
+		await page.goto( `/?p=${ product.id }` );
+
+		const controllingSelect = selectByName( page, controllingId );
+		const conditionalSelect = selectByName( page, conditionalId );
+
+		await expect( conditionalSelect ).toBeHidden();
+
+		await controllingSelect.selectOption( { label: '2' } );
+		await expect( conditionalSelect ).toBeVisible();
+		await expect( conditionalSelect ).toHaveValue( '1.1' );
+
+		// Hide it again, then re-show — the value must be restored, not empty.
+		await controllingSelect.selectOption( { label: '1' } );
+		await expect( conditionalSelect ).toBeHidden();
+
+		await controllingSelect.selectOption( { label: '2' } );
+		await expect( conditionalSelect ).toBeVisible();
+		await expect( conditionalSelect ).toHaveValue( '1.1' );
+	} );
+
+	test( 'free: a conditionally revealed Select restores its configured default option', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		await ensureFreeTier( requestUtils );
+
+		const token = uniqueToken();
+		const { product, controllingId, conditionalId } =
+			await createConditionalSelectProduct( requestUtils, {
+				token,
+				conditionalOverrides: { selected: '2.1' },
+			} );
+
+		await page.goto( `/?p=${ product.id }` );
+
+		const controllingSelect = selectByName( page, controllingId );
+		const conditionalSelect = selectByName( page, conditionalId );
+
+		await expect( conditionalSelect ).toBeHidden();
+
+		await controllingSelect.selectOption( { label: '2' } );
+		await expect( conditionalSelect ).toBeVisible();
+		await expect( conditionalSelect ).toHaveValue( '2.1' );
+
+		await controllingSelect.selectOption( { label: '3' } );
+		await expect( conditionalSelect ).toBeHidden();
+
+		await controllingSelect.selectOption( { label: '2' } );
+		await expect( conditionalSelect ).toBeVisible();
+		await expect( conditionalSelect ).toHaveValue( '2.1' );
+	} );
+} );


### PR DESCRIPTION
### Summary

Fixes the long-standing "empty value when using conditional select" bug (#337): a Select field revealed by conditional logic rendered blank — no option selected — even when a default value was configured.

**Root cause** (two stacked defects in `js/ppom-conditions-v2.js`):

1. When a conditional field is hidden (including on initial page load), the `ppom_field_hidden` handler clears selects with `.val( '' )`. Since no `<option>` has the value `''`, the browser sets `selectedIndex` to `-1` — and from then on `.val()` returns **`null`**, not `''`.
2. On re-show, `ppom_set_default_option()`'s `select` case only restored the default when `'' === .val()`. Because the value is `null`, the guard never fired, so the select stayed blank forever. Additionally, when no default is configured, `field.selected` is empty, so there was no fallback to the first option (the state the PHP renderer produces on initial page load).

**Fix:** in `ppom_set_default_option()`, treat a cleared select (`.val()` is `null` **or** `''`) as restorable: apply `field.selected`, and if that doesn't resolve to an existing option (no default configured), fall back to `selectedIndex 0`, mirroring the server-rendered initial state. A select the user already interacted with has a non-null value, so user choices are never overwritten.

This intentionally avoids the event-plumbing rewrite proposed in #508 (threading `was_hidden` through every `ppom_check_conditions` callback), which would have changed default-restore gating for all field types (checkbox/radio/image/quantities) and carried a much larger regression surface. Credit to @ab-tools for the original investigation and fix proposal in #508.

### Will affect visual aspect of the product
NO

### Test instructions

- Follow the steps in #337: create a PPOM group with Select 1 (options 1, 2, 3), Select 2 (options 1.1, 2.1, 3.1) with conditional logic "Show when Select 1 is 2", and Select 3 (no conditions); attach it to a product.
- On the product page, set Select 1 to "2" → Select 2 must appear showing "1.1" (its first option), not an empty value.
- Set a default option on Select 2 and repeat → it must appear showing the configured default.
- Toggle Select 1 away and back → the value must be restored each time.
- Automated coverage: `tests/e2e/specs/conditional-select-default.spec.js` (new, 2 tests) covers both scenarios including show/hide cycles; `conditions.spec.js`, `checkbox-conditions-import.spec.js`, and `multi-source-conditions-cart.spec.js` guard the surrounding conditions engine.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes #337. Supersedes #508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
