### PR TITLE
Improved field visibility for legacy conditions

### DIFF
--- a/bin/wp-env/mu-plugins/ppom-e2e-bootstrap.php
+++ b/bin/wp-env/mu-plugins/ppom-e2e-bootstrap.php
@@ -35,6 +35,14 @@ if ( ! defined( 'PPOM_E2E_BREAK_GROUP_READS_OPTION' ) ) {
 	define( 'PPOM_E2E_BREAK_GROUP_READS_OPTION', 'ppom_e2e_break_group_reads' );
 }
 
+if ( ! defined( 'PPOM_E2E_SETTINGS_PANEL_OPTION' ) ) {
+	define( 'PPOM_E2E_SETTINGS_PANEL_OPTION', 'ppom-settings_panel' );
+}
+
+if ( ! defined( 'PPOM_E2E_SETTINGS_TOUCHED_OPTION' ) ) {
+	define( 'PPOM_E2E_SETTINGS_TOUCHED_OPTION', 'ppom_e2e_touched_settings' );
+}
+
 /**
  * Rewrite SELECTs on the PPOM field-group table to a nonexistent table so they
  * error out, simulating a transient DB read failure (lock/timeout/dropped
@@ -1439,6 +1447,94 @@ add_action( 'wp_ajax_ppom_e2e_read_license_fixture', 'ppom_e2e_read_license_fixt
 add_action( 'wp_ajax_nopriv_ppom_e2e_read_license_fixture', 'ppom_e2e_read_license_fixture' );
 
 /**
+ * Allowlist of PPOM settings E2E fixtures may flip.
+ *
+ * @return string[]
+ */
+function ppom_e2e_settable_settings() {
+	return array(
+		'ppom_new_conditions',
+		'ppom_price_table_v2',
+		'ppom_enable_legacy_inputs_rendering',
+		'ppom_legacy_price',
+	);
+}
+
+/**
+ * Write one PPOM setting through whichever store the plugin currently reads.
+ *
+ * Mirrors Helpers::get_option(): migrated installs read the settings-panel
+ * array, older ones read a standalone option.
+ *
+ * @param string $key   Setting id.
+ * @param string $value Setting value; empty string removes it.
+ * @return void
+ */
+function ppom_e2e_write_ppom_setting( $key, $value ) {
+
+	if ( function_exists( 'ppom_settings_migrated' ) && ppom_settings_migrated() ) {
+		$saved = get_option( PPOM_E2E_SETTINGS_PANEL_OPTION );
+		$saved = is_array( $saved ) ? $saved : array();
+
+		if ( '' === $value ) {
+			unset( $saved[ $key ] );
+		} else {
+			$saved[ $key ] = $value;
+		}
+
+		update_option( PPOM_E2E_SETTINGS_PANEL_OPTION, $saved, false );
+	} elseif ( '' === $value ) {
+		delete_option( $key );
+	} else {
+		update_option( $key, $value, false );
+	}
+
+	$touched = get_option( PPOM_E2E_SETTINGS_TOUCHED_OPTION );
+	$touched = is_array( $touched ) ? $touched : array();
+
+	if ( ! in_array( $key, $touched, true ) ) {
+		$touched[] = $key;
+		update_option( PPOM_E2E_SETTINGS_TOUCHED_OPTION, $touched, false );
+	}
+}
+
+/**
+ * Set allowlisted PPOM settings, e.g. the "Legacy Conditions Script" toggle.
+ *
+ * @return void
+ */
+function ppom_e2e_set_ppom_settings() {
+	ppom_e2e_require_capability();
+	ppom_e2e_require_nonce();
+
+	$requested = ppom_e2e_decode_json_request( 'settings' );
+	$allowed   = ppom_e2e_settable_settings();
+	$applied   = array();
+
+	foreach ( $requested as $key => $value ) {
+		$key = sanitize_key( $key );
+
+		if ( ! in_array( $key, $allowed, true ) ) {
+			continue;
+		}
+
+		$value = is_scalar( $value ) ? sanitize_text_field( (string) $value ) : '';
+
+		ppom_e2e_write_ppom_setting( $key, $value );
+		$applied[ $key ] = $value;
+	}
+
+	wp_send_json_success(
+		array(
+			'applied'         => $applied,
+			'conditions_mode' => function_exists( 'ppom_get_conditions_mode' ) ? ppom_get_conditions_mode() : '',
+		)
+	);
+}
+add_action( 'wp_ajax_ppom_e2e_set_ppom_settings', 'ppom_e2e_set_ppom_settings' );
+add_action( 'wp_ajax_nopriv_ppom_e2e_set_ppom_settings', 'ppom_e2e_set_ppom_settings' );
+
+/**
  * Toggle the simulated transient failure of PPOM field-group reads.
  *
  * @return void
@@ -1454,6 +1550,11 @@ function ppom_e2e_set_group_read_failure() {
 		update_option( PPOM_E2E_BREAK_GROUP_READS_OPTION, '1', false );
 	} else {
 		delete_option( PPOM_E2E_BREAK_GROUP_READS_OPTION );
+
+	foreach ( (array) get_option( PPOM_E2E_SETTINGS_TOUCHED_OPTION, array() ) as $touched_setting ) {
+		ppom_e2e_write_ppom_setting( $touched_setting, '' );
+	}
+	delete_option( PPOM_E2E_SETTINGS_TOUCHED_OPTION );
 	}
 
 	wp_send_json_success(

--- a/bin/wp-env/mu-plugins/ppom-e2e-bootstrap.php
+++ b/bin/wp-env/mu-plugins/ppom-e2e-bootstrap.php
@@ -1550,11 +1550,6 @@ function ppom_e2e_set_group_read_failure() {
 		update_option( PPOM_E2E_BREAK_GROUP_READS_OPTION, '1', false );
 	} else {
 		delete_option( PPOM_E2E_BREAK_GROUP_READS_OPTION );
-
-	foreach ( (array) get_option( PPOM_E2E_SETTINGS_TOUCHED_OPTION, array() ) as $touched_setting ) {
-		ppom_e2e_write_ppom_setting( $touched_setting, '' );
-	}
-	delete_option( PPOM_E2E_SETTINGS_TOUCHED_OPTION );
 	}
 
 	wp_send_json_success(
@@ -1680,6 +1675,11 @@ function ppom_e2e_reset_state() {
 	delete_option( PPOM_E2E_BREAK_GROUP_READS_OPTION );
 	update_option( 'woocommerce_coming_soon', 'no', false );
 	update_option( 'woocommerce_store_pages_only', 'no', false );
+
+	foreach ( (array) get_option( PPOM_E2E_SETTINGS_TOUCHED_OPTION, array() ) as $touched_setting ) {
+		ppom_e2e_write_ppom_setting( $touched_setting, '' );
+	}
+	delete_option( PPOM_E2E_SETTINGS_TOUCHED_OPTION );
 
 	if ( defined( 'PPOM_PRODUCT_META_KEY' ) ) {
 		delete_post_meta_by_key( PPOM_PRODUCT_META_KEY );

--- a/classes/frontend-scripts.class.php
+++ b/classes/frontend-scripts.class.php
@@ -524,6 +524,10 @@ class PPOM_FRONTEND_SCRIPTS {
 									$field_conditions['rules'][ $rule_index ]['element_values'] = ppom_wpml_translate( $rule['element_values'], 'PPOM' );
 								}
 
+								if ( isset( $rule['element_constant'] ) ) {
+									$field_conditions['rules'][ $rule_index ]['element_constant'] = ppom_wpml_translate( $rule['element_constant'], 'PPOM' );
+								}
+
 								if (
 									! $conditions_pro_enabled &&
 									isset( $rule['operators'] ) &&

--- a/classes/frontend-scripts.class.php
+++ b/classes/frontend-scripts.class.php
@@ -342,6 +342,9 @@ class PPOM_FRONTEND_SCRIPTS {
 
 				$decimal_palces = wc_get_price_decimals();
 
+				// Pro-only condition operators are driven by these rule keys.
+				$conditions_pro_enabled = ppom_pro_is_valid_license();
+
 				if ( $ppom_meta_fields ) {
 
 					foreach ( $ppom_meta_fields as $field ) {
@@ -514,16 +517,17 @@ class PPOM_FRONTEND_SCRIPTS {
 
 							$field_conditions = $field['conditions'];
 
-							// WPML Translation
-							$condition_rules = $field_conditions['rules'];
-							$rule_index      = 0;
-							foreach ( $condition_rules as $rule ) {
-								if ( ! isset( $field_conditions['rules'][ $rule_index ]['element_values'] ) ) {
-									continue;
+							foreach ( $field_conditions['rules'] as $rule_index => $rule ) {
+
+								// WPML Translation.
+								if ( isset( $rule['element_values'] ) ) {
+									$field_conditions['rules'][ $rule_index ]['element_values'] = ppom_wpml_translate( $rule['element_values'], 'PPOM' );
 								}
 
-								$field_conditions['rules'][ $rule_index ]['element_values'] = ppom_wpml_translate( $rule['element_values'], 'PPOM' );
-								++$rule_index;
+								if ( ! $conditions_pro_enabled ) {
+									unset( $field_conditions['rules'][ $rule_index ]['element_constant'] );
+									unset( $field_conditions['rules'][ $rule_index ]['cond-between-interval'] );
+								}
 							}
 
 							$ppom_conditional_fields[ $data_name ] = $field_conditions;
@@ -561,6 +565,7 @@ class PPOM_FRONTEND_SCRIPTS {
 				// Conditional fields
 				if ( ! empty( $ppom_conditional_fields ) || apply_filters( 'ppom_enqueue_conditions_js', false ) ) {
 					$input_js_vars['conditions'] = $ppom_conditional_fields;
+					$input_js_vars['conditions_pro_enabled'] = $conditions_pro_enabled ? 'yes' : 'no';
 
 					$ppom_conditions_script = ppom_get_conditions_mode() === 'new' ? 'ppom-conditions-v2' : 'ppom-conditions';
 					$ppom_conditions_script = apply_filters( 'ppom_conditional_script_file', $ppom_conditions_script, $product );

--- a/classes/frontend-scripts.class.php
+++ b/classes/frontend-scripts.class.php
@@ -564,7 +564,7 @@ class PPOM_FRONTEND_SCRIPTS {
 
 				// Conditional fields
 				if ( ! empty( $ppom_conditional_fields ) || apply_filters( 'ppom_enqueue_conditions_js', false ) ) {
-					$input_js_vars['conditions'] = $ppom_conditional_fields;
+					$input_js_vars['conditions']             = $ppom_conditional_fields;
 					$input_js_vars['conditions_pro_enabled'] = $conditions_pro_enabled ? 'yes' : 'no';
 
 					$ppom_conditions_script = ppom_get_conditions_mode() === 'new' ? 'ppom-conditions-v2' : 'ppom-conditions';

--- a/classes/frontend-scripts.class.php
+++ b/classes/frontend-scripts.class.php
@@ -524,7 +524,11 @@ class PPOM_FRONTEND_SCRIPTS {
 									$field_conditions['rules'][ $rule_index ]['element_values'] = ppom_wpml_translate( $rule['element_values'], 'PPOM' );
 								}
 
-								if ( ! $conditions_pro_enabled ) {
+								if (
+									! $conditions_pro_enabled &&
+									isset( $rule['operators'] ) &&
+									in_array( $rule['operators'], array( 'contains', 'not-contains', 'regex', 'between', 'number-multiplier', 'even-number', 'odd-number' ), true )
+								) {
 									unset( $field_conditions['rules'][ $rule_index ]['element_constant'] );
 									unset( $field_conditions['rules'][ $rule_index ]['cond-between-interval'] );
 								}

--- a/js/ppom-conditions.js
+++ b/js/ppom-conditions.js
@@ -300,34 +300,52 @@ function ppom_toggle_condition_visibility( $fields, visible ) {
 		.addClass( 'ppom-c-hide' );
 }
 
+const ppom_field_visibility = {};
+
 // Showing/hiding a field also needs to broadcast the same lifecycle events
 // used by uploads, pricing, and validation to keep their state consistent.
-function ppom_unlock_field_from_condition( field, unlock ) {
-	const classname = '.ppom-input-' + field;
-	const visible = unlock === 'Show';
+function ppom_apply_field_visibility(
+	field,
+	visible,
+	remove_class,
+	add_class
+) {
+	const $fields = jQuery( '.ppom-input-' + field );
 
-	ppom_toggle_condition_visibility( jQuery( classname ), visible )
-		.removeClass( 'ppom-locked' )
-		.addClass( 'ppom-unlocked' )
-		.trigger( {
-			type: visible ? 'ppom_field_shown' : 'ppom_field_hidden',
-			field,
-			time: new Date(),
-		} );
+	// Classes are idempotent, so they stay in sync on every recalculation.
+	ppom_toggle_condition_visibility( $fields, visible )
+		.removeClass( remove_class )
+		.addClass( add_class );
+
+	if ( ppom_field_visibility[ field ] === visible ) {
+		return;
+	}
+
+	ppom_field_visibility[ field ] = visible;
+
+	$fields.trigger( {
+		type: visible ? 'ppom_field_shown' : 'ppom_field_hidden',
+		field,
+		time: new Date(),
+	} );
+}
+
+function ppom_unlock_field_from_condition( field, unlock ) {
+	ppom_apply_field_visibility(
+		field,
+		unlock === 'Show',
+		'ppom-locked',
+		'ppom-unlocked'
+	);
 }
 
 function ppom_lock_field_from_condition( field, lock ) {
-	const classname = '.ppom-input-' + field;
-	const visible = lock !== 'Show';
-
-	ppom_toggle_condition_visibility( jQuery( classname ), visible )
-		.removeClass( 'ppom-unlocked' )
-		.addClass( 'ppom-locked' )
-		.trigger( {
-			type: visible ? 'ppom_field_shown' : 'ppom_field_hidden',
-			field,
-			time: new Date(),
-		} );
+	ppom_apply_field_visibility(
+		field,
+		lock !== 'Show',
+		'ppom-unlocked',
+		'ppom-locked'
+	);
 
 	jQuery.event.trigger( {
 		type: 'ppom_field_locked',
@@ -389,8 +407,8 @@ function ppom_rule_matches( rule ) {
 			: ! ppom_element_value_is_empty( element_value );
 	}
 
-	// Multi-value sources (checkbox, image) compare against the whole selection
-	// for equality and against each selected value for everything else.
+	// Multi-value sources (checkbox, palettes, image) compare against the whole
+	// selection for equality and against each selected value for the rest.
 	if ( Array.isArray( element_value ) ) {
 		if ( operator === 'is' ) {
 			return jQuery.inArray( rule.element_values, element_value ) > -1;
@@ -400,11 +418,15 @@ function ppom_rule_matches( rule ) {
 			return jQuery.inArray( rule.element_values, element_value ) === -1;
 		}
 
-		return (
-			jQuery.grep( element_value, function ( item ) {
-				return ppom_compare_rule_value( item, rule );
-			} ).length > 0
-		);
+		const matched = jQuery.grep( element_value, function ( item ) {
+			return ppom_compare_rule_value( item, rule );
+		} );
+
+		if ( operator === 'not-contains' ) {
+			return matched.length === element_value.length;
+		}
+
+		return matched.length > 0;
 	}
 
 	return ppom_compare_rule_value( element_value, rule );

--- a/js/ppom-conditions.js
+++ b/js/ppom-conditions.js
@@ -306,7 +306,6 @@ function ppom_unlock_field_from_condition( field, unlock ) {
 	const classname = '.ppom-input-' + field;
 	const visible = unlock === 'Show';
 
-	console.log(classname, visible);
 	ppom_toggle_condition_visibility( jQuery( classname ), visible )
 		.removeClass( 'ppom-locked' )
 		.addClass( 'ppom-unlocked' )
@@ -353,10 +352,36 @@ function ppom_get_field_rule_status( condition ) {
 	return ppom_rules_matched;
 }
 
+// Operators the conditions UI marks as Pro. Some of them ('even-number',
+// 'odd-number') need no rule data at all, so the payload cannot gate them and
+// the server has to state whether Pro is active.
+const ppom_pro_only_operators = [
+	'contains',
+	'not-contains',
+	'regex',
+	'between',
+	'number-multiplier',
+	'even-number',
+	'odd-number',
+];
+
+function ppom_operator_is_available( operator ) {
+	if ( jQuery.inArray( operator, ppom_pro_only_operators ) === -1 ) {
+		return true;
+	}
+
+	return ppom_input_vars.conditions_pro_enabled === 'yes';
+}
+
 // Evaluate one rule against the current value of its source field.
 function ppom_rule_matches( rule ) {
-	const element_value = ppom_get_element_value( rule.elements );
 	const operator = rule.operators;
+
+	if ( ! ppom_operator_is_available( operator ) ) {
+		return false;
+	}
+
+	const element_value = ppom_get_element_value( rule.elements );
 
 	if ( operator === 'any' || operator === 'empty' ) {
 		return operator === 'empty'
@@ -412,8 +437,8 @@ function ppom_rule_comparison_value( rule ) {
 
 // Compare a single source value against one rule.
 function ppom_compare_rule_value( element_value, rule ) {
-	// Pro-only operators are unusable without their constant, which PHP strips
-	// for installs without an active Pro license.
+	// PHP also withholds this value from installs without an active Pro
+	// license, so the constant-driven operators have nothing to match against.
 	const constant = rule.element_constant;
 
 	switch ( rule.operators ) {
@@ -505,12 +530,14 @@ function ppom_regex_matches( element_value, pattern ) {
 		return false;
 	}
 
-	const parts = pattern.split( '/' );
+	const delimited = pattern.match( /^\/(.*)\/([a-z]*)$/ );
 
 	try {
-		return new RegExp( parts[ 1 ] || pattern, parts[ 2 ] ).test(
-			element_value
-		);
+		const regex = delimited
+			? new RegExp( delimited[ 1 ], delimited[ 2 ] )
+			: new RegExp( pattern );
+
+		return regex.test( element_value );
 	} catch ( error ) {
 		return false;
 	}
@@ -557,6 +584,12 @@ function ppom_get_element_value( field_name ) {
 			value_found = jQuery(
 				'input[name="ppom[fields][' + field_name + ']"]:checked'
 			).attr( 'data-title' );
+			break;
+
+		case 'switcher':
+			value_found = jQuery(
+				'.ppom-input[data-data_name="' + field_name + '"]:checked'
+			).val();
 			break;
 
 		default:

--- a/js/ppom-conditions.js
+++ b/js/ppom-conditions.js
@@ -300,7 +300,10 @@ function ppom_toggle_condition_visibility( $fields, visible ) {
 		.addClass( 'ppom-c-hide' );
 }
 
-const ppom_field_visibility = {};
+// Fields whose condition has been evaluated at least once. The first pass always
+// emits, so listeners that set widgets up still run for fields that are already
+// visible on page load.
+const ppom_evaluated_fields = {};
 
 // Showing/hiding a field also needs to broadcast the same lifecycle events
 // used by uploads, pricing, and validation to keep their state consistent.
@@ -317,11 +320,13 @@ function ppom_apply_field_visibility(
 		.removeClass( remove_class )
 		.addClass( add_class );
 
-	if ( ppom_field_visibility[ field ] === visible ) {
+	const tracked_visible = jQuery.inArray( field, ppom_hidden_fields ) === -1;
+
+	if ( ppom_evaluated_fields[ field ] && tracked_visible === visible ) {
 		return;
 	}
 
-	ppom_field_visibility[ field ] = visible;
+	ppom_evaluated_fields[ field ] = true;
 
 	$fields.trigger( {
 		type: visible ? 'ppom_field_shown' : 'ppom_field_hidden',

--- a/js/ppom-conditions.js
+++ b/js/ppom-conditions.js
@@ -12,8 +12,9 @@ const ppom_hidden_fields = [];
 jQuery( function ( $ ) {
 	// Legacy mode recalculates all conditions after each relevant field change.
 	$( '.ppom-wrapper' ).on(
-		'change',
-		'select,input:radio,input:checkbox',
+		'change keyup',
+		'select, textarea, input:radio, input:checkbox, input:text,' +
+			' input[type="number"], input[type="email"], input[type="date"]',
 		function ( e ) {
 			ppom_check_conditions();
 		}
@@ -185,7 +186,12 @@ jQuery( function ( $ ) {
 				break;
 		}
 
-		ppom_hidden_fields.push( e.field );
+		// The event fires on every recalculation, not only on a change, so the
+		// submitted `conditionally_hidden` list must not collect duplicates.
+		if ( $.inArray( e.field, ppom_hidden_fields ) === -1 ) {
+			ppom_hidden_fields.push( e.field );
+		}
+
 		$.event.trigger( {
 			type: 'ppom_hidden_fields_updated',
 			field: e.field,
@@ -280,56 +286,49 @@ function ppom_check_conditions() {
 	} );
 }
 
+function ppom_toggle_condition_visibility( $fields, visible ) {
+	if ( visible ) {
+		return $fields
+			.removeClass( 'ppom-c-hide' )
+			.addClass( 'ppom-c-show' )
+			.show();
+	}
+
+	return $fields
+		.hide()
+		.removeClass( 'ppom-c-show' )
+		.addClass( 'ppom-c-hide' );
+}
+
 // Showing/hiding a field also needs to broadcast the same lifecycle events
 // used by uploads, pricing, and validation to keep their state consistent.
 function ppom_unlock_field_from_condition( field, unlock ) {
 	const classname = '.ppom-input-' + field;
-	if ( unlock === 'Show' ) {
-		jQuery( classname )
-			.show()
-			.removeClass( 'ppom-locked' )
-			.addClass( 'ppom-unlocked' )
-			.trigger( {
-				type: 'ppom_field_shown',
-				field,
-				time: new Date(),
-			} );
-	} else {
-		jQuery( classname )
-			.hide()
-			.removeClass( 'ppom-locked' )
-			.addClass( 'ppom-unlocked' )
-			.trigger( {
-				type: 'ppom_field_hidden',
-				field,
-				time: new Date(),
-			} );
-	}
+	const visible = unlock === 'Show';
+
+	console.log(classname, visible);
+	ppom_toggle_condition_visibility( jQuery( classname ), visible )
+		.removeClass( 'ppom-locked' )
+		.addClass( 'ppom-unlocked' )
+		.trigger( {
+			type: visible ? 'ppom_field_shown' : 'ppom_field_hidden',
+			field,
+			time: new Date(),
+		} );
 }
 
 function ppom_lock_field_from_condition( field, lock ) {
 	const classname = '.ppom-input-' + field;
-	if ( lock === 'Show' ) {
-		jQuery( classname )
-			.hide()
-			.removeClass( 'ppom-unlocked' )
-			.addClass( 'ppom-locked' )
-			.trigger( {
-				type: 'ppom_field_hidden',
-				field,
-				time: new Date(),
-			} );
-	} else {
-		jQuery( classname )
-			.show()
-			.removeClass( 'ppom-unlocked' )
-			.addClass( 'ppom-locked' )
-			.trigger( {
-				type: 'ppom_field_shown',
-				field,
-				time: new Date(),
-			} );
-	}
+	const visible = lock !== 'Show';
+
+	ppom_toggle_condition_visibility( jQuery( classname ), visible )
+		.removeClass( 'ppom-unlocked' )
+		.addClass( 'ppom-locked' )
+		.trigger( {
+			type: visible ? 'ppom_field_shown' : 'ppom_field_hidden',
+			field,
+			time: new Date(),
+		} );
 
 	jQuery.event.trigger( {
 		type: 'ppom_field_locked',
@@ -342,91 +341,179 @@ function ppom_lock_field_from_condition( field, lock ) {
 // Count how many rules match for a target field in the legacy condition format.
 function ppom_get_field_rule_status( condition ) {
 	let ppom_rules_matched = 0;
+
 	jQuery.each( condition.rules, function ( i, rule ) {
-		const element_type = ppom_get_field_type_by_id( rule.elements );
-
-		// console.log(element_type);
-		switch ( rule.operators ) {
-			case 'is':
-				if ( element_type === 'checkbox' ) {
-					var element_value = ppom_get_element_value( rule.elements );
-					jQuery( element_value ).each( function ( i, item ) {
-						if ( item === rule.element_values ) {
-							ppom_rules_matched++;
-						}
-					} );
-				} else if ( element_type === 'image' ) {
-					var element_value = ppom_get_element_value( rule.elements );
-					jQuery( element_value ).each( function ( i, item ) {
-						if ( item === rule.element_values ) {
-							ppom_rules_matched++;
-						}
-					} );
-				} else if (
-					ppom_get_element_value( rule.elements ) ===
-					rule.element_values
-				) {
-					ppom_rules_matched++;
-				}
-				break;
-
-			case 'not':
-				if ( element_type === 'checkbox' ) {
-					var element_value = ppom_get_element_value( rule.elements );
-					jQuery( element_value ).each( function ( i, item ) {
-						if ( item !== rule.element_values ) {
-							ppom_rules_matched++;
-						}
-					} );
-				} else if (
-					ppom_get_element_value( rule.elements ) !==
-					rule.element_values
-				) {
-					ppom_rules_matched++;
-				}
-				break;
-
-			case 'greater than':
-				if ( element_type === 'checkbox' ) {
-					var element_value = ppom_get_element_value( rule.elements );
-					jQuery( element_value ).each( function ( i, item ) {
-						if (
-							parseFloat( item ) >
-							parseFloat( rule.element_values )
-						) {
-							ppom_rules_matched++;
-						}
-					} );
-				} else if (
-					parseFloat( ppom_get_element_value( rule.elements ) ) >
-					parseFloat( rule.element_values )
-				) {
-					ppom_rules_matched++;
-				}
-				break;
-
-			case 'less than':
-				if ( element_type === 'checkbox' ) {
-					var element_value = ppom_get_element_value( rule.elements );
-					jQuery( element_value ).each( function ( i, item ) {
-						if (
-							parseFloat( item ) <
-							parseFloat( rule.element_values )
-						) {
-							ppom_rules_matched++;
-						}
-					} );
-				} else if (
-					parseFloat( ppom_get_element_value( rule.elements ) ) <
-					parseFloat( rule.element_values )
-				) {
-					ppom_rules_matched++;
-				}
-				break;
+		// A rule contributes at most one match so `All` can compare the match
+		// count against the rule count.
+		if ( ppom_rule_matches( rule ) ) {
+			ppom_rules_matched++;
 		}
 	} );
 
 	return ppom_rules_matched;
+}
+
+// Evaluate one rule against the current value of its source field.
+function ppom_rule_matches( rule ) {
+	const element_value = ppom_get_element_value( rule.elements );
+	const operator = rule.operators;
+
+	if ( operator === 'any' || operator === 'empty' ) {
+		return operator === 'empty'
+			? ppom_element_value_is_empty( element_value )
+			: ! ppom_element_value_is_empty( element_value );
+	}
+
+	// Multi-value sources (checkbox, image) compare against the whole selection
+	// for equality and against each selected value for everything else.
+	if ( Array.isArray( element_value ) ) {
+		if ( operator === 'is' ) {
+			return jQuery.inArray( rule.element_values, element_value ) > -1;
+		}
+
+		if ( operator === 'not' ) {
+			return jQuery.inArray( rule.element_values, element_value ) === -1;
+		}
+
+		return (
+			jQuery.grep( element_value, function ( item ) {
+				return ppom_compare_rule_value( item, rule );
+			} ).length > 0
+		);
+	}
+
+	return ppom_compare_rule_value( element_value, rule );
+}
+
+function ppom_element_value_is_empty( element_value ) {
+	if ( Array.isArray( element_value ) ) {
+		return element_value.length === 0;
+	}
+
+	return (
+		element_value === undefined ||
+		element_value === null ||
+		element_value === ''
+	);
+}
+
+// Numeric operators must not treat a blank or non-numeric field as a number,
+// otherwise an untouched field reads as "odd" or "not a multiple of".
+function ppom_to_number( value ) {
+	const number = parseFloat( value );
+
+	return isNaN( number ) ? null : number;
+}
+
+// The option dropdown wins; the Pro-only constant input is the fallback.
+function ppom_rule_comparison_value( rule ) {
+	return rule.element_values || rule.element_constant;
+}
+
+// Compare a single source value against one rule.
+function ppom_compare_rule_value( element_value, rule ) {
+	// Pro-only operators are unusable without their constant, which PHP strips
+	// for installs without an active Pro license.
+	const constant = rule.element_constant;
+
+	switch ( rule.operators ) {
+		case 'is':
+			return element_value === ppom_rule_comparison_value( rule );
+
+		case 'not':
+			return element_value !== ppom_rule_comparison_value( rule );
+
+		case 'contains':
+			return (
+				!! constant && String( element_value ).indexOf( constant ) > -1
+			);
+
+		case 'not-contains':
+			return (
+				!! constant &&
+				String( element_value ).indexOf( constant ) === -1
+			);
+
+		case 'regex':
+			return ppom_regex_matches( element_value, constant );
+
+		case 'greater than':
+		case 'less than':
+		case 'between':
+		case 'number-multiplier':
+		case 'even-number':
+		case 'odd-number':
+			return ppom_compare_numeric_rule_value(
+				ppom_to_number( element_value ),
+				rule
+			);
+
+		default:
+			// An operator this build does not know about never matches, the
+			// same as the v2 engine.
+			return false;
+	}
+}
+
+// Numeric operators, split out so a blank or non-numeric source value can be
+// rejected once instead of per operator.
+function ppom_compare_numeric_rule_value( number, rule ) {
+	if ( number === null ) {
+		return false;
+	}
+
+	switch ( rule.operators ) {
+		case 'greater than':
+			return number > parseFloat( ppom_rule_comparison_value( rule ) );
+
+		case 'less than':
+			return number < parseFloat( ppom_rule_comparison_value( rule ) );
+
+		case 'between': {
+			const interval = rule[ 'cond-between-interval' ] || {};
+
+			return (
+				number >= parseFloat( interval.from ) &&
+				number <= parseFloat( interval.to )
+			);
+		}
+
+		case 'number-multiplier': {
+			const multiplier = ppom_to_number( rule.element_constant );
+
+			return (
+				multiplier !== null &&
+				multiplier !== 0 &&
+				number % multiplier === 0
+			);
+		}
+
+		case 'even-number':
+			return number % 2 === 0;
+
+		case 'odd-number':
+			return number % 2 !== 0;
+	}
+
+	return false;
+}
+
+// Accepts both `/pattern/flags` and a bare pattern, and never lets a malformed
+// pattern throw out of the condition loop.
+function ppom_regex_matches( element_value, pattern ) {
+	if ( typeof pattern !== 'string' || pattern === '' ) {
+		return false;
+	}
+
+	const parts = pattern.split( '/' );
+
+	try {
+		return new RegExp( parts[ 1 ] || pattern, parts[ 2 ] ).test(
+			element_value
+		);
+	} catch ( error ) {
+		return false;
+	}
 }
 
 // Normalize legacy field values before comparing them against rule operators.
@@ -448,6 +535,7 @@ function ppom_get_element_value( field_name ) {
 			).val();
 			break;
 
+		case 'palettes':
 		case 'checkbox':
 			jQuery(
 				'input[name="ppom[fields][' + field_name + '][]"]:checked'
@@ -470,9 +558,19 @@ function ppom_get_element_value( field_name ) {
 				'input[name="ppom[fields][' + field_name + ']"]:checked'
 			).attr( 'data-title' );
 			break;
+
+		default:
+			value_found = jQuery(
+				'.ppom-input[data-data_name="' + field_name + '"]'
+			).val();
+			break;
 	}
 
-	if ( element_type === 'checkbox' || element_type === 'image' ) {
+	if (
+		element_type === 'checkbox' ||
+		element_type === 'palettes' ||
+		element_type === 'image'
+	) {
 		return value_found_cb;
 	}
 

--- a/js/ppom-conditions.js
+++ b/js/ppom-conditions.js
@@ -300,10 +300,10 @@ function ppom_toggle_condition_visibility( $fields, visible ) {
 		.addClass( 'ppom-c-hide' );
 }
 
-// Fields whose condition has been evaluated at least once. The first pass always
-// emits, so listeners that set widgets up still run for fields that are already
-// visible on page load.
-const ppom_evaluated_fields = {};
+// Visibility this engine last announced per field. Undefined until the first
+// evaluation, which therefore always emits so listeners that set widgets up run
+// for fields already visible on page load.
+const ppom_field_visibility = {};
 
 // Showing/hiding a field also needs to broadcast the same lifecycle events
 // used by uploads, pricing, and validation to keep their state consistent.
@@ -320,13 +320,21 @@ function ppom_apply_field_visibility(
 		.removeClass( remove_class )
 		.addClass( add_class );
 
+	// Two states have to agree before an event can be skipped, because both can
+	// be moved by something other than this recalculation:
+	// - what this engine last announced, which a real condition flip changes;
+	// - `ppom_hidden_fields`, the submitted payload, which the lifecycle events
+	//   maintain and which js/ppom-variation-rules.js also emits into.
+	// Skipping on either alone drops a genuine transition or leaves the payload
+	// disagreeing with what the customer can see.
+	const announced_visible = ppom_field_visibility[ field ];
 	const tracked_visible = jQuery.inArray( field, ppom_hidden_fields ) === -1;
 
-	if ( ppom_evaluated_fields[ field ] && tracked_visible === visible ) {
+	if ( announced_visible === visible && tracked_visible === visible ) {
 		return;
 	}
 
-	ppom_evaluated_fields[ field ] = true;
+	ppom_field_visibility[ field ] = visible;
 
 	$fields.trigger( {
 		type: visible ? 'ppom_field_shown' : 'ppom_field_hidden',

--- a/src/Hooks/Callbacks.php
+++ b/src/Hooks/Callbacks.php
@@ -533,8 +533,8 @@ final class Callbacks {
 
 		// Conditional fields
 		if ( ! empty( $ppom_conditional_fields ) || apply_filters( 'ppom_enqueue_conditions_js', false ) ) {
-			$ppom_input_vars['conditions']             = $ppom_conditional_fields;
-			$ppom_input_vars['conditions_pro_enabled'] = Helpers::conditions_pro_enabled() ? 'yes' : 'no';
+			$ppom_input_vars['conditions']           = $ppom_conditional_fields;
+			$input_js_vars['conditions_pro_enabled'] = $conditions_pro_enabled ? 'yes' : 'no';
 
 			$ppom_conditions_script = Helpers::get_conditions_mode() === 'new' ? 'ppom-conditions-v2' : 'ppom-conditions';
 			$ppom_conditions_script = apply_filters( 'ppom_conditional_script_file', $ppom_conditions_script, $product );

--- a/src/Hooks/Callbacks.php
+++ b/src/Hooks/Callbacks.php
@@ -533,8 +533,8 @@ final class Callbacks {
 
 		// Conditional fields
 		if ( ! empty( $ppom_conditional_fields ) || apply_filters( 'ppom_enqueue_conditions_js', false ) ) {
-			$ppom_input_vars['conditions']           = $ppom_conditional_fields;
-			$input_js_vars['conditions_pro_enabled'] = $conditions_pro_enabled ? 'yes' : 'no';
+			$ppom_input_vars['conditions']             = $ppom_conditional_fields;
+			$ppom_input_vars['conditions_pro_enabled'] = $conditions_pro_enabled ? 'yes' : 'no';
 
 			$ppom_conditions_script = Helpers::get_conditions_mode() === 'new' ? 'ppom-conditions-v2' : 'ppom-conditions';
 			$ppom_conditions_script = apply_filters( 'ppom_conditional_script_file', $ppom_conditions_script, $product );

--- a/src/Hooks/Callbacks.php
+++ b/src/Hooks/Callbacks.php
@@ -308,6 +308,9 @@ final class Callbacks {
 		// ppom_pa($ppom_meta_fields);
 
 		$decimal_palces = wc_get_price_decimals();
+		// Pro-only condition operators are driven by these rule keys.
+		$conditions_pro_enabled = ppom_pro_is_valid_license();
+
 		if ( $ppom_meta_fields ) {
 			foreach ( $ppom_meta_fields as $field ) {
 
@@ -475,16 +478,25 @@ final class Callbacks {
 
 					$field_conditions = $field['conditions'];
 
-					// WPML Translation
-					$condition_rules = $field_conditions['rules'];
-					$rule_index      = 0;
-					foreach ( $condition_rules as $rule ) {
-						// ppom_pa($rule);
-						if ( ! isset( $field_conditions['rules'][ $rule_index ]['element_values'] ) ) {
-							continue;
+					foreach ( $field_conditions['rules'] as $rule_index => $rule ) {
+
+						// WPML Translation.
+						if ( isset( $rule['element_values'] ) ) {
+							$field_conditions['rules'][ $rule_index ]['element_values'] = ppom_wpml_translate( $rule['element_values'], 'PPOM' );
 						}
-						$field_conditions['rules'][ $rule_index ]['element_values'] = Helpers::wpml_translate( $rule['element_values'], 'PPOM' );
-						++$rule_index;
+
+						if ( isset( $rule['element_constant'] ) ) {
+							$field_conditions['rules'][ $rule_index ]['element_constant'] = ppom_wpml_translate( $rule['element_constant'], 'PPOM' );
+						}
+
+						if (
+							! $conditions_pro_enabled &&
+							isset( $rule['operators'] ) &&
+							in_array( $rule['operators'], array( 'contains', 'not-contains', 'regex', 'between', 'number-multiplier', 'even-number', 'odd-number' ), true )
+						) {
+							unset( $field_conditions['rules'][ $rule_index ]['element_constant'] );
+							unset( $field_conditions['rules'][ $rule_index ]['cond-between-interval'] );
+						}
 					}
 
 					$ppom_conditional_fields[ $data_name ] = $field_conditions;
@@ -521,7 +533,8 @@ final class Callbacks {
 
 		// Conditional fields
 		if ( ! empty( $ppom_conditional_fields ) || apply_filters( 'ppom_enqueue_conditions_js', false ) ) {
-			$ppom_input_vars['conditions'] = $ppom_conditional_fields;
+			$ppom_input_vars['conditions']             = $ppom_conditional_fields;
+			$ppom_input_vars['conditions_pro_enabled'] = Helpers::conditions_pro_enabled() ? 'yes' : 'no';
 
 			$ppom_conditions_script = Helpers::get_conditions_mode() === 'new' ? 'ppom-conditions-v2' : 'ppom-conditions';
 			$ppom_conditions_script = apply_filters( 'ppom_conditional_script_file', $ppom_conditions_script, $product );

--- a/tests/e2e/fixtures/fields.js
+++ b/tests/e2e/fixtures/fields.js
@@ -31,6 +31,10 @@ function buildTextareaField( args ) {
 	return buildField( 'textarea', args );
 }
 
+function buildNumberField( args ) {
+	return buildField( 'number', args );
+}
+
 function buildImageField( args ) {
 	return buildField( 'image', {
 		images: [],
@@ -148,6 +152,7 @@ function buildTextCounterField( {
 export {
 	buildCheckboxField,
 	buildImageField,
+	buildNumberField,
 	buildPalettesField,
 	buildPriceMatrixField,
 	buildQuantitiesField,

--- a/tests/e2e/fixtures/index.js
+++ b/tests/e2e/fixtures/index.js
@@ -14,6 +14,7 @@ export {
 	buildCheckboxField,
 	buildFileField,
 	buildHtmlField,
+	buildNumberField,
 	buildPriceMatrixField,
 	buildQuantitiesField,
 	buildSelectField,
@@ -22,6 +23,7 @@ export {
 	buildTextCounterField,
 } from './fields.js';
 export { getPpomLicenseFixture, setPpomLicenseFixture } from './license.js';
+export { setLegacyConditionsScript, setPpomSettings } from './settings.js';
 export {
 	createProductCategory,
 	createProductTag,

--- a/tests/e2e/fixtures/settings.js
+++ b/tests/e2e/fixtures/settings.js
@@ -1,0 +1,34 @@
+import { postBootstrapAction } from './internal.js';
+
+/**
+ * Set allowlisted PPOM plugin settings for the current test.
+ *
+ * Values are reverted by the bootstrap reset path, so tests do not leak the
+ * toggle into the rest of the suite.
+ *
+ * @param {import('@wordpress/e2e-test-utils-playwright').RequestUtils} requestUtils Authenticated request utils.
+ * @param {Object<string, string>} settings Setting id => value ('' clears it).
+ * @return {Promise<{ applied: Object<string, string>, conditions_mode: string }>} Applied settings and resolved conditions mode.
+ */
+export async function setPpomSettings( requestUtils, settings ) {
+	return postBootstrapAction( requestUtils, 'ppom_e2e_set_ppom_settings', {
+		settings,
+	} );
+}
+
+/**
+ * Enable or disable the "Legacy Conditions Script" option, which swaps
+ * `ppom-conditions-v2.js` for the legacy `ppom-conditions.js` engine.
+ *
+ * @param {import('@wordpress/e2e-test-utils-playwright').RequestUtils} requestUtils Authenticated request utils.
+ * @param {boolean} [enabled=true] Whether legacy conditions should be used.
+ * @return {Promise<{ applied: Object<string, string>, conditions_mode: string }>} Applied settings and resolved conditions mode.
+ */
+export async function setLegacyConditionsScript(
+	requestUtils,
+	enabled = true
+) {
+	return setPpomSettings( requestUtils, {
+		ppom_new_conditions: enabled ? 'yes' : '',
+	} );
+}

--- a/tests/e2e/specs/legacy-conditions.spec.js
+++ b/tests/e2e/specs/legacy-conditions.spec.js
@@ -1,0 +1,436 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+import {
+	attachPpomGroupToProducts,
+	buildCheckboxField,
+	buildNumberField,
+	buildSelectField,
+	buildTextField,
+	createPpomGroup,
+	createSimpleProduct,
+	setLegacyConditionsScript,
+	setPpomLicenseFixture,
+} from '../fixtures/index.js';
+
+/**
+ * Coverage for the "Legacy Conditions Script" setting (`ppom_new_conditions`),
+ * which swaps `ppom-conditions-v2.js` for the legacy `ppom-conditions.js`
+ * engine. In legacy mode PHP hides Show-conditioned wrappers with the
+ * `ppom-c-hide` class, so the engine has to toggle that class — jQuery
+ * `show()`/`hide()` alone cannot beat `visibility: hidden`.
+ */
+function uniqueToken() {
+	return `${ Date.now() }_${ Math.floor( Math.random() * 1e6 ) }`;
+}
+
+function selectByName( page, dataName ) {
+	return page.locator( `select[name="ppom[fields][${ dataName }]"]` );
+}
+
+/**
+ * Build a group whose only conditional field is driven by `rules`, attach it to
+ * a fresh product, and open that product page.
+ *
+ * @param {Object} args
+ * @param {import('@playwright/test').Page} args.page Playwright page.
+ * @param {import('@wordpress/e2e-test-utils-playwright').RequestUtils} args.requestUtils Authenticated request utils.
+ * @param {string} args.groupName Field group title.
+ * @param {Object[]} args.sourceFields Fields the rules point at.
+ * @param {Object[]} args.rules Condition rules for the target field.
+ * @param {string} [args.visibility='Show'] Condition visibility.
+ * @param {string} [args.bound='All'] Rule binding.
+ * @param {string} args.targetDataName Target field data_name.
+ * @return {Promise<void>}
+ */
+async function openConditionalProduct( {
+	page,
+	requestUtils,
+	groupName,
+	sourceFields,
+	rules,
+	visibility = 'Show',
+	bound = 'All',
+	targetDataName,
+} ) {
+	const product = await createSimpleProduct( requestUtils );
+	const { ppomId } = await createPpomGroup( requestUtils, {
+		groupName,
+		fields: [
+			...sourceFields,
+			buildTextField( {
+				title: 'Output',
+				dataName: targetDataName,
+				logic: 'on',
+				conditions: { visibility, bound, rules },
+			} ),
+		],
+	} );
+
+	await attachPpomGroupToProducts( requestUtils, {
+		ppomId,
+		productIds: [ product.id ],
+	} );
+
+	await page.goto( `/?p=${ product.id }` );
+}
+
+test.describe( 'Legacy conditions script', () => {
+	test.beforeEach( async ( { requestUtils } ) => {
+		await setPpomLicenseFixture( requestUtils, {
+			valid: true,
+			plan: 1,
+			proInstalled: false,
+		} );
+
+		const applied = await setLegacyConditionsScript( requestUtils, true );
+		expect( applied.conditions_mode ).toBe( 'legacy' );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		const applied = await setLegacyConditionsScript( requestUtils, false );
+		expect( applied.conditions_mode ).toBe( 'new' );
+	} );
+
+	test( 'legacy: the legacy engine is the one loaded on the product page', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const token = uniqueToken();
+		const controllingId = `size_${ token }`;
+		const outputId = `size_notes_${ token }`;
+		const product = await createSimpleProduct( requestUtils );
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: `LC Script ${ token }`,
+			fields: [
+				buildSelectField( {
+					title: `Size ${ token }`,
+					dataName: controllingId,
+					options: [
+						{ label: 'Small', value: 'small' },
+						{ label: 'Large', value: 'large' },
+					],
+				} ),
+				buildTextField( {
+					title: 'Size notes',
+					dataName: outputId,
+					logic: 'on',
+					conditions: {
+						visibility: 'Show',
+						bound: 'All',
+						rules: [
+							{
+								elements: controllingId,
+								operators: 'is',
+								element_values: 'Large',
+							},
+						],
+					},
+				} ),
+			],
+		} );
+
+		await attachPpomGroupToProducts( requestUtils, {
+			ppomId,
+			productIds: [ product.id ],
+		} );
+
+		await page.goto( `/?p=${ product.id }` );
+
+		await expect(
+			page.locator( 'script[src*="ppom-conditions.js"]' )
+		).toHaveCount( 1 );
+		await expect(
+			page.locator( 'script[src*="ppom-conditions-v2.js"]' )
+		).toHaveCount( 0 );
+	} );
+
+	test( 'legacy: Show + is reveals and re-hides the target as the controlling Select changes', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const optionOne = { label: 'Option 1', value: 'option_1' };
+		const optionTwo = { label: 'Option 2', value: 'option_2' };
+		const token = uniqueToken();
+		const controllingId = `legacy_show_${ token }`;
+		const outputId = `legacy_show_out_${ token }`;
+		const product = await createSimpleProduct( requestUtils );
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: `LC Show ${ token }`,
+			fields: [
+				buildSelectField( {
+					title: `Controller ${ token }`,
+					dataName: controllingId,
+					options: [ optionOne, optionTwo ],
+				} ),
+				buildTextField( {
+					title: 'Output',
+					dataName: outputId,
+					logic: 'on',
+					conditions: {
+						visibility: 'Show',
+						bound: 'All',
+						rules: [
+							{
+								elements: controllingId,
+								operators: 'is',
+								element_values: optionTwo.label,
+							},
+						],
+					},
+				} ),
+			],
+		} );
+
+		await attachPpomGroupToProducts( requestUtils, {
+			ppomId,
+			productIds: [ product.id ],
+		} );
+
+		await page.goto( `/?p=${ product.id }` );
+
+		const output = page.getByLabel( 'Output' );
+		await expect( output ).toBeHidden();
+
+		const controllingSelect = selectByName( page, controllingId );
+		await controllingSelect.selectOption( { label: optionTwo.label } );
+		await expect( controllingSelect ).toHaveValue( optionTwo.label );
+
+		await expect( output ).toBeVisible();
+
+		// Reverting the controller must put the target back out of view.
+		await controllingSelect.selectOption( { label: optionOne.label } );
+		await expect( output ).toBeHidden();
+	} );
+
+	test( 'legacy: Hide + is removes and restores the target as the controlling Select changes', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const noOpt = { label: 'No', value: 'no' };
+		const yesOpt = { label: 'Yes', value: 'yes' };
+		const token = uniqueToken();
+		const controllingId = `legacy_hide_${ token }`;
+		const outputId = `legacy_hide_out_${ token }`;
+		const product = await createSimpleProduct( requestUtils );
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: `LC Hide ${ token }`,
+			fields: [
+				buildSelectField( {
+					title: `Gift wrap ${ token }`,
+					dataName: controllingId,
+					options: [ noOpt, yesOpt ],
+				} ),
+				buildTextField( {
+					title: 'Gift message',
+					dataName: outputId,
+					logic: 'on',
+					conditions: {
+						visibility: 'Hide',
+						bound: 'All',
+						rules: [
+							{
+								elements: controllingId,
+								operators: 'is',
+								element_values: yesOpt.label,
+							},
+						],
+					},
+				} ),
+			],
+		} );
+
+		await attachPpomGroupToProducts( requestUtils, {
+			ppomId,
+			productIds: [ product.id ],
+		} );
+
+		await page.goto( `/?p=${ product.id }` );
+
+		const output = page.getByLabel( 'Gift message' );
+		const controllingSelect = selectByName( page, controllingId );
+
+		await expect( controllingSelect ).toHaveValue( noOpt.label );
+		await expect( output ).toBeVisible();
+
+		await controllingSelect.selectOption( { label: yesOpt.label } );
+		await expect( output ).toBeHidden();
+
+		await controllingSelect.selectOption( { label: noOpt.label } );
+		await expect( output ).toBeVisible();
+	} );
+	test( 'legacy: has any value / is empty operators evaluate instead of being ignored', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const token = uniqueToken();
+		const sourceId = `legacy_any_src_${ token }`;
+
+		await openConditionalProduct( {
+			page,
+			requestUtils,
+			groupName: `LC Any ${ token }`,
+			targetDataName: `legacy_any_out_${ token }`,
+			sourceFields: [
+				buildTextField( {
+					title: `Engraving ${ token }`,
+					dataName: sourceId,
+				} ),
+			],
+			rules: [
+				{
+					elements: sourceId,
+					operators: 'any',
+					element_values: '',
+				},
+			],
+		} );
+
+		const output = page.getByLabel( 'Output' );
+		const source = page.locator(
+			`input[name="ppom[fields][${ sourceId }]"]`
+		);
+
+		await expect( output ).toBeHidden();
+
+		await source.fill( 'Happy birthday' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeVisible();
+
+		await source.fill( '' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeHidden();
+	} );
+
+	test( 'legacy: greater than compares the real value of a Number source', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const token = uniqueToken();
+		const sourceId = `legacy_qty_${ token }`;
+
+		await openConditionalProduct( {
+			page,
+			requestUtils,
+			groupName: `LC Greater ${ token }`,
+			targetDataName: `legacy_qty_out_${ token }`,
+			sourceFields: [
+				buildNumberField( {
+					title: `Copies ${ token }`,
+					dataName: sourceId,
+				} ),
+			],
+			rules: [
+				{
+					elements: sourceId,
+					operators: 'greater than',
+					element_values: '10',
+				},
+			],
+		} );
+
+		const output = page.getByLabel( 'Output' );
+		const source = page.locator(
+			`input[name="ppom[fields][${ sourceId }]"]`
+		);
+
+		await expect( output ).toBeHidden();
+
+		await source.fill( '25' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeVisible();
+
+		await source.fill( '3' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeHidden();
+	} );
+
+	test( 'legacy: is not on a Checkbox source looks at the whole selection', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const token = uniqueToken();
+		const sourceId = `legacy_cb_${ token }`;
+		const optionA = { label: 'Gift wrap', value: 'gift_wrap' };
+		const optionB = { label: 'Express', value: 'express' };
+
+		await openConditionalProduct( {
+			page,
+			requestUtils,
+			groupName: `LC Checkbox Not ${ token }`,
+			targetDataName: `legacy_cb_out_${ token }`,
+			sourceFields: [
+				buildCheckboxField( {
+					title: `Extras ${ token }`,
+					dataName: sourceId,
+					options: [ optionA, optionB ],
+				} ),
+			],
+			rules: [
+				{
+					elements: sourceId,
+					operators: 'not',
+					element_values: optionA.label,
+				},
+			],
+		} );
+
+		const output = page.getByLabel( 'Output' );
+		const boxes = page.locator(
+			`input[name="ppom[fields][${ sourceId }][]"]`
+		);
+
+		// Nothing selected: "is not Gift wrap" holds.
+		await expect( output ).toBeVisible();
+
+		// Gift wrap selected alongside another box must still count as a match
+		// for the rule value, so the target hides.
+		await boxes.nth( 0 ).check();
+		await boxes.nth( 1 ).check();
+		await expect( output ).toBeHidden();
+
+		await boxes.nth( 0 ).uncheck();
+		await expect( output ).toBeVisible();
+	} );
+
+	test( 'legacy: an unknown operator never matches', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const token = uniqueToken();
+		const sourceId = `legacy_unknown_${ token }`;
+
+		await openConditionalProduct( {
+			page,
+			requestUtils,
+			groupName: `LC Unknown ${ token }`,
+			targetDataName: `legacy_unknown_out_${ token }`,
+			sourceFields: [
+				buildTextField( {
+					title: `Notes ${ token }`,
+					dataName: sourceId,
+				} ),
+			],
+			rules: [
+				{
+					elements: sourceId,
+					operators: 'operator-from-the-future',
+					element_values: 'anything',
+				},
+			],
+		} );
+
+		const output = page.getByLabel( 'Output' );
+		const source = page.locator(
+			`input[name="ppom[fields][${ sourceId }]"]`
+		);
+
+		await expect( output ).toBeHidden();
+
+		await source.fill( 'anything' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeHidden();
+	} );
+} );

--- a/tests/e2e/specs/legacy-conditions.spec.js
+++ b/tests/e2e/specs/legacy-conditions.spec.js
@@ -192,17 +192,21 @@ test.describe( 'Legacy conditions script', () => {
 		await page.goto( `/?p=${ product.id }` );
 
 		const output = page.getByLabel( 'Output' );
+		const hiddenFields = page.locator( '#conditionally_hidden' );
 		await expect( output ).toBeHidden();
+		await expect( hiddenFields ).toHaveValue( outputId );
 
 		const controllingSelect = selectByName( page, controllingId );
 		await controllingSelect.selectOption( { label: optionTwo.label } );
 		await expect( controllingSelect ).toHaveValue( optionTwo.label );
 
 		await expect( output ).toBeVisible();
+		await expect( hiddenFields ).toHaveValue( '' );
 
 		// Reverting the controller must put the target back out of view.
 		await controllingSelect.selectOption( { label: optionOne.label } );
 		await expect( output ).toBeHidden();
+		await expect( hiddenFields ).toHaveValue( outputId );
 	} );
 
 	test( 'legacy: Hide + is removes and restores the target as the controlling Select changes', async ( {
@@ -432,5 +436,231 @@ test.describe( 'Legacy conditions script', () => {
 		await source.fill( 'anything' );
 		await source.dispatchEvent( 'change' );
 		await expect( output ).toBeHidden();
+	} );
+	test( 'legacy: PRO-only contains operator stays inert without a Pro license', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const token = uniqueToken();
+		const sourceId = `legacy_contains_free_${ token }`;
+
+		await openConditionalProduct( {
+			page,
+			requestUtils,
+			groupName: `LC Contains Free ${ token }`,
+			targetDataName: `legacy_contains_free_out_${ token }`,
+			sourceFields: [
+				buildTextField( {
+					title: `Message ${ token }`,
+					dataName: sourceId,
+				} ),
+			],
+			rules: [
+				{
+					elements: sourceId,
+					operators: 'contains',
+					element_values: '',
+					element_constant: 'urgent',
+				},
+			],
+		} );
+
+		const output = page.getByLabel( 'Output' );
+		const source = page.locator(
+			`input[name="ppom[fields][${ sourceId }]"]`
+		);
+
+		await expect( output ).toBeHidden();
+
+		await source.fill( 'this is urgent' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeHidden();
+	} );
+
+	test( 'legacy: PRO-only odd-number operator stays inert without a Pro license', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const token = uniqueToken();
+		const sourceId = `legacy_odd_free_${ token }`;
+
+		await openConditionalProduct( {
+			page,
+			requestUtils,
+			groupName: `LC Odd Free ${ token }`,
+			targetDataName: `legacy_odd_free_out_${ token }`,
+			sourceFields: [
+				buildNumberField( {
+					title: `Copies ${ token }`,
+					dataName: sourceId,
+				} ),
+			],
+			rules: [
+				{
+					elements: sourceId,
+					operators: 'odd-number',
+					element_values: '',
+				},
+			],
+		} );
+
+		const output = page.getByLabel( 'Output' );
+		const source = page.locator(
+			`input[name="ppom[fields][${ sourceId }]"]`
+		);
+
+		await expect( output ).toBeHidden();
+
+		// This operator carries no rule payload, so only the server-side Pro
+		// flag can keep it from running on a free install.
+		await source.fill( '7' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeHidden();
+	} );
+
+	test( 'legacy: PRO odd-number operator evaluates with Pro installed and licensed', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		await setPpomLicenseFixture( requestUtils, {
+			valid: true,
+			plan: 3,
+			proInstalled: true,
+		} );
+
+		const token = uniqueToken();
+		const sourceId = `legacy_odd_pro_${ token }`;
+
+		await openConditionalProduct( {
+			page,
+			requestUtils,
+			groupName: `LC Odd Pro ${ token }`,
+			targetDataName: `legacy_odd_pro_out_${ token }`,
+			sourceFields: [
+				buildNumberField( {
+					title: `Copies ${ token }`,
+					dataName: sourceId,
+				} ),
+			],
+			rules: [
+				{
+					elements: sourceId,
+					operators: 'odd-number',
+					element_values: '',
+				},
+			],
+		} );
+
+		const output = page.getByLabel( 'Output' );
+		const source = page.locator(
+			`input[name="ppom[fields][${ sourceId }]"]`
+		);
+
+		await expect( output ).toBeHidden();
+
+		await source.fill( '7' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeVisible();
+
+		await source.fill( '8' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeHidden();
+	} );
+
+	test( 'legacy: a bare RegEx pattern keeps its slash instead of being read as delimiters', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		await setPpomLicenseFixture( requestUtils, {
+			valid: true,
+			plan: 3,
+			proInstalled: true,
+		} );
+
+		const token = uniqueToken();
+		const sourceId = `legacy_regex_bare_${ token }`;
+
+		await openConditionalProduct( {
+			page,
+			requestUtils,
+			groupName: `LC Regex Bare ${ token }`,
+			targetDataName: `legacy_regex_bare_out_${ token }`,
+			sourceFields: [
+				buildTextField( {
+					title: `Path ${ token }`,
+					dataName: sourceId,
+				} ),
+			],
+			rules: [
+				{
+					elements: sourceId,
+					operators: 'regex',
+					element_values: '',
+					element_constant: 'foo/bar',
+				},
+			],
+		} );
+
+		const output = page.getByLabel( 'Output' );
+		const source = page.locator(
+			`input[name="ppom[fields][${ sourceId }]"]`
+		);
+
+		// `bar` alone must not match: the pattern is `foo/bar`, not `/bar/`.
+		await source.fill( 'bar' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeHidden();
+
+		await source.fill( 'foo/bar' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeVisible();
+	} );
+
+	test( 'legacy: a slash-delimited RegEx pattern still applies its flags', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		await setPpomLicenseFixture( requestUtils, {
+			valid: true,
+			plan: 3,
+			proInstalled: true,
+		} );
+
+		const token = uniqueToken();
+		const sourceId = `legacy_regex_flags_${ token }`;
+
+		await openConditionalProduct( {
+			page,
+			requestUtils,
+			groupName: `LC Regex Flags ${ token }`,
+			targetDataName: `legacy_regex_flags_out_${ token }`,
+			sourceFields: [
+				buildTextField( {
+					title: `Code ${ token }`,
+					dataName: sourceId,
+				} ),
+			],
+			rules: [
+				{
+					elements: sourceId,
+					operators: 'regex',
+					element_values: '',
+					element_constant: '/^abc$/i',
+				},
+			],
+		} );
+
+		const output = page.getByLabel( 'Output' );
+		const source = page.locator(
+			`input[name="ppom[fields][${ sourceId }]"]`
+		);
+
+		await source.fill( 'xabc' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeHidden();
+
+		await source.fill( 'ABC' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeVisible();
 	} );
 } );

--- a/tests/e2e/specs/legacy-conditions.spec.js
+++ b/tests/e2e/specs/legacy-conditions.spec.js
@@ -265,7 +265,7 @@ test.describe( 'Legacy conditions script', () => {
 		await controllingSelect.selectOption( { label: noOpt.label } );
 		await expect( output ).toBeVisible();
 	} );
-	test( 'legacy: has any value / is empty operators evaluate instead of being ignored', async ( {
+	test( 'legacy: has any value operator evaluates instead of being ignored', async ( {
 		page,
 		requestUtils,
 	} ) => {
@@ -306,6 +306,50 @@ test.describe( 'Legacy conditions script', () => {
 		await source.fill( '' );
 		await source.dispatchEvent( 'change' );
 		await expect( output ).toBeHidden();
+	} );
+
+	test( 'legacy: is empty operator evaluates instead of being ignored', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const token = uniqueToken();
+		const sourceId = `legacy_empty_src_${ token }`;
+
+		await openConditionalProduct( {
+			page,
+			requestUtils,
+			groupName: `LC Empty ${ token }`,
+			targetDataName: `legacy_empty_out_${ token }`,
+			sourceFields: [
+				buildTextField( {
+					title: `Engraving ${ token }`,
+					dataName: sourceId,
+				} ),
+			],
+			rules: [
+				{
+					elements: sourceId,
+					operators: 'empty',
+					element_values: '',
+				},
+			],
+		} );
+
+		const output = page.getByLabel( 'Output' );
+		const source = page.locator(
+			`input[name="ppom[fields][${ sourceId }]"]`
+		);
+
+		// An untouched source is empty, so the target starts out revealed.
+		await expect( output ).toBeVisible();
+
+		await source.fill( 'Happy birthday' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeHidden();
+
+		await source.fill( '' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeVisible();
 	} );
 
 	test( 'legacy: greater than compares the real value of a Number source', async ( {
@@ -661,6 +705,168 @@ test.describe( 'Legacy conditions script', () => {
 
 		await source.fill( 'ABC' );
 		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeVisible();
+	} );
+
+	test( 'legacy: typing keeps its own value in a revealed conditional field', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const token = uniqueToken();
+		const sourceId = `legacy_keep_src_${ token }`;
+		const targetId = `legacy_keep_out_${ token }`;
+
+		await openConditionalProduct( {
+			page,
+			requestUtils,
+			groupName: `LC Keep ${ token }`,
+			targetDataName: targetId,
+			sourceFields: [
+				buildTextField( {
+					title: `Engraving ${ token }`,
+					dataName: sourceId,
+				} ),
+			],
+			rules: [
+				{
+					elements: sourceId,
+					operators: 'any',
+					element_values: '',
+				},
+			],
+		} );
+
+		const output = page.getByLabel( 'Output' );
+		const source = page.locator(
+			`input[name="ppom[fields][${ sourceId }]"]`
+		);
+
+		await source.pressSequentially( 'Ana' );
+		await expect( output ).toBeVisible();
+
+		await output.pressSequentially( 'Keep me' );
+		await expect( output ).toHaveValue( 'Keep me' );
+
+		// Recalculation runs on every keystroke; the revealed target must not be
+		// reset by the lifecycle events those recalculations would emit.
+		await source.press( 'End' );
+		await source.pressSequentially( 'stasia' );
+		await expect( output ).toHaveValue( 'Keep me' );
+		await expect( source ).toHaveValue( 'Anastasia' );
+	} );
+
+	test( 'legacy: lifecycle events fire only when visibility actually flips', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const token = uniqueToken();
+		const sourceId = `legacy_events_src_${ token }`;
+
+		await openConditionalProduct( {
+			page,
+			requestUtils,
+			groupName: `LC Events ${ token }`,
+			targetDataName: `legacy_events_out_${ token }`,
+			sourceFields: [
+				buildTextField( {
+					title: `Engraving ${ token }`,
+					dataName: sourceId,
+				} ),
+			],
+			rules: [
+				{
+					elements: sourceId,
+					operators: 'any',
+					element_values: '',
+				},
+			],
+		} );
+
+		const output = page.getByLabel( 'Output' );
+		const source = page.locator(
+			`input[name="ppom[fields][${ sourceId }]"]`
+		);
+
+		await page.evaluate( () => {
+			window.ppomLifecycleEvents = [];
+			window.jQuery( document ).on(
+				'ppom_field_shown ppom_field_hidden',
+				( event ) => window.ppomLifecycleEvents.push( event.type )
+			);
+		} );
+
+		await source.pressSequentially( 'A' );
+		await expect( output ).toBeVisible();
+		expect(
+			await page.evaluate( () => window.ppomLifecycleEvents )
+		).toEqual( [ 'ppom_field_shown' ] );
+
+		// Six more keystrokes, same visibility: no further events.
+		await source.pressSequentially( 'nastas' );
+		expect(
+			await page.evaluate( () => window.ppomLifecycleEvents )
+		).toEqual( [ 'ppom_field_shown' ] );
+
+		await source.fill( '' );
+		await source.dispatchEvent( 'change' );
+		await expect( output ).toBeHidden();
+		expect(
+			await page.evaluate( () => window.ppomLifecycleEvents )
+		).toEqual( [ 'ppom_field_shown', 'ppom_field_hidden' ] );
+	} );
+
+	test( 'legacy: not-contains requires every selected value to satisfy the rule', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		await setPpomLicenseFixture( requestUtils, {
+			valid: true,
+			plan: 3,
+			proInstalled: true,
+		} );
+
+		const token = uniqueToken();
+		const sourceId = `legacy_ncontains_${ token }`;
+
+		await openConditionalProduct( {
+			page,
+			requestUtils,
+			groupName: `LC Not Contains ${ token }`,
+			targetDataName: `legacy_ncontains_out_${ token }`,
+			sourceFields: [
+				buildCheckboxField( {
+					title: `Extras ${ token }`,
+					dataName: sourceId,
+					options: [
+						{ label: 'foo', value: 'foo' },
+						{ label: 'bar', value: 'bar' },
+					],
+				} ),
+			],
+			rules: [
+				{
+					elements: sourceId,
+					operators: 'not-contains',
+					element_values: '',
+					element_constant: 'foo',
+				},
+			],
+		} );
+
+		const output = page.getByLabel( 'Output' );
+		const boxes = page.locator(
+			`input[name="ppom[fields][${ sourceId }][]"]`
+		);
+
+		await boxes.nth( 1 ).check();
+		await expect( output ).toBeVisible();
+
+		// `foo` is now part of the selection, so "does not contain foo" is false
+		// even though `bar` on its own would satisfy it.
+		await boxes.nth( 0 ).check();
+		await expect( output ).toBeHidden();
+
+		await boxes.nth( 0 ).uncheck();
 		await expect( output ).toBeVisible();
 	} );
 } );

--- a/tests/e2e/specs/legacy-conditions.spec.js
+++ b/tests/e2e/specs/legacy-conditions.spec.js
@@ -789,10 +789,11 @@ test.describe( 'Legacy conditions script', () => {
 
 		await page.evaluate( () => {
 			window.ppomLifecycleEvents = [];
-			window.jQuery( document ).on(
-				'ppom_field_shown ppom_field_hidden',
-				( event ) => window.ppomLifecycleEvents.push( event.type )
-			);
+			window
+				.jQuery( document )
+				.on( 'ppom_field_shown ppom_field_hidden', ( event ) =>
+					window.ppomLifecycleEvents.push( event.type )
+				);
 		} );
 
 		await source.pressSequentially( 'A' );


### PR DESCRIPTION
### Summary
Refactor the legacy conditional logic to ensure hidden fields are tracked and expand the support for additional input types and conditional operators.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/707