### PR TITLE
fix: schedule the abandoned-upload sweep reliably

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -368,7 +368,7 @@ The upload subsystem handles:
 - cropper support
 - cleanup of stale temporary uploads
 
-On activation, PPOM schedules the cleanup hook `do_action_remove_images`, which removes temporary uploads older than 7 days.
+PPOM schedules the cleanup hook `do_action_remove_images` on `init`, which removes temporary uploads older than 7 days. Scheduling sits behind a `wp_next_scheduled()` guard rather than in the activation hook, so installs that are missing the event pick it up on the next request instead of needing a reactivation.
 
 ### Admin and Settings
 

--- a/classes/plugin.class.php
+++ b/classes/plugin.class.php
@@ -110,6 +110,8 @@ class NM_PersonalizedProduct {
 		// adding scheduale weekly
 		add_filter( 'cron_schedules', 'ppom_hooks_weekly_cron_schedule' );
 
+		add_action( 'init', array( __CLASS__, 'schedule_unused_images_cleanup' ) );
+
 		add_action( 'admin_footer-edit.php', array( $this, 'nm_add_bulk_meta' ) );
 
 		add_action( 'load-edit.php', array( &$this, 'nm_meta_bulk_action' ) );
@@ -521,15 +523,41 @@ class NM_PersonalizedProduct {
 		PPOM_Meta_Repository::ensure_schema();
 	}
 
-	public static function activate_plugin() {
-		
-		self::upgrade_database();
-		// this is to remove un-confirmed files daily
+	/**
+	 * Makes sure the sweep that removes un-confirmed uploads is scheduled.
+	 *
+	 * Hooked to `init` rather than only to activation so that sites which
+	 * activated while the recurrence was invalid — and therefore never got the
+	 * event at all — pick it up without having to reactivate the plugin.
+	 *
+	 * @return void
+	 *
+	 * @see ppom_files_removed_unused_images()
+	 */
+	public static function schedule_unused_images_cleanup() {
 
-		$delete_frequency = ppom_get_option( 'ppom_remove_unused_images_schedule' );
-		if ( ! wp_next_scheduled( 'do_action_remove_images' ) ) {
-			wp_schedule_event( time(), $delete_frequency, 'do_action_remove_images' );
+		if ( wp_next_scheduled( 'do_action_remove_images' ) ) {
+			return;
 		}
+
+		$delete_frequency = ppom_get_option( 'ppom_remove_unused_images_schedule', 'daily' );
+
+		wp_schedule_event( time(), $delete_frequency, 'do_action_remove_images' );
+	}
+
+	/**
+	 * Runs on plugin activation.
+	 *
+	 * The un-confirmed upload sweep is not scheduled here; it is scheduled on
+	 * `init` so that existing installs recover it too.
+	 *
+	 * @return void
+	 *
+	 * @see self::schedule_unused_images_cleanup()
+	 */
+	public static function activate_plugin() {
+
+		self::upgrade_database();
 
 		if ( ! wp_next_scheduled( 'setup_styles_and_scripts_wooproduct' ) ) {
 			wp_schedule_event( time(), 'daily', 'setup_styles_and_scripts_wooproduct' );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1111,12 +1111,6 @@ parameters:
 			path: classes/plugin.class.php
 
 		-
-			message: '#^Method NM_PersonalizedProduct\:\:activate_plugin\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: classes/plugin.class.php
-
-		-
 			message: '#^Method NM_PersonalizedProduct\:\:add_ppom_meta_panel\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/tests/unit/test-cleanup-cron-schedule.php
+++ b/tests/unit/test-cleanup-cron-schedule.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Scheduling of the abandoned-upload cleanup sweep.
+ *
+ * @package ppom-pro
+ */
+
+require_once __DIR__ . '/class-ppom-test-case.php';
+
+/**
+ * @covers NM_PersonalizedProduct::schedule_unused_images_cleanup
+ */
+class Test_Cleanup_Cron_Schedule extends PPOM_Test_Case {
+
+	const HOOK = 'do_action_remove_images';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		wp_clear_scheduled_hook( self::HOOK );
+		$this->unset_ppom_option( 'ppom_remove_unused_images_schedule' );
+	}
+
+	public function tearDown(): void {
+		wp_clear_scheduled_hook( self::HOOK );
+		$this->unset_ppom_option( 'ppom_remove_unused_images_schedule' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * On a site where nobody has saved the settings page the frequency option is
+	 * unset, and passing that straight to wp_schedule_event() left the sweep
+	 * unscheduled forever — abandoned uploads were never removed.
+	 *
+	 * @return void
+	 */
+	public function test_sweep_is_scheduled_when_no_frequency_has_been_saved() {
+		NM_PersonalizedProduct::schedule_unused_images_cleanup();
+
+		$this->assertNotFalse(
+			wp_next_scheduled( self::HOOK ),
+			'The cleanup sweep must be scheduled even with no saved frequency.'
+		);
+		$this->assertSame( 'daily', wp_get_schedule( self::HOOK ) );
+	}
+
+	/**
+	 * A frequency the merchant actually chose must be respected rather than
+	 * overridden by the default. `monthly` is registered by WooCommerce, which
+	 * PPOM requires, so every option the settings dropdown offers resolves.
+	 *
+	 * @return void
+	 */
+	public function test_sweep_honours_a_saved_frequency() {
+		$this->set_ppom_option( 'ppom_remove_unused_images_schedule', 'monthly' );
+
+		NM_PersonalizedProduct::schedule_unused_images_cleanup();
+
+		$this->assertSame( 'monthly', wp_get_schedule( self::HOOK ) );
+	}
+
+	/**
+	 * The option predates having a default and can still be stored empty. An
+	 * unusable recurrence makes wp_schedule_event() fail without warning, which
+	 * is exactly how the sweep came to never run.
+	 *
+	 * @return void
+	 */
+	public function test_sweep_is_still_scheduled_when_saved_frequency_is_empty() {
+		$this->set_ppom_option( 'ppom_remove_unused_images_schedule', '' );
+
+		NM_PersonalizedProduct::schedule_unused_images_cleanup();
+
+		$this->assertNotFalse(
+			wp_next_scheduled( self::HOOK ),
+			'An empty saved frequency must not leave the sweep unscheduled.'
+		);
+	}
+
+	/**
+	 * The scheduler only helps if it actually runs. Scheduling used to happen in
+	 * the activation hook alone, which is why installs that activated with an
+	 * unusable recurrence never recovered; hooking it to `init` is what lets them
+	 * pick the event up. Without this test the hook could be dropped and every
+	 * other test here would still pass.
+	 *
+	 * @return void
+	 */
+	public function test_scheduler_runs_on_init() {
+		$this->assertNotFalse(
+			has_action( 'init', array( 'NM_PersonalizedProduct', 'schedule_unused_images_cleanup' ) ),
+			'The cleanup scheduler must be hooked to init, not only to activation.'
+		);
+	}
+
+	/**
+	 * The sweep runs on a schedule, so a second pass must not stack a duplicate
+	 * event on every request now that scheduling happens on `init`.
+	 *
+	 * @return void
+	 */
+	public function test_scheduling_twice_does_not_duplicate_the_event() {
+		NM_PersonalizedProduct::schedule_unused_images_cleanup();
+		$first = wp_next_scheduled( self::HOOK );
+
+		NM_PersonalizedProduct::schedule_unused_images_cleanup();
+
+		$this->assertSame( $first, wp_next_scheduled( self::HOOK ) );
+		$this->assertCount( 1, _get_cron_array()[ $first ][ self::HOOK ] );
+	}
+}


### PR DESCRIPTION
The cron event that sweeps abandoned uploads is never scheduled on a default install, so files from abandoned carts accumulate in `wp-content/uploads/ppom_files/` indefinitely. Reported in [Codeinwp/ppom-pro#746](https://github.com/Codeinwp/ppom-pro/issues/746).

`activate_plugin()` passed `ppom_get_option( 'ppom_remove_unused_images_schedule' )` straight to `wp_schedule_event()`. That getter defaults to `false` and the caller supplied no default, so on any site where an admin had never saved the settings page the recurrence was `false`, the event was rejected silently, and the seven-day sweep never ran.

## What changed

- **Frequency lookup** — now supplies a `'daily'` default, so an unsaved setting no longer produces an unusable recurrence. A frequency the merchant did choose is still honoured; all three options the dropdown offers resolve (`weekly` from PPOM, `monthly` from WooCommerce).

- **Scheduling** — moved out of the activation hook onto `init`. The default alone would only fix sites activated *after* this ships, because activation hooks do not re-run on update; every install already missing the event would stay broken. On `init` they recover it on the next page load, with no manual reactivation.

- **Duplicate protection** — an early `wp_next_scheduled()` return keeps the per-request check to one event, so nothing stacks.

- **`activate_plugin()` docblock and a `phpstan-baseline.neon` entry** — incidental. Editing the method shifted a phpcs baseline signature (the baseline hashes each violation plus one line either side), and the docblock's `@return void` then left a PHPStan baseline entry unmatched, so the stale entry is removed.

> [!NOTE]
> Deactivation still wins: `deactivate_plugin()` clears the event and `init` does not resurrect it in that same request, verified through a full deactivate/reactivate cycle. Changing the frequency still requires a deactivate/reactivate to take effect, exactly as before and as the setting's own description states — this PR does not change that workflow. The `add_action` sits a couple of lines below the related cron hooks on purpose, so the neighbouring baselined violations keep their original context.

## Scheduling flow

```mermaid
flowchart LR
    A[Any request] --> B[Changed:<br/>init]:::changed
    B --> C{Event already<br/>scheduled?}
    C -- Yes --> D[Do nothing]
    C -- No --> E[New: read frequency,<br/>default daily]:::added
    E --> F[Schedule<br/>do_action_remove_images]
    F --> G[Sweep removes uploads<br/>older than 7 days]

    H[Activation] --> I[Changed:<br/>no longer schedules<br/>the sweep here]:::changed

    classDef added fill:#1a7f37,color:#fff,stroke:#116329,stroke-width:3px
    classDef changed fill:#9a6700,color:#fff,stroke:#5c3d00,stroke-width:3px,stroke-dasharray:6 3
```

## QA

1. On a site that has never had the PPOM settings page saved, run `wp cron event list --fields=hook,recurrence` and look for `do_action_remove_images`.

   **Expect:** the hook is listed at `1 day`. Before this change it was absent entirely.

2. Confirm an existing broken install recovers without reactivation:

   ```bash
   wp cron event delete do_action_remove_images
   wp cron event list --fields=hook,recurrence   # triggers a request
   ```

   **Expect:** the hook is back at `1 day` after the second command, with exactly one entry.

3. Set the sweep frequency to Weekly in PPOM settings, then deactivate and reactivate the plugin.

   **Expect:** `wp cron event list` shows `do_action_remove_images` at `1 week`.

4. Deactivate the plugin and load any page of the site.

   **Expect:** `do_action_remove_images` is gone from the cron list and does not come back while the plugin stays deactivated.

5. Let the sweep run against a real abandoned upload — place a file in `wp-content/uploads/ppom_files/`, backdate it more than seven days (`touch -d '8 days ago'`), then run `wp cron event run do_action_remove_images`.

   **Expect:** the backdated file is deleted and files newer than seven days are left alone.
