### PR TITLE
Preserved third-party prices during totals calculation

### DIFF
--- a/inc/prices.php
+++ b/inc/prices.php
@@ -12,6 +12,17 @@ function ppom_before_calculate_totals( ...$args ) {
 	return \PPOM\Pricing\Engine::before_calculate_totals( ...$args );
 }
 
+/**
+ * Restores PPOM-priced cart lines to their catalog price before third parties price them.
+ *
+ * @param mixed ...$args Cart instance.
+ *
+ * @return void
+ */
+function ppom_restore_line_base_prices( ...$args ) {
+	\PPOM\Pricing\Engine::restore_line_base_prices( ...$args );
+}
+
 function ppom_get_field_prices( $ppom_fields_post, $product_id, &$product_quantity, $variation_id, $item = null ) {
 	return \PPOM\Pricing\Engine::get_field_prices( $ppom_fields_post, $product_id, $product_quantity, $variation_id, $item );
 }

--- a/src/Cart/WooCommerceCartLifecycleHooks.php
+++ b/src/Cart/WooCommerceCartLifecycleHooks.php
@@ -32,7 +32,7 @@ final class WooCommerceCartLifecycleHooks {
 
 			add_filter( 'woocommerce_get_cart_item_from_session', 'ppom_price_check_price_matrix', 8, 2 );
 
-			add_filter( 'woocommerce_get_cart_item_from_session', 'ppom_price_controller', 10, 2 );
+			add_filter( 'woocommerce_get_cart_item_from_session', 'ppom_price_controller', 10, 3 );
 
 			// Late priority: re-assert the line price after third-party set_price() calls. See #680.
 			add_action( 'woocommerce_before_calculate_totals', 'ppom_before_calculate_totals', 1000 );

--- a/src/Cart/WooCommerceCartLifecycleHooks.php
+++ b/src/Cart/WooCommerceCartLifecycleHooks.php
@@ -34,6 +34,10 @@ final class WooCommerceCartLifecycleHooks {
 
 			add_filter( 'woocommerce_get_cart_item_from_session', 'ppom_price_controller', 10, 3 );
 
+			// Early priority: put PPOM-priced lines back to their catalog price, so a
+			// set_price() later in this pass is recognisable as a third party's base.
+			add_action( 'woocommerce_before_calculate_totals', 'ppom_restore_line_base_prices', 0 );
+
 			// Late priority: re-assert the line price after third-party set_price() calls. See #680.
 			add_action( 'woocommerce_before_calculate_totals', 'ppom_before_calculate_totals', 1000 );
 

--- a/src/Pricing/Engine.php
+++ b/src/Pricing/Engine.php
@@ -80,7 +80,8 @@ final class Engine {
 		$total_addon_price    = self::price_get_addon_total( $ppom_field_prices );
 		$total_cart_fee_price = self::price_get_cart_fee_total( $ppom_field_prices );
 
-		$product_price = apply_filters( 'ppom_product_price_on_cart', $wc_product->get_price(), $cart_item );
+		$base_price    = $wc_product->get_price();
+		$product_price = apply_filters( 'ppom_product_price_on_cart', $base_price, $cart_item );
 
 		// return array with: price, source
 		$price_info         = self::price_get_product_base(
@@ -112,7 +113,7 @@ final class Engine {
 		if ( '' !== $cart_item_key ) {
 			self::$line_price_state[ $cart_item_key ] = array(
 				'written' => (float) $ppom_total_price,
-				'base'    => (float) $product_price,
+				'base'    => (float) $base_price,
 			);
 		}
 
@@ -120,7 +121,7 @@ final class Engine {
 	}
 
 	/**
-	 * Restores PPOM-priced cart lines to their catalog price before third parties price them.
+	 * Restores PPOM-priced cart lines to their base price before third parties price them.
 	 *
 	 * @param mixed $cart_items Cart instance.
 	 *
@@ -153,13 +154,7 @@ final class Engine {
 				continue;
 			}
 
-			$product_id   = isset( $cart_item['product_id'] ) ? $cart_item['product_id'] : '';
-			$variation_id = isset( $cart_item['variation_id'] ) ? $cart_item['variation_id'] : '';
-			$pristine     = wc_get_product( $variation_id ? $variation_id : $product_id );
-
-			if ( $pristine ) {
-				$wc_product->set_price( $pristine->get_price() );
-			}
+			$wc_product->set_price( $state['base'] );
 		}
 	}
 
@@ -194,18 +189,20 @@ final class Engine {
 			$total_addon_price    = self::price_get_addon_total( $ppom_field_prices );
 			$total_cart_fee_price = self::price_get_cart_fee_total( $ppom_field_prices );
 
-			// Early pass restores catalog price; use current value as base.
+			// Early pass restores the line's base price; use current value as base.
 			// If it did not run, infer base to avoid double-counting on repeats.
 			$pristine      = wc_get_product( $variation_id ? $variation_id : $product_id );
 			$catalog_price = $pristine ? $pristine->get_price() : $wc_product->get_price();
 
 			if ( isset( self::$line_base_restored[ $cart_item_key ] ) ) {
 				unset( self::$line_base_restored[ $cart_item_key ] );
-				$product_price = (float) $wc_product->get_price();
+				$base_price = (float) $wc_product->get_price();
 			} else {
-				$product_price = self::resolve_line_base_price( $cart_item_key, $wc_product->get_price(), $catalog_price );
+				$base_price = self::resolve_line_base_price( $cart_item_key, $wc_product->get_price(), $catalog_price );
 			}
-			$product_price = apply_filters( 'ppom_product_price_on_cart', $product_price, $cart_item );
+
+			// Recorded pre-filter, so restoring it never applies the filter twice.
+			$product_price = apply_filters( 'ppom_product_price_on_cart', $base_price, $cart_item );
 
 			// $context     = 'cart';
 			// $product_price   = Helpers::get_product_price( $product, $variation_id, $context);
@@ -237,7 +234,7 @@ final class Engine {
 
 			self::$line_price_state[ $cart_item_key ] = array(
 				'written' => (float) $ppom_total_price,
-				'base'    => (float) $product_price,
+				'base'    => (float) $base_price,
 			);
 		}
 	}

--- a/src/Pricing/Engine.php
+++ b/src/Pricing/Engine.php
@@ -30,6 +30,15 @@ final class Engine {
 	 */
 	private static $line_price_state = array();
 
+	/**
+	 * Tracks which cart lines have been restored to their catalog price in the
+	 * current request, so self::before_calculate_totals() can know whether to trust
+	 * the line's price.
+	 *
+	 * @var array<string, bool>
+	 */
+	private static $line_base_restored = array();
+
 	// Cart line pricing.
 
 	/**
@@ -110,6 +119,50 @@ final class Engine {
 		return $cart_item;
 	}
 
+	/**
+	 * Restores PPOM-priced cart lines to their catalog price before third parties price them.
+	 *
+	 * @param mixed $cart_items Cart instance.
+	 *
+	 * @return void
+	 */
+	public static function restore_line_base_prices( $cart_items ) {
+
+		if ( empty( $cart_items ) ) {
+			return;
+		}
+
+		self::$line_base_restored = array();
+
+		foreach ( $cart_items->cart_contents as $cart_item_key => $cart_item ) {
+
+			if ( ! isset( $cart_item['ppom']['fields'] ) ) {
+				continue;
+			}
+
+			self::$line_base_restored[ $cart_item_key ] = true;
+
+			if ( ! isset( self::$line_price_state[ $cart_item_key ] ) ) {
+				continue;
+			}
+
+			$wc_product = $cart_item['data'];
+			$state      = self::$line_price_state[ $cart_item_key ];
+
+			if ( ! self::prices_match( (float) $wc_product->get_price(), $state['written'] ) ) {
+				continue;
+			}
+
+			$product_id   = isset( $cart_item['product_id'] ) ? $cart_item['product_id'] : '';
+			$variation_id = isset( $cart_item['variation_id'] ) ? $cart_item['variation_id'] : '';
+			$pristine     = wc_get_product( $variation_id ? $variation_id : $product_id );
+
+			if ( $pristine ) {
+				$wc_product->set_price( $pristine->get_price() );
+			}
+		}
+	}
+
 	public static function before_calculate_totals( $cart_items ) {
 
 		// ppom_pa($cart_items);
@@ -141,11 +194,17 @@ final class Engine {
 			$total_addon_price    = self::price_get_addon_total( $ppom_field_prices );
 			$total_cart_fee_price = self::price_get_cart_fee_total( $ppom_field_prices );
 
-			// Prefer a price a third party calculated for this line; fall back to the
-			// catalog price, so repeated passes never double-count.
+			// Early pass restores catalog price; use current value as base.
+			// If it did not run, infer base to avoid double-counting on repeats.
 			$pristine      = wc_get_product( $variation_id ? $variation_id : $product_id );
 			$catalog_price = $pristine ? $pristine->get_price() : $wc_product->get_price();
-			$product_price = self::resolve_line_base_price( $cart_item_key, $wc_product->get_price(), $catalog_price );
+
+			if ( isset( self::$line_base_restored[ $cart_item_key ] ) ) {
+				unset( self::$line_base_restored[ $cart_item_key ] );
+				$product_price = (float) $wc_product->get_price();
+			} else {
+				$product_price = self::resolve_line_base_price( $cart_item_key, $wc_product->get_price(), $catalog_price );
+			}
 			$product_price = apply_filters( 'ppom_product_price_on_cart', $product_price, $cart_item );
 
 			// $context     = 'cart';
@@ -184,7 +243,7 @@ final class Engine {
 	}
 
 	/**
-	 * Resolves the base price for a cart line, given the current in-cart price and the pristine catalog price.
+	 * Infers the base price for a cart line from the amounts alone.
 	 *
 	 * @param string       $cart_item_key Cart item key.
 	 * @param float|string $in_cart_price Price currently set on the cart line product object.

--- a/src/Pricing/Engine.php
+++ b/src/Pricing/Engine.php
@@ -35,8 +35,9 @@ final class Engine {
 	/**
 	 * Recalculates the cart line price for a PPOM cart item.
 	 *
-	 * @param array $cart_item Cart item restored from the session.
-	 * @param array $values    Raw cart item values.
+	 * @param array  $cart_item     Cart item restored from the session.
+	 * @param array  $values        Raw cart item values.
+	 * @param string $cart_item_key Cart item key, when the session filter supplies it.
 	 *
 	 * @return array
 	 *
@@ -44,7 +45,7 @@ final class Engine {
 	 * @see self::price_get_product_base()
 	 * @see self::price_cart_fee()
 	 */
-	public static function price_controller( $cart_item, $values ) {
+	public static function price_controller( $cart_item, $values, $cart_item_key = '' ) {
 
 		// ppom_pa($cart_item);
 		if ( empty( $cart_item ) ) {
@@ -96,6 +97,15 @@ final class Engine {
 
 		$ppom_total_price = apply_filters( 'ppom_cart_line_total', $ppom_total_price, $cart_item, $values );
 		$wc_product->set_price( $ppom_total_price );
+
+		// Totals run later in this same request and must recognise this price as
+		// PPOM's own, not as a price a third party calculated for the line.
+		if ( '' !== $cart_item_key ) {
+			self::$line_price_state[ $cart_item_key ] = array(
+				'written' => (float) $ppom_total_price,
+				'base'    => (float) $product_price,
+			);
+		}
 
 		return $cart_item;
 	}

--- a/src/Pricing/Engine.php
+++ b/src/Pricing/Engine.php
@@ -21,6 +21,15 @@ use PPOM\Support\Helpers;
  */
 final class Engine {
 
+	/**
+	 * Stores the last base price and last written price for each cart line,
+	 * so repeated totals passes can detect whether a third party has changed
+	 * the line's price since PPOM last priced it.
+	 *
+	 * @var array<string, array<string, float>>
+	 */
+	private static $line_price_state = array();
+
 	// Cart line pricing.
 
 	/**
@@ -98,6 +107,9 @@ final class Engine {
 			return $cart_items;
 		}
 
+		// Drop state for lines no longer in the cart.
+		self::$line_price_state = array_intersect_key( self::$line_price_state, $cart_items->cart_contents );
+
 		foreach ( $cart_items->cart_contents as $cart_item_key => $cart_item ) {
 
 
@@ -119,9 +131,11 @@ final class Engine {
 			$total_addon_price    = self::price_get_addon_total( $ppom_field_prices );
 			$total_cart_fee_price = self::price_get_cart_fee_total( $ppom_field_prices );
 
-			// Base on the pristine catalog price, not the mutated in-cart price, so repeated passes never double-count.
+			// Prefer a price a third party calculated for this line; fall back to the
+			// catalog price, so repeated passes never double-count.
 			$pristine      = wc_get_product( $variation_id ? $variation_id : $product_id );
-			$product_price = $pristine ? $pristine->get_price() : $wc_product->get_price();
+			$catalog_price = $pristine ? $pristine->get_price() : $wc_product->get_price();
+			$product_price = self::resolve_line_base_price( $cart_item_key, $wc_product->get_price(), $catalog_price );
 			$product_price = apply_filters( 'ppom_product_price_on_cart', $product_price, $cart_item );
 
 			// $context     = 'cart';
@@ -151,7 +165,54 @@ final class Engine {
 			// No ppom_before_calculate_cart_total here: its weight listener is not idempotent and would stack weight each pass.
 			$ppom_total_price = apply_filters( 'ppom_cart_line_total', $ppom_total_price, $cart_item, $cart_item );
 			$cart_item['data']->set_price( $ppom_total_price );
+
+			self::$line_price_state[ $cart_item_key ] = array(
+				'written' => (float) $ppom_total_price,
+				'base'    => (float) $product_price,
+			);
 		}
+	}
+
+	/**
+	 * Resolves the base price for a cart line, given the current in-cart price and the pristine catalog price.
+	 *
+	 * @param string       $cart_item_key Cart item key.
+	 * @param float|string $in_cart_price Price currently set on the cart line product object.
+	 * @param float|string $catalog_price Pristine catalog price for the product or variation.
+	 *
+	 * @return float
+	 */
+	private static function resolve_line_base_price( $cart_item_key, $in_cart_price, $catalog_price ) {
+		$in_cart_price = (float) $in_cart_price;
+		$catalog_price = (float) $catalog_price;
+
+		// Untouched line, or a third party that reset it to the catalog price.
+		if ( self::prices_match( $in_cart_price, $catalog_price ) ) {
+			return $catalog_price;
+		}
+
+		if ( isset( self::$line_price_state[ $cart_item_key ] ) ) {
+			$state = self::$line_price_state[ $cart_item_key ];
+
+			// Nothing changed the line since PPOM priced it: reuse that same base.
+			if ( self::prices_match( $in_cart_price, $state['written'] ) ) {
+				return $state['base'];
+			}
+		}
+
+		return $in_cart_price;
+	}
+
+	/**
+	 * Compares two prices at cart precision.
+	 *
+	 * @param float $left  First price.
+	 * @param float $right Second price.
+	 *
+	 * @return bool
+	 */
+	private static function prices_match( $left, $right ) {
+		return abs( $left - $right ) < 0.00001;
 	}
 
 

--- a/tests/unit/test-third-party-price-mutation.php
+++ b/tests/unit/test-third-party-price-mutation.php
@@ -186,6 +186,111 @@ class Test_Third_Party_Price_Mutation extends PPOM_Test_Case {
 	}
 
 	/**
+	 * A zero catalog price with no priced PPOM fields must not erase a dynamic
+	 * price another plugin set earlier in the same totals pass: PPOM contributes
+	 * nothing here, so it has nothing to rebase onto the pristine 0.00 catalog price.
+	 *
+	 * @return void
+	 */
+	public function testDynamicPriceSurvivesZeroCatalogPriceWithZeroCostAddons() {
+		$product = $this->create_simple_product( array( 'regular_price' => '0' ) );
+
+		$this->insert_ppom_meta(
+			array(
+				$this->build_text_field( 'engraving', 'Engraving' ),
+			),
+			$product->get_id()
+		);
+
+		$this->initialize_woocommerce_checkout_context();
+
+		$cart_key = $this->add_product_to_real_cart(
+			$product->get_id(),
+			array(
+				'fields' => array(
+					'engraving' => 'Happy Birthday',
+				),
+			)
+		);
+
+		$this->assertNotFalse( $cart_key );
+
+		$reloaded = $this->reload_real_cart_from_session();
+
+		// Nothing priced: the line sits at the zero catalog price before totals run.
+		$this->assertSame( 0.0, (float) $reloaded[ $cart_key ]['data']->get_price() );
+
+		// Dynamic-pricing plugin prices the line before PPOM's priority-1000 pass.
+		add_action(
+			'woocommerce_before_calculate_totals',
+			function ( $cart ) {
+				foreach ( $cart->get_cart() as $cart_item ) {
+					$cart_item['data']->set_price( 40.0 );
+				}
+			},
+			20
+		);
+
+		WC()->cart->calculate_totals();
+
+		$this->assertSame( 40.0, (float) WC()->cart->get_total( 'edit' ) );
+	}
+
+	/**
+	 * A dynamically priced line keeps that price and still gets its addon on top,
+	 * across repeated totals passes.
+	 *
+	 * @return void
+	 */
+	public function testAddonPriceStacksOnThirdPartyDynamicPrice() {
+		$product = $this->create_simple_product( array( 'regular_price' => '0' ) );
+
+		$this->insert_ppom_meta(
+			array(
+				array(
+					'type'      => 'radio',
+					'title'     => 'Gift wrap',
+					'data_name' => 'giftwrap',
+					'options'   => array(
+						array( 'option' => 'Premium wrap', 'price' => '5' ),
+					),
+				),
+			),
+			$product->get_id()
+		);
+
+		$this->initialize_woocommerce_checkout_context();
+
+		$cart_key = $this->add_product_to_real_cart(
+			$product->get_id(),
+			array(
+				'fields' => array(
+					'giftwrap' => 'Premium wrap',
+				),
+			)
+		);
+
+		$this->assertNotFalse( $cart_key );
+		$this->reload_real_cart_from_session();
+
+		// Dynamic-pricing plugin prices the line before PPOM's priority-1000 pass.
+		add_action(
+			'woocommerce_before_calculate_totals',
+			function ( $cart ) {
+				foreach ( $cart->get_cart() as $cart_item ) {
+					$cart_item['data']->set_price( 40.0 );
+				}
+			},
+			20
+		);
+
+		WC()->cart->calculate_totals();
+		WC()->cart->calculate_totals();
+
+		$this->assertSame( 45.0, (float) WC()->cart->get_total( 'edit' ) );
+	}
+
+	/**
 	 * The addon price is included in totals within the same request as add-to-cart,
 	 * before any session restore — the wc-ajax=add_to_cart flow (issue #623).
 	 *

--- a/tests/unit/test-third-party-price-mutation.php
+++ b/tests/unit/test-third-party-price-mutation.php
@@ -340,6 +340,63 @@ class Test_Third_Party_Price_Mutation extends PPOM_Test_Case {
 	}
 
 	/**
+	 * A third-party base price is honoured even when it happens to equal the total
+	 * PPOM wrote on an earlier pass — the amount alone cannot tell the two apart.
+	 *
+	 * @return void
+	 */
+	public function testThirdPartyBaseEqualToPreviousPpomTotalIsStillTreatedAsABase() {
+		$product = $this->create_simple_product( array( 'regular_price' => '10' ) );
+
+		$this->insert_ppom_meta(
+			array(
+				array(
+					'type'      => 'radio',
+					'title'     => 'Gift wrap',
+					'data_name' => 'giftwrap',
+					'options'   => array(
+						array( 'option' => 'Premium wrap', 'price' => '5' ),
+					),
+				),
+			),
+			$product->get_id()
+		);
+
+		$this->initialize_woocommerce_checkout_context();
+
+		$cart_key = $this->add_product_to_real_cart(
+			$product->get_id(),
+			array(
+				'fields' => array(
+					'giftwrap' => 'Premium wrap',
+				),
+			)
+		);
+
+		$this->assertNotFalse( $cart_key );
+
+		$reloaded = $this->reload_real_cart_from_session();
+
+		// PPOM's own total for this line, which the third party is about to match.
+		$this->assertSame( 15.0, (float) $reloaded[ $cart_key ]['data']->get_price() );
+
+		add_action(
+			'woocommerce_before_calculate_totals',
+			function ( $cart ) {
+				foreach ( $cart->get_cart() as $cart_item ) {
+					$cart_item['data']->set_price( 15.0 );
+				}
+			},
+			20
+		);
+
+		WC()->cart->calculate_totals();
+		WC()->cart->calculate_totals();
+
+		$this->assertSame( 20.0, (float) WC()->cart->get_total( 'edit' ) );
+	}
+
+	/**
 	 * Forget the per-request line pricing state, as a new PHP request would.
 	 *
 	 * @return void

--- a/tests/unit/test-third-party-price-mutation.php
+++ b/tests/unit/test-third-party-price-mutation.php
@@ -291,6 +291,66 @@ class Test_Third_Party_Price_Mutation extends PPOM_Test_Case {
 	}
 
 	/**
+	 * On a fresh request the session-restored PPOM price must not be mistaken for
+	 * a third-party dynamic price and used as a base for the addons again.
+	 *
+	 * @return void
+	 */
+	public function testSessionRestoredPriceIsNotReusedAsBaseInANewRequest() {
+		$product = $this->create_simple_product( array( 'regular_price' => '10' ) );
+
+		$this->insert_ppom_meta(
+			array(
+				array(
+					'type'      => 'radio',
+					'title'     => 'Gift wrap',
+					'data_name' => 'giftwrap',
+					'options'   => array(
+						array( 'option' => 'Premium wrap', 'price' => '5' ),
+					),
+				),
+			),
+			$product->get_id()
+		);
+
+		$this->initialize_woocommerce_checkout_context();
+
+		$cart_key = $this->add_product_to_real_cart(
+			$product->get_id(),
+			array(
+				'fields' => array(
+					'giftwrap' => 'Premium wrap',
+				),
+			)
+		);
+
+		$this->assertNotFalse( $cart_key );
+
+		// The cart page is a separate request: nothing survives from add-to-cart.
+		$this->reset_ppom_line_price_state();
+
+		$reloaded = $this->reload_real_cart_from_session();
+
+		$this->assertSame( 15.0, (float) $reloaded[ $cart_key ]['data']->get_price() );
+
+		WC()->cart->calculate_totals();
+		WC()->cart->calculate_totals();
+
+		$this->assertSame( 15.0, (float) WC()->cart->get_total( 'edit' ) );
+	}
+
+	/**
+	 * Forget the per-request line pricing state, as a new PHP request would.
+	 *
+	 * @return void
+	 */
+	private function reset_ppom_line_price_state() {
+		$state = new ReflectionProperty( \PPOM\Pricing\Engine::class, 'line_price_state' );
+		$state->setAccessible( true );
+		$state->setValue( null, array() );
+	}
+
+	/**
 	 * The addon price is included in totals within the same request as add-to-cart,
 	 * before any session restore — the wc-ajax=add_to_cart flow (issue #623).
 	 *


### PR DESCRIPTION
### Summary
Introduced a mechanism to track and resolve base prices for cart lines in the pricing engine, ensuring compatibility with third-party dynamic pricing plugins and preventing double-counting or price overwrites during repeated totals calculations.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/708