### PR TITLE
fix: let delete work on a file restored into the form

### DIFF
--- a/js/file-upload.js
+++ b/js/file-upload.js
@@ -282,7 +282,13 @@ jQuery( function ( $ ) {
 				return;
 			}
 
-			const ppomFileWrapper = e.target.closest( '.ppom-file-wrapper' );
+			// Fresh uploads are wrapped by the uploader in `.ppom-file-wrapper`;
+			// files the server renders back into the form get `.u_i_c_box` instead.
+			// Both carry data-fileid, so accept either or delete does nothing on a
+			// restored file.
+			const ppomFileWrapper = e.target.closest(
+				'.ppom-file-wrapper, .u_i_c_box'
+			);
 			const fileId = ppomFileWrapper?.getAttribute( 'data-fileid' );
 			const ppomFieldWrapper = e.target.closest(
 				'div.ppom-field-wrapper'

--- a/js/file-upload.js
+++ b/js/file-upload.js
@@ -317,9 +317,11 @@ jQuery( function ( $ ) {
 			}
 
 			// Delete animation.
-			const imageElement = document.querySelector(
-				`#u_i_c_${ fileId } img`
-			);
+			// Scoped to this click's wrapper, not looked up by id: restored ids come
+			// from each field's own array key, so the first file of every field is
+			// `u_i_c_0` and a document lookup would leave another field's thumbnail
+			// showing the spinner for good.
+			const imageElement = ppomFileWrapper?.querySelector( 'img' );
 			if ( imageElement ) {
 				imageElement.src = `${ ppom_file_vars.plugin_url }/images/loading.gif`;
 			}

--- a/js/file-upload.js
+++ b/js/file-upload.js
@@ -375,21 +375,17 @@ jQuery( function ( $ ) {
 				// proof and made the file impossible to remove. Entries are per tab
 				// and go when it closes.
 
-				// Update UI
-				const fileContainer = document.querySelector(
-					`#u_i_c_${ fileId }`
-				);
-				if ( fileContainer ) {
-					fileContainer.remove();
+				// Update UI. Remove the wrapper this click resolved rather than
+				// looking one up by id: restored ids come from each field's own array
+				// key, so the first file of every field is `u_i_c_0` and a document
+				// lookup would take whichever comes first, stripping another field's
+				// value out of the form.
+				if ( ppomFileWrapper ) {
+					ppomFileWrapper.remove();
 				}
 
 				if ( checkbox ) {
 					checkbox.remove();
-				}
-
-				const parentBox = e.target.closest( '.u_i_c_box' );
-				if ( parentBox ) {
-					parentBox.remove();
 				}
 
 				const croppiePreview = document.querySelector(

--- a/tests/e2e/specs/file-upload.spec.js
+++ b/tests/e2e/specs/file-upload.spec.js
@@ -788,6 +788,99 @@ test.describe( 'File Upload with Dynamic Nonce Refresh', () => {
 		).toBe( tokenBefore );
 	} );
 
+	/**
+	 * Server-restored files are wrapped in `.u_i_c_box`
+	 * (`src/FieldMarkup/Renderers/FileRenderer.php:59`,
+	 * `templates/frontend/inputs/file.php:79`) while the uploader wraps fresh ones
+	 * in `.ppom-file-wrapper` (`js/file-upload.js:356`). The delete handler used to
+	 * read the file id only from the latter and return without it, so the click on
+	 * a restored file sent nothing at all.
+	 *
+	 * `templates/render-fields.php:41` repopulates the form from
+	 * `$_POST['ppom']['fields']`, which is what happens when add-to-cart fails
+	 * validation. Posting the product page with a stored file name reaches the same
+	 * code, so the markup here is exactly what a shopper sees after such a reload.
+	 */
+	test( 'a genuinely restored file can be deleted', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const fieldId = 'file_real_restore_test';
+
+		const { fileName, permalink } = await uploadOneFile(
+			page,
+			requestUtils,
+			fieldId,
+			'Real Restore Test'
+		);
+
+		// Canonical form, whatever the permalink setting: `/?p=<id>` answers 404
+		// to a POST, the canonical URL does not.
+		expect( permalink ).toBeTruthy();
+		expect( permalink ).not.toContain( '?p=' );
+
+		// Re-render the product page through POST, the way a failed add-to-cart
+		// does, with this upload as the field's existing value.
+		await page.evaluate(
+			( { action, field, name } ) => {
+				const form = document.createElement( 'form' );
+				form.method = 'POST';
+				form.action = action;
+
+				const input = document.createElement( 'input' );
+				input.type = 'hidden';
+				input.name = `ppom[fields][${ field }][0][org]`;
+				input.value = name;
+
+				form.appendChild( input );
+				document.body.appendChild( form );
+				form.submit();
+			},
+			{ action: permalink, field: fieldId, name: fileName }
+		);
+
+		await page.waitForLoadState( 'load' );
+
+		// Confirm this really is server-rendered markup before judging the click.
+		const restoredBox = page.locator(
+			`#filelist-${ fieldId } .u_i_c_box`
+		);
+		await restoredBox.waitFor( { state: 'attached', timeout: 10000 } );
+
+		expect(
+			await page.locator( '.ppom-file-wrapper' ).count(),
+			'server-restored markup should not carry the uploader wrapper'
+		).toBe( 0 );
+
+		const deleteButton = page
+			.locator( `#filelist-${ fieldId } .u_i_c_tools_del` )
+			.first();
+		await deleteButton.waitFor( { state: 'visible', timeout: 10000 } );
+
+		page.on( 'dialog', ( dialog ) => dialog.accept().catch( () => {} ) );
+
+		let requested = false;
+		const seen = page
+			.waitForRequest(
+				( request ) =>
+					request.url().includes( 'admin-ajax.php' ) &&
+					!! request.postData()?.includes( 'ppom_delete_file' ),
+				{ timeout: 5000 }
+			)
+			.then( () => {
+				requested = true;
+			} )
+			.catch( () => {} );
+
+		await deleteButton.click();
+		await seen;
+
+		expect(
+			requested,
+			'delete on a restored file must reach the endpoint'
+		).toBe( true );
+	} );
+
 	test( 'should refresh nonce via REST endpoint', async ( {
 		page,
 		requestUtils,

--- a/tests/e2e/specs/file-upload.spec.js
+++ b/tests/e2e/specs/file-upload.spec.js
@@ -881,6 +881,137 @@ test.describe( 'File Upload with Dynamic Nonce Refresh', () => {
 		).toBe( true );
 	} );
 
+	/**
+	 * Restored file ids come from each field's own array key, so the first file of
+	 * every field is `u_i_c_0`. Looking the wrapper up by that id reaches whichever
+	 * one comes first in the document, so deleting the second field's file used to
+	 * strip the first field's value out of the form while leaving its file on the
+	 * server.
+	 */
+	test( 'deleting one restored file leaves the other field alone', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const frontField = 'dup_front_field';
+		const backField = 'dup_back_field';
+
+		const product = await createSimpleProduct( requestUtils );
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: 'Two File Fields Test',
+			fields: [
+				buildFileField( {
+					title: 'Front',
+					dataName: frontField,
+					file_size: '5mb',
+					files_allowed: '1',
+					file_types: 'png,jpg',
+				} ),
+				buildFileField( {
+					title: 'Back',
+					dataName: backField,
+					file_size: '5mb',
+					files_allowed: '1',
+					file_types: 'png,jpg',
+				} ),
+			],
+		} );
+
+		await attachPpomGroupToProducts( requestUtils, {
+			ppomId,
+			productIds: [ product.id ],
+		} );
+
+		await page.goto( `/?p=${ product.id }` );
+		const permalink = page.url();
+
+		page.on( 'dialog', ( dialog ) => dialog.accept().catch( () => {} ) );
+
+		const pixel = {
+			name: 'pixel.png',
+			mimeType: 'image/png',
+			buffer: Buffer.from(
+				'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+				'base64'
+			),
+		};
+
+		const uploaded = {};
+
+		for ( const field of [ frontField, backField ] ) {
+			const input = page.locator(
+				`#ppom-file-container-${ field } input[type=file]`
+			);
+			await input.waitFor( { state: 'attached', timeout: 10000 } );
+			await input.setInputFiles( pixel );
+
+			const stored = page.locator(
+				`input[name^="ppom[fields][${ field }]"][name$="[org]"]`
+			);
+			await stored.waitFor( { state: 'attached', timeout: 15000 } );
+			uploaded[ field ] = await stored.inputValue();
+		}
+
+		// Restore both, the way a failed add-to-cart does.
+		await page.evaluate(
+			( { action, values } ) => {
+				const form = document.createElement( 'form' );
+				form.method = 'POST';
+				form.action = action;
+
+				Object.entries( values ).forEach( ( [ field, name ] ) => {
+					const input = document.createElement( 'input' );
+					input.type = 'hidden';
+					input.name = `ppom[fields][${ field }][0][org]`;
+					input.value = name;
+					form.appendChild( input );
+				} );
+
+				document.body.appendChild( form );
+				form.submit();
+			},
+			{ action: permalink, values: uploaded }
+		);
+
+		await page.waitForLoadState( 'load' );
+
+		const frontBox = page.locator( `#filelist-${ frontField } .u_i_c_box` );
+		const backBox = page.locator( `#filelist-${ backField } .u_i_c_box` );
+		await frontBox.waitFor( { state: 'attached', timeout: 10000 } );
+		await backBox.waitFor( { state: 'attached', timeout: 10000 } );
+
+		// Remove the second field's file.
+		const backDelete = page
+			.locator( `#filelist-${ backField } .u_i_c_tools_del` )
+			.first();
+		await backDelete.waitFor( { state: 'visible', timeout: 10000 } );
+
+		await Promise.all( [
+			page.waitForResponse(
+				( response ) =>
+					response.url().includes( 'admin-ajax.php' ) &&
+					!! response
+						.request()
+						.postData()
+						?.includes( 'ppom_delete_file' )
+			),
+			backDelete.click(),
+		] );
+
+		await expect( backBox ).toHaveCount( 0 );
+
+		await expect(
+			frontBox,
+			'the other field must keep its restored file'
+		).toHaveCount( 1 );
+
+		await expect(
+			page.locator(
+				`input[name^="ppom[fields][${ frontField }]"][name$="[org]"]`
+			),
+			'and keep it in the form submission'
+		).toHaveCount( 1 );
+	} );
+
 	test( 'should refresh nonce via REST endpoint', async ( {
 		page,
 		requestUtils,

--- a/tests/e2e/specs/file-upload.spec.js
+++ b/tests/e2e/specs/file-upload.spec.js
@@ -416,7 +416,9 @@ test.describe( 'File Upload with Dynamic Nonce Refresh', () => {
 	} );
 
 	/**
-	 * Only file and cropper fields get an uploader (`js/file-upload.js:338`), so a
+	 * Only file and cropper fields are given an uploader -- the loop over
+	 * `ppom_input_vars.ppom_inputs` calls `ppom_setup_file_upload_input()` for
+	 * those two types only -- so a
 	 * text field's data_name is not something the form could have posted here.
 	 * Checking only that the field exists let such a request through and stored a
 	 * file no form can reference.
@@ -790,13 +792,13 @@ test.describe( 'File Upload with Dynamic Nonce Refresh', () => {
 
 	/**
 	 * Server-restored files are wrapped in `.u_i_c_box`
-	 * (`src/FieldMarkup/Renderers/FileRenderer.php:59`,
-	 * `templates/frontend/inputs/file.php:79`) while the uploader wraps fresh ones
-	 * in `.ppom-file-wrapper` (`js/file-upload.js:356`). The delete handler used to
+	 * (`FileRenderer` and `templates/frontend/inputs/file.php`) while the
+	 * uploader wraps fresh ones
+	 * in `.ppom-file-wrapper` (`add_thumb_box()`). The delete handler used to
 	 * read the file id only from the latter and return without it, so the click on
 	 * a restored file sent nothing at all.
 	 *
-	 * `templates/render-fields.php:41` repopulates the form from
+	 * `templates/render-fields.php` repopulates the form from
 	 * `$_POST['ppom']['fields']`, which is what happens when add-to-cart fails
 	 * validation. Posting the product page with a stored file name reaches the same
 	 * code, so the markup here is exactly what a shopper sees after such a reload.
@@ -1010,6 +1012,13 @@ test.describe( 'File Upload with Dynamic Nonce Refresh', () => {
 			),
 			'and keep it in the form submission'
 		).toHaveCount( 1 );
+
+		// The delete also swaps the thumbnail for a spinner while it runs, which is
+		// another id lookup that can land on the wrong field.
+		await expect(
+			frontBox.locator( 'img' ).first(),
+			'and keep its preview rather than a stuck spinner'
+		).not.toHaveAttribute( 'src', /loading\.gif/ );
 	} );
 
 	test( 'should refresh nonce via REST endpoint', async ( {

--- a/tests/e2e/specs/file-upload.spec.js
+++ b/tests/e2e/specs/file-upload.spec.js
@@ -861,26 +861,39 @@ test.describe( 'File Upload with Dynamic Nonce Refresh', () => {
 
 		page.on( 'dialog', ( dialog ) => dialog.accept().catch( () => {} ) );
 
-		let requested = false;
-		const seen = page
-			.waitForRequest(
-				( request ) =>
-					request.url().includes( 'admin-ajax.php' ) &&
-					!! request.postData()?.includes( 'ppom_delete_file' ),
+		// Caught rather than awaited directly, so a click that sends nothing fails
+		// on the message below instead of an opaque timeout.
+		const answered = page
+			.waitForResponse(
+				( response ) =>
+					response.url().includes( 'admin-ajax.php' ) &&
+					!! response
+						.request()
+						.postData()
+						?.includes( 'ppom_delete_file' ),
 				{ timeout: 5000 }
 			)
-			.then( () => {
-				requested = true;
-			} )
-			.catch( () => {} );
+			.catch( () => null );
 
 		await deleteButton.click();
-		await seen;
+		const response = await answered;
 
 		expect(
-			requested,
+			response,
 			'delete on a restored file must reach the endpoint'
-		).toBe( true );
+		).not.toBeNull();
+
+		// The endpoint answers 200 even when it refuses, so reaching it proves
+		// nothing on its own.
+		expect(
+			await response.text(),
+			'and the endpoint must report the file removed'
+		).toContain( 'File removed' );
+
+		await expect(
+			restoredBox,
+			'and the file must leave the form'
+		).toHaveCount( 0 );
 	} );
 
 	/**
@@ -987,7 +1000,7 @@ test.describe( 'File Upload with Dynamic Nonce Refresh', () => {
 			.first();
 		await backDelete.waitFor( { state: 'visible', timeout: 10000 } );
 
-		await Promise.all( [
+		const [ deleteResponse ] = await Promise.all( [
 			page.waitForResponse(
 				( response ) =>
 					response.url().includes( 'admin-ajax.php' ) &&
@@ -998,6 +1011,12 @@ test.describe( 'File Upload with Dynamic Nonce Refresh', () => {
 			),
 			backDelete.click(),
 		] );
+
+		// 200 alone means nothing here: the endpoint answers 200 when it refuses.
+		expect(
+			await deleteResponse.text(),
+			'the deleted file must actually be removed server-side'
+		).toContain( 'File removed' );
 
 		await expect( backBox ).toHaveCount( 0 );
 


### PR DESCRIPTION
Clicking **Delete** on a file the server rendered back into the form did nothing — no request, no error, and the file stayed on disk. The uploader and the server wrap uploaded files in different elements, and the delete handler only recognised one of them. Reported in [Codeinwp/ppom-pro issue 748](https://github.com/Codeinwp/ppom-pro/issues/748).

Making that path reachable exposed two further problems in the same handler, both of which only bite once restored files reach it, so they are fixed here rather than left behind.

### Will affect visual aspect of the product

NO

## What changed

- **Delete handler** — finds the file id on either wrapper, so the click reaches the endpoint for restored files as well as fresh ones. Before, it read the id only from `.ppom-file-wrapper`, which the uploader adds to fresh uploads; files restored by the server are wrapped in `.u_i_c_box` instead, so the handler found nothing and returned before sending anything.

- **Removing the deleted file** — removes the wrapper the click resolved, rather than looking one up by id. Restored ids come from each field's own array key, so the first file of every field is `u_i_c_0`; a document-wide lookup took whichever came first, so deleting the second field's file removed the first field's box **and the hidden input carrying its value** — the shopper silently lost an upload that stayed on the server.

- **Loading spinner** — reads the thumbnail from that same wrapper. The delete swaps the image for a spinner while the request runs, and by the same id collision it could leave another field's preview showing the spinner permanently, since the element that would have been restored was the one removed.

> [!NOTE]
> Fresh uploads were never affected by the second and third points: plupload ids are globally unique, so those lookups only became ambiguous once restored files started reaching this code — which is what the first change does. That is why all three belong together.
>
> Worth a second opinion before merging: this assumes deleting a restored file is meant to work. If the design instead expects the shopper to untick the file's checkbox, the right change is removing the dead handler branch rather than repairing it — in which case close this rather than merge it.

## Delete click on an uploaded file

```mermaid
flowchart LR
    A[Shopper clicks Delete] --> B[Changed:<br/>resolve the wrapper<br/>holding the file id]:::changed
    B --> C{Id and field<br/>name found?}
    C -- No --> D[Nothing happens]
    C -- Yes --> E[Send ppom_delete_file]
    E --> F{Authorised?}
    F -- No --> G[Refused, file kept]
    F -- Yes --> H[Changed:<br/>remove only that<br/>file's wrapper]:::changed

    classDef changed fill:#9a6700,color:#fff,stroke:#5c3d00,stroke-width:3px,stroke-dasharray:6 3
```

## Test instructions

1. **Create a product with two file fields and a required text field.** Go to **WP Admin → WooCommerce → PPOM Fields** (`/wp-admin/admin.php?page=ppom`; the menu needs the `manage_options` capability, so use an Administrator account) and build a group with **two File Upload** fields plus a **Text** field marked **Required**. Then open any product under **WP Admin → Products**, pick that group in the **Select PPOM Meta** box in the right-hand sidebar, and click **Update**.

   **Expect:** the product's public page shows both upload fields and the text field.

2. **Reach a restored form.** Upload a file to *each* file field, leave the required text field empty, and press **Add to cart**. Validation fails and the page re-renders with both uploads still listed.

   **Expect:** both files are shown, each with a **Delete** button.

3. **The reported bug.** With DevTools → Network open, click **Delete** on the **second** field's file.

   **Expect:** a request to `admin-ajax.php` with `action=ppom_delete_file` answering `File removed`; that file disappears and is gone from `wp-content/uploads/ppom_files/`. Before this change the click produced no request at all.

4. **The first field must be untouched.** Look at the first field after step 3.

   **Expect:** its thumbnail is still its own image — not a spinner — and its file is still listed. Add to cart with the text field filled in, then check the cart line item.

   **Expect:** the first field's file is still attached to the order.

5. **Fresh uploads are unaffected.** Reload the product page, upload a file, and delete it straight away without submitting the form.

   **Expect:** the delete works exactly as before.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR
