### PR TITLE
Fix runtime PPOM resolution rewriting product assignments

### DIFF
--- a/classes/class-ppom-meta-repository.php
+++ b/classes/class-ppom-meta-repository.php
@@ -775,7 +775,7 @@ class PPOM_Meta_Repository {
 	}
 
 	/**
-	 * Delete one row.
+	 * Delete one row and clean its direct product assignments after success.
 	 *
 	 * @param int $id Row id.
 	 * @return int|false Rows deleted or false.
@@ -793,12 +793,15 @@ class PPOM_Meta_Repository {
 		);
 		$this->invalidate_row_cache( $id );
 		$this->invalidate_aggregate_list_caches();
+		if ( $result > 0 ) {
+			$this->remove_product_assignments( array( $id ) );
+		}
 
 		return $result;
 	}
 
 	/**
-	 * Delete many rows in one prepared statement.
+	 * Delete many rows and clean their direct product assignments after success.
 	 *
 	 * @param array<int> $ids Row ids.
 	 * @return int|false
@@ -836,8 +839,56 @@ class PPOM_Meta_Repository {
 		if ( false === $result ) {
 			return false;
 		}
+		if ( $result > 0 ) {
+			$this->remove_product_assignments( $ids );
+		}
 
 		return (int) $result;
+	}
+
+	/**
+	 * Removes deleted field-group IDs from direct product assignments.
+	 *
+	 * @param array<int> $deleted_ids Deleted field-group IDs.
+	 * @return void
+	 */
+	private function remove_product_assignments( array $deleted_ids ) {
+		$deleted_ids = array_values( array_unique( array_filter( array_map( 'absint', $deleted_ids ) ) ) );
+		if ( empty( $deleted_ids ) ) {
+			return;
+		}
+
+		$query = $this->wpdb->prepare(
+			'SELECT post_id, meta_value FROM %i WHERE meta_key = %s',
+			$this->wpdb->postmeta,
+			PPOM_PRODUCT_META_KEY
+		);
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Prepared immediately above with identifier and value placeholders.
+		$assignments = $this->wpdb->get_results( $query, ARRAY_A );
+
+		foreach ( (array) $assignments as $assignment ) {
+			$post_id      = absint( $assignment['post_id'] ?? 0 );
+			$stored_value = maybe_unserialize( (string) ( $assignment['meta_value'] ?? '' ) );
+			$stored_ids   = (array) $stored_value;
+			$kept_ids     = array_values(
+				array_filter(
+					$stored_ids,
+					static function ( $stored_id ) use ( $deleted_ids ) {
+						return ! in_array( absint( $stored_id ), $deleted_ids, true );
+					}
+				)
+			);
+
+			if ( 0 === $post_id || count( $kept_ids ) === count( $stored_ids ) ) {
+				continue;
+			}
+
+			if ( empty( $kept_ids ) ) {
+				delete_post_meta( $post_id, PPOM_PRODUCT_META_KEY, $stored_value );
+			} else {
+				update_post_meta( $post_id, PPOM_PRODUCT_META_KEY, $kept_ids, $stored_value );
+			}
+		}
 	}
 
 	/**

--- a/classes/ppom.class.php
+++ b/classes/ppom.class.php
@@ -345,15 +345,14 @@ class PPOM_Meta {
 			}
 		}
 
-		// Cleanup meta_id if there are any invalid entries.
+		// Ignore invalid resolved IDs for this request without rewriting the
+		// product's stored assignment.
 		$valid_ids = array_filter( $valid_ids );
 		if ( count( $valid_ids ) !== count( (array) $this->meta_id ) ) {
 			if ( ! empty( $valid_ids ) ) {
 				$this->meta_id = $this->has_multiple_meta() ? $valid_ids : (int) reset( $valid_ids );
-				update_post_meta( self::$product_id, PPOM_PRODUCT_META_KEY, $valid_ids );
 			} else {
 				$this->meta_id = null;
-				delete_post_meta( self::$product_id, PPOM_PRODUCT_META_KEY );
 			}
 		}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5601,7 +5601,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property object\:\:\$productmeta_id\.$#'
 			identifier: property.notFound
-			count: 10
+			count: 9
 			path: src/Rest/ProductFieldGroupService.php
 
 		-

--- a/src/Rest/ProductFieldGroupService.php
+++ b/src/Rest/ProductFieldGroupService.php
@@ -187,13 +187,8 @@ final class ProductFieldGroupService {
 
 		// Check if all fields request exist.
 		if ( in_array( '__all_keys', $delete_fields ) ) {
-
-			// Unset product meta key.
-			delete_post_meta( $product_id, PPOM_PRODUCT_META_KEY );
-
 			// Deleting all fields.
-			$res                = ppom_meta_repository()->delete_by_id( (int) $ppom_meta->productmeta_id );
-			$delete_fields_resp = array( 'ppom_id' => $ppom_meta->productmeta_id );
+			ppom_meta_repository()->delete_by_id( (int) $ppom_meta->productmeta_id );
 
 			$resp = array(
 				'status'     => 'success',

--- a/tests/e2e/specs/transient-read-failure.spec.js
+++ b/tests/e2e/specs/transient-read-failure.spec.js
@@ -66,7 +66,7 @@ test.describe("PPOM assignment vs transient field-group read failures", () => {
 		await expect(page.locator(`.ppom-id-${ppomId}`).first()).toBeVisible();
 	});
 
-	test("confirmed-deleted group still cleans up the stale assignment", async ({
+	test("deleting a group cleans its product assignment at deletion time", async ({
 		page,
 		requestUtils,
 	}) => {
@@ -86,17 +86,16 @@ test.describe("PPOM assignment vs transient field-group read failures", () => {
 		await page.goto(`/?p=${product.id}`);
 		await expect(page.locator(`.ppom-id-${ppomId}`).first()).toBeVisible();
 
-		// Hard-delete the group row while the assignment stays behind, then
-		// load the product page so get_fields() reconciles the stored ids.
+		// Deleting the group row cleans the direct assignment immediately.
 		await deletePpomGroupRows(requestUtils, { ppomIds: [ppomId] });
-		await page.goto(`/?p=${product.id}`);
-		await expect(page.locator(`.ppom-id-${ppomId}`)).toHaveCount(0);
-
-		// Confirmed absence must still remove the stale assignment.
 		const assignment = await getProductPpomAssignment(requestUtils, {
 			productId: product.id,
 		});
 		expect(assignment.exists).toBe(false);
 		expect(assignment.meta_ids).toEqual([]);
+
+		// Storefront resolution stays read-only and simply renders no fields.
+		await page.goto(`/?p=${product.id}`);
+		await expect(page.locator(`.ppom-id-${ppomId}`)).toHaveCount(0);
 	});
 });

--- a/tests/unit/test-ppom-meta-multi-group.php
+++ b/tests/unit/test-ppom-meta-multi-group.php
@@ -107,12 +107,15 @@ class Test_PPOM_Meta_Multi_Group extends PPOM_Test_Case {
 	}
 
 	/**
-	 * get_fields() removes stale meta_id entries from the product's post meta
-	 * when the underlying row is gone, while preserving the surviving group.
+	 * get_fields() skips stale meta_id entries for the current request while
+	 * preserving the surviving group — and never rewrites the stored
+	 * assignment, because $this->meta_id is the display-time resolution
+	 * (direct + category + ppom_product_meta_id filter), not the stored
+	 * value (#686).
 	 *
 	 * @return void
 	 */
-	public function test_get_fields_cleans_up_stale_meta_id_reference() {
+	public function test_get_fields_skips_stale_reference_without_persisting() {
 		$product = $this->create_simple_product();
 
 		$valid_meta_id  = $this->insert_ppom_meta(
@@ -129,7 +132,6 @@ class Test_PPOM_Meta_Multi_Group extends PPOM_Test_Case {
 		$ppom = new PPOM_Meta( $product->get_id() );
 		$this->assertTrue( $ppom->has_multiple_meta() );
 
-		// Triggering the field resolver runs the cleanup.
 		$fields = (array) $ppom->get_fields();
 		$data_names = array_map(
 			static function ( $field ) {
@@ -139,18 +141,94 @@ class Test_PPOM_Meta_Multi_Group extends PPOM_Test_Case {
 		);
 		$this->assertContains( 'keep_field', $data_names );
 
+		// The stale id is dropped from the in-memory resolution only.
+		$this->assertSame( array( $valid_meta_id ), array_values( (array) $ppom->meta_id ) );
+
+		// The stored assignment is untouched — front-end reads must not write.
 		$stored = get_post_meta( $product->get_id(), PPOM_PRODUCT_META_KEY, true );
-		$this->assertIsArray( $stored );
-		$this->assertSame( array( $valid_meta_id ), array_values( array_map( 'intval', $stored ) ) );
+		$this->assertSame(
+			array( $valid_meta_id, $stale_meta_id ),
+			array_values( array_map( 'intval', (array) $stored ) )
+		);
 	}
 
 	/**
-	 * get_fields() deletes the product's post meta entirely when every
-	 * attached meta_id references a row that no longer exists.
+	 * A display-time override may replace the product's stored assignment.
+	 * Resolving its fields must not persist that temporary set.
 	 *
 	 * @return void
 	 */
-	public function test_get_fields_deletes_post_meta_when_all_references_are_stale() {
+	public function test_get_fields_does_not_persist_runtime_override() {
+		$product          = $this->create_simple_product();
+		$stored_meta_id   = $this->insert_ppom_meta(
+			array( $this->build_text_field( 'stored_field', 'Stored' ) )
+		);
+		$override_meta_id = $this->insert_ppom_meta(
+			array( $this->build_text_field( 'override_field', 'Override' ) )
+		);
+
+		update_post_meta( $product->get_id(), PPOM_PRODUCT_META_KEY, array( $stored_meta_id ) );
+
+		$filter = static function () use ( $override_meta_id ) {
+			return array( $override_meta_id, 0 );
+		};
+		add_filter( 'ppom_product_meta_id', $filter, 99 );
+
+		try {
+			$ppom = new PPOM_Meta( $product->get_id() );
+		} finally {
+			remove_filter( 'ppom_product_meta_id', $filter, 99 );
+		}
+
+		$this->assertSame( array( $override_meta_id ), array_values( (array) $ppom->meta_id ) );
+		$this->assertSame(
+			array( $stored_meta_id ),
+			array_values( array_map( 'intval', (array) get_post_meta( $product->get_id(), PPOM_PRODUCT_META_KEY, true ) ) )
+		);
+		$this->assertContains( 'override_field', array_column( (array) $ppom->fields, 'data_name' ) );
+	}
+
+	/**
+	 * A category group merged with a stale direct assignment remains
+	 * display-only and must not become the product's direct assignment.
+	 *
+	 * @return void
+	 */
+	public function test_get_fields_does_not_persist_category_group_over_stale_assignment() {
+		$term = wp_insert_term( 'PPOM Category ' . wp_generate_password( 6, false ), 'product_cat' );
+		$this->assertIsArray( $term );
+
+		$product   = $this->create_simple_product();
+		$term_slug = get_term( $term['term_id'], 'product_cat' )->slug;
+		wp_set_object_terms( $product->get_id(), array( (int) $term['term_id'] ), 'product_cat' );
+
+		$category_meta_id = $this->insert_ppom_meta(
+			array( $this->build_text_field( 'category_field', 'Category' ) ),
+			0,
+			array( 'productmeta_categories' => $term_slug )
+		);
+		$stale_meta_id = 999999;
+		update_post_meta( $product->get_id(), PPOM_PRODUCT_META_KEY, array( $stale_meta_id ) );
+
+		$ppom = new PPOM_Meta( $product->get_id() );
+
+		$this->assertSame( array( $category_meta_id ), array_values( (array) $ppom->meta_id ) );
+		$this->assertContains( 'category_field', array_column( (array) $ppom->fields, 'data_name' ) );
+		$this->assertSame(
+			array( $stale_meta_id ),
+			array_values( array_map( 'intval', (array) get_post_meta( $product->get_id(), PPOM_PRODUCT_META_KEY, true ) ) )
+		);
+	}
+
+	/**
+	 * get_fields() must not delete the product's post meta when every attached
+	 * meta_id fails to resolve: an empty read is indistinguishable from a
+	 * transient DB failure (#679), and the resolved set may not be the stored
+	 * assignment at all (#686). It renders nothing for the request instead.
+	 *
+	 * @return void
+	 */
+	public function test_get_fields_keeps_post_meta_when_all_references_are_stale() {
 		$product = $this->create_simple_product();
 
 		update_post_meta(
@@ -159,12 +237,17 @@ class Test_PPOM_Meta_Multi_Group extends PPOM_Test_Case {
 			array( 9999991, 9999992 )
 		);
 
-		$ppom = new PPOM_Meta( $product->get_id() );
-		$ppom->get_fields();
+		$ppom   = new PPOM_Meta( $product->get_id() );
+		$fields = $ppom->get_fields();
 
+		$this->assertSame( array(), (array) $fields );
+
+		$this->assertTrue(
+			metadata_exists( 'post', $product->get_id(), PPOM_PRODUCT_META_KEY )
+		);
 		$this->assertSame(
-			'',
-			(string) get_post_meta( $product->get_id(), PPOM_PRODUCT_META_KEY, true )
+			array( 9999991, 9999992 ),
+			array_values( array_map( 'intval', (array) get_post_meta( $product->get_id(), PPOM_PRODUCT_META_KEY, true ) ) )
 		);
 	}
 

--- a/tests/unit/test-rest-and-admin.php
+++ b/tests/unit/test-rest-and-admin.php
@@ -199,6 +199,70 @@ class Test_Rest_And_Admin extends PPOM_Test_Case {
 	}
 
 	/**
+	 * Deleting a shared group removes only that group from every direct product
+	 * assignment while preserving other attached groups.
+	 *
+	 * @return void
+	 */
+	public function testDeletePPOMFieldsProductCleansSharedAssignmentsAndPreservesOtherGroups() {
+		$product_a = $this->create_simple_product();
+		$product_b = $this->create_simple_product();
+		$deleted   = $this->insert_ppom_meta(
+			array(
+				$this->build_text_field( 'deleted_field', 'Deleted' ),
+			)
+		);
+		$kept      = $this->insert_ppom_meta(
+			array(
+				$this->build_text_field( 'kept_field', 'Kept' ),
+			)
+		);
+
+		update_post_meta( $product_a->get_id(), PPOM_PRODUCT_META_KEY, array( $deleted, $kept ) );
+		update_post_meta( $product_b->get_id(), PPOM_PRODUCT_META_KEY, array( $deleted, $kept ) );
+
+		$response = $this->dispatch_ppom_rest_request(
+			'POST',
+			'/ppom/v1/delete/product/',
+			array(
+				'product_id' => $product_a->get_id(),
+				'secret_key' => 'expected-secret',
+				'fields'     => wp_json_encode( array( '__all_keys' ) ),
+			),
+			'expected-secret'
+		);
+
+		$this->assertSame( 'success', $response->get_data()['status'] );
+		$this->assertNull( $this->get_ppom_meta_row( $deleted ) );
+		$this->assertNotNull( $this->get_ppom_meta_row( $kept ) );
+		$this->assertSame( array( $kept ), array_values( (array) get_post_meta( $product_a->get_id(), PPOM_PRODUCT_META_KEY, true ) ) );
+		$this->assertSame( array( $kept ), array_values( (array) get_post_meta( $product_b->get_id(), PPOM_PRODUCT_META_KEY, true ) ) );
+	}
+
+	/**
+	 * Bulk group deletion cleans both multi-group and legacy scalar assignments.
+	 *
+	 * @return void
+	 */
+	public function testBulkGroupDeletionCleansMultiGroupAndLegacyScalarAssignments() {
+		$multi_product  = $this->create_simple_product();
+		$scalar_product = $this->create_simple_product();
+		$deleted_a      = $this->insert_ppom_meta( array( $this->build_text_field( 'deleted_a', 'Deleted A' ) ) );
+		$deleted_b      = $this->insert_ppom_meta( array( $this->build_text_field( 'deleted_b', 'Deleted B' ) ) );
+		$kept           = $this->insert_ppom_meta( array( $this->build_text_field( 'kept', 'Kept' ) ) );
+
+		update_post_meta( $multi_product->get_id(), PPOM_PRODUCT_META_KEY, array( $deleted_a, $kept, $deleted_b ) );
+		update_post_meta( $scalar_product->get_id(), PPOM_PRODUCT_META_KEY, $deleted_b );
+
+		$deleted_count = ppom_meta_repository()->delete_by_ids( array( $deleted_a, $deleted_b ) );
+
+		$this->assertSame( 2, $deleted_count );
+		$this->assertSame( array( $kept ), array_values( (array) get_post_meta( $multi_product->get_id(), PPOM_PRODUCT_META_KEY, true ) ) );
+		$this->assertFalse( metadata_exists( 'post', $scalar_product->get_id(), PPOM_PRODUCT_META_KEY ) );
+		$this->assertNotNull( $this->get_ppom_meta_row( $kept ) );
+	}
+
+	/**
 	 * Ensure the order read route returns the formatted PPOM item metadata.
 	 *
 	 * @return void


### PR DESCRIPTION
Viewing a product page could permanently rewrite the product's saved field-group assignment (#686). `get_fields()` persisted its *display-time* resolution — the merge of the direct assignment, category rules, and the `ppom_product_meta_id` filter (which Pro's ConditionalMeta feeds from an unauthenticated `?ppom-meta=` URL parameter) — back into `_product_meta_id` whenever any ID in that set failed to resolve. Products lost their forms, picked up forms they were never assigned, and one crafted URL could reassign every product on a page. This PR makes field resolution read-only.

## What changed

- Before: an invalid ID in the resolved set (deleted group, `0` filler, failed row read) triggered `update_post_meta` with the merged set — or `delete_post_meta` when nothing resolved. After: invalid IDs are dropped from the in-memory resolution only; product-page reads never touch the stored assignment.
- Category-matched and filter-provided groups remain temporary, display-time choices and can no longer be baked in as direct assignments.
- When every ID fails to resolve, the request renders no fields instead of deleting the stored assignment — a full resolution failure is indistinguishable from a transient DB failure (#679), and the resolved set may not be the stored value at all.

Out of scope (tracked in #686): scoping ConditionalMeta's URL override to the product in context (Pro), cleaning `_product_meta_id` references on group deletion, and the cleanup routine for already-corrupted stores.

## Verification

New regression tests lock in the read-only behavior:

- A stale ID is skipped for the request while the surviving group still renders, and the stored assignment keeps both IDs.
- A runtime `ppom_product_meta_id` override renders its fields but is never persisted over the stored assignment.
- A category-matched group merged over a stale direct assignment stays display-only and never becomes the product's direct assignment.
- When every reference is stale, the request renders no fields and the stored meta survives untouched.

The full test suite passes, apart from one pre-existing MIME-detection failure unrelated to this change.

Manual check (scenario A from #686, with Pro active):

1. Assign group Alpha to a product, then load `/product/…/?ppom-meta=<other-group-id>,0` logged out — the other group renders for that request only.
2. Reload without the query string — Alpha renders and `_product_meta_id` still holds Alpha's ID.

Related to #686
