### PR TITLE
Preserved min date with disable past dates

### DIFF
--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -112,6 +112,45 @@ jQuery( function ( $ ) {
 } );
 
 /**
+ * Whether the datepicker's current minDate resolves to a date before today.
+ *
+ * @param {Object} input_selector jQuery object wrapping the datepicker input.
+ * @return {boolean} True when there is no minDate or it resolves to a past date.
+ */
+function ppom_datepicker_min_date_is_past( input_selector ) {
+	const picker = jQuery.datepicker;
+
+	if (
+		! picker ||
+		typeof picker._getInst !== 'function' ||
+		typeof picker._getMinMaxDate !== 'function'
+	) {
+		return true;
+	}
+
+	let min_date = null;
+
+	try {
+		min_date = picker._getMinMaxDate(
+			picker._getInst( input_selector.get( 0 ) ),
+			'min'
+		);
+	} catch ( e ) {
+		return true;
+	}
+
+	if ( ! min_date ) {
+		return true;
+	}
+
+	const today = new Date();
+	today.setHours( 0, 0, 0, 0 );
+	min_date.setHours( 0, 0, 0, 0 );
+
+	return min_date < today;
+}
+
+/**
  * Hydrate each localized field definition with the JS behavior its type needs.
  *
  * @param {PPOMLocalizedFieldMeta[]} ppom_fields
@@ -211,10 +250,13 @@ function ppom_init_js_for_ppom_fields( ppom_fields ) {
 						);
 					}
 
-					if ( typeof input.past_dates !== 'undefined' ) {
-						if ( input.past_dates === 'on' ) {
-							InputSelector.datepicker( 'option', 'minDate', 0 );
-						}
+					if (
+						typeof input.past_dates !== 'undefined' &&
+						input.past_dates === 'on' &&
+						ppom_datepicker_min_date_is_past( InputSelector )
+					) {
+						// Only clamp to today when min_date is unset or already in the past.
+						InputSelector.datepicker( 'option', 'minDate', 0 );
 					}
 
 					if ( typeof input.max_date !== 'undefined' ) {

--- a/tests/e2e/fixtures/fields.js
+++ b/tests/e2e/fixtures/fields.js
@@ -121,6 +121,30 @@ function buildHtmlField( { html = '', ...args } ) {
 	} );
 }
 
+function buildDateField( {
+	jqueryDp = 'on',
+	dateFormats = 'mm/dd/yy',
+	yearRange = 'c-10:c+10',
+	minDate = '',
+	maxDate = '',
+	pastDates = '',
+	noWeekends = '',
+	firstDayOfWeek = '0',
+	...args
+} ) {
+	return buildField( 'date', {
+		...args,
+		jquery_dp: jqueryDp,
+		date_formats: dateFormats,
+		year_range: yearRange,
+		min_date: minDate,
+		max_date: maxDate,
+		past_dates: pastDates,
+		no_weekends: noWeekends,
+		first_day_of_week: firstDayOfWeek,
+	} );
+}
+
 function buildTextCounterField( {
 	countType = 'character',
 	maxlength = '50',
@@ -147,6 +171,7 @@ function buildTextCounterField( {
 
 export {
 	buildCheckboxField,
+	buildDateField,
 	buildImageField,
 	buildPalettesField,
 	buildPriceMatrixField,

--- a/tests/e2e/fixtures/index.js
+++ b/tests/e2e/fixtures/index.js
@@ -12,6 +12,7 @@ export {
 } from './ppom.js';
 export {
 	buildCheckboxField,
+	buildDateField,
 	buildFileField,
 	buildHtmlField,
 	buildPriceMatrixField,

--- a/tests/e2e/specs/date-picker.spec.js
+++ b/tests/e2e/specs/date-picker.spec.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+import {
+	attachPpomGroupToProducts,
+	buildDateField,
+	createPpomGroup,
+	createSimpleProduct,
+} from '../fixtures/index.js';
+
+test.describe( 'Date field min date', () => {
+	/**
+	 * "Disable past dates" must not relax a future min date lead time.
+	 */
+	test( 'keeps the min date lead time when past dates are disabled', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const fieldId = 'delivery_date';
+
+		const product = await createSimpleProduct( requestUtils );
+		const { ppomId } = await createPpomGroup( requestUtils, {
+			groupName: 'Date Min Date Test',
+			fields: [
+				buildDateField( {
+					title: 'Delivery date',
+					dataName: fieldId,
+					minDate: '+2d',
+					pastDates: 'on',
+				} ),
+			],
+		} );
+
+		await attachPpomGroupToProducts( requestUtils, {
+			ppomId,
+			productIds: [ product.id ],
+		} );
+
+		// Freeze "today" so the rendered month and the lead time are deterministic.
+		await page.clock.setFixedTime( new Date( '2026-06-10T12:00:00' ) );
+
+		await page.goto( `/?p=${ product.id }` );
+
+		const dateInput = page.locator(
+			`input[name="ppom[fields][${ fieldId }]"]`
+		);
+		await expect( dateInput ).toBeVisible();
+
+		await dateInput.click();
+
+		const calendar = page.locator( '#ui-datepicker-div' );
+		await expect( calendar ).toBeVisible();
+		// changeMonth/changeYear render the header as selects.
+		await expect( calendar.locator( 'select.ui-datepicker-month' ) ).toHaveValue( '5' );
+		await expect( calendar.locator( 'select.ui-datepicker-year' ) ).toHaveValue( '2026' );
+
+		const dayCell = ( day ) =>
+			calendar.locator( 'td:not(.ui-datepicker-other-month)', {
+				hasText: new RegExp( `^${ day }$` ),
+			} );
+
+		// Today and today + 1 are before the +2d lead time.
+		await expect( dayCell( 10 ) ).toHaveClass( /ui-state-disabled/ );
+		await expect( dayCell( 11 ) ).toHaveClass( /ui-state-disabled/ );
+
+		// Today + 2 is the first selectable date.
+		await expect( dayCell( 12 ) ).not.toHaveClass( /ui-state-disabled/ );
+
+		await dayCell( 12 ).locator( 'a' ).click();
+
+		await expect( dateInput ).toHaveValue( '06/12/2026' );
+	} );
+} );


### PR DESCRIPTION
### Summary
Preserved the Min date when Disable Past Dates is enabled and the Min date is set to a future date.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/717