### PR TITLE
Corrected cart item subtotal values

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6643,12 +6643,6 @@ parameters:
 			path: src/Validation/Validator.php
 
 		-
-			message: '#^Binary operation "\+" between float and ''''\|''0''\|array\{\}\|float\|false results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/WooCommerce/Cart/CartHandler.php
-
-		-
 			message: '#^Binary operation "\+\=" between 0 and float\|int\|string results in an error\.$#'
 			identifier: assignOp.invalid
 			count: 1

--- a/src/WooCommerce/Cart/CartHandler.php
+++ b/src/WooCommerce/Cart/CartHandler.php
@@ -853,6 +853,14 @@ final class CartHandler {
 		}
 
 		if ( isset( $option['option_id'] ) ) {
+			$key = sanitize_key( (string) $option['data_name'] ) . '|' . (string) $option['option_id'];
+
+			if ( isset( $counted_fields[ $key ] ) ) {
+				return 0.0;
+			}
+
+			$counted_fields[ $key ] = true;
+
 			return self::resolved_onetime_option_price( $option, $product, $attached_ids, $selected_fields );
 		}
 
@@ -1227,6 +1235,7 @@ final class CartHandler {
 		// The selected variation prices the line, and its pristine copy resolves addons.
 		$pristine        = wc_get_product( $variation_id ? $variation_id : $product_id );
 		$line_product    = $pristine instanceof \WC_Product ? $pristine : new \WC_Product( $product_id );
+		$base_product    = isset( $cart_item['data'] ) && $cart_item['data'] instanceof \WC_Product ? $cart_item['data'] : $line_product;
 		$ppom_meta_ids   = isset( $cart_item['ppom']['fields']['id'] ) ? $cart_item['ppom']['fields']['id'] : '';
 		$selected_fields = isset( $cart_item['ppom']['fields'] ) && is_array( $cart_item['ppom']['fields'] ) ? $cart_item['ppom']['fields'] : array();
 		$attached_ids    = null;
@@ -1288,7 +1297,7 @@ final class CartHandler {
 		if ( 0.0 === $price ) {
 			return $item_subtotal;
 		}
-		$product_price = floatval( $line_product->get_price() ) * $quantity;
+		$product_price = floatval( $base_product->get_price() ) * $quantity;
 		$item_subtotal = $product_price + $price;
 		return Helpers::price( $item_subtotal );
 	}

--- a/src/WooCommerce/Cart/CartHandler.php
+++ b/src/WooCommerce/Cart/CartHandler.php
@@ -788,25 +788,41 @@ final class CartHandler {
 			return $item_subtotal;
 		}
 
+		$product_id   = $cart_item['product_id'];
+		$quantity     = $cart_item['quantity'];
+		$product_data = new \WC_Product( $product_id );
+
+		// Resolve amounts against saved field meta, like the authoritative pricing path.
+		$line_product  = isset( $cart_item['data'] ) && $cart_item['data'] instanceof \WC_Product ? $cart_item['data'] : $product_data;
+		$ppom_meta_ids = isset( $cart_item['ppom']['fields']['id'] ) ? $cart_item['ppom']['fields']['id'] : '';
+
 		$price = 0.0;
 		foreach ( $option_prices as $option ) {
+			if ( ! is_array( $option ) ) {
+				continue;
+			}
+
 			$option       = Helpers::translation_options( $option );
 			$option_price = isset( $option['price'] ) ? (float) $option['price'] : 0.0;
 			if ( 0.0 === $option_price || ( ! isset( $option['apply'] ) || 'onetime' !== $option['apply'] ) ) {
 				continue;
 			}
-			$option_price = isset( $option['discount'] ) && $option['discount'] > 0 ? (float) $option['discount'] : $option_price;
+
+			if ( ! empty( $ppom_meta_ids ) && isset( $option['data_name'], $option['option_id'] ) ) {
+				$option_price = (float) Helpers::get_field_option_price_by_id( $option, $line_product, $ppom_meta_ids );
+			} elseif ( isset( $option['discount'] ) && $option['discount'] > 0 ) {
+				$option_price = (float) $option['discount'];
+			}
+
 			$option_price = apply_filters( 'ppom_option_price', $option_price );
 
+			// Accumulate every fixed-fee option on the line, not just the last one.
 			$price += floatval( wp_strip_all_tags( (string) $option_price ) );
 		}
 
 		if ( 0.0 === $price ) {
 			return $item_subtotal;
 		}
-		$product_id    = $cart_item['product_id'];
-		$quantity      = $cart_item['quantity'];
-		$product_data  = new \WC_Product( $product_id );
 		$product_price = floatval( $product_data->get_price() ) * $quantity;
 		$item_subtotal = $product_price + $price;
 		return Helpers::price( $item_subtotal );

--- a/src/WooCommerce/Cart/CartHandler.php
+++ b/src/WooCommerce/Cart/CartHandler.php
@@ -788,21 +788,20 @@ final class CartHandler {
 			return $item_subtotal;
 		}
 
-		$price = 0;
+		$price = 0.0;
 		foreach ( $option_prices as $option ) {
 			$option       = Helpers::translation_options( $option );
-			$option_price = isset( $option['price'] ) ? $option['price'] : 0;
-			if ( 0 === $option_price || ( ! isset( $option['apply'] ) || 'onetime' !== $option['apply'] ) ) {
+			$option_price = isset( $option['price'] ) ? (float) $option['price'] : 0.0;
+			if ( 0.0 === $option_price || ( ! isset( $option['apply'] ) || 'onetime' !== $option['apply'] ) ) {
 				continue;
 			}
-			$price = isset( $option['discount'] ) && $option['discount'] > 0 ? $option['discount'] : $option_price;
-			if ( ! empty( $price ) ) {
-				$price = apply_filters( 'ppom_option_price', $price );
-				$price = floatval( wp_strip_all_tags( $price ) );
-			}
+			$option_price = isset( $option['discount'] ) && $option['discount'] > 0 ? (float) $option['discount'] : $option_price;
+			$option_price = apply_filters( 'ppom_option_price', $option_price );
+
+			$price += floatval( wp_strip_all_tags( (string) $option_price ) );
 		}
 
-		if ( 0 === $price ) {
+		if ( 0.0 === $price ) {
 			return $item_subtotal;
 		}
 		$product_id    = $cart_item['product_id'];

--- a/src/WooCommerce/Cart/CartHandler.php
+++ b/src/WooCommerce/Cart/CartHandler.php
@@ -584,7 +584,16 @@ final class CartHandler {
 						$resolved = self::canonical_onetime_price( $fee, $pristine, $attached_ids, $selected_fields, $counted_fields );
 					}
 
-					$fee_price = null !== $resolved ? $resolved : (float) $fee_price;
+					if ( null !== $resolved ) {
+						$fee_price        = apply_filters( 'ppom_option_price', $resolved );
+						$resolved_taxable = self::resolved_onetime_taxable( $fee, $attached_ids );
+
+						if ( null !== $resolved_taxable ) {
+							$taxable = $resolved_taxable;
+						}
+					} else {
+						$fee_price = self::unresolved_payload_amount( $fee_price );
+					}
 
 					// if(  'incl' === get_option( 'woocommerce_tax_display_shop' ) ) {
 					// $taxable = false;
@@ -792,6 +801,41 @@ final class CartHandler {
 	}
 
 	/**
+	 * Amount to use for a row that cannot be resolved from saved meta.
+	 *
+	 * @param mixed $amount Amount carried by the payload row.
+	 *
+	 * @return float
+	 */
+	private static function unresolved_payload_amount( $amount ) {
+		$amount = is_scalar( $amount ) ? (float) $amount : 0.0;
+
+		return $amount < 0 ? 0.0 : $amount;
+	}
+
+	/**
+	 * Whether a resolved fixed fee is taxable according to its saved field.
+	 *
+	 * @param array<string, mixed> $option       Single decoded option row.
+	 * @param int[]                $attached_ids Group ids confirmed attached to the product.
+	 *
+	 * @return bool|null Null when the field cannot be resolved.
+	 */
+	private static function resolved_onetime_taxable( array $option, array $attached_ids ) {
+		if ( empty( $attached_ids ) || ! isset( $option['data_name'] ) ) {
+			return null;
+		}
+
+		$field_meta = Helpers::get_field_meta_by_dataname( 0, sanitize_key( (string) $option['data_name'] ), implode( ',', $attached_ids ) );
+
+		if ( empty( $field_meta ) || ! is_array( $field_meta ) ) {
+			return null;
+		}
+
+		return isset( $field_meta['onetime_taxable'] ) && 'on' === $field_meta['onetime_taxable'];
+	}
+
+	/**
 	 * Canonical fixed-fee amount for one `ppom_option_price` row, or null when the row
 	 * cannot be resolved from saved meta at all.
 	 *
@@ -995,7 +1039,8 @@ final class CartHandler {
 		$amount = (string) $amount;
 
 		if ( false !== strpos( $amount, '%' ) ) {
-			$amount = Engine::get_amount_after_percentage( Helpers::get_product_price( $product, null, 'cart' ), $amount );
+			$base   = Callbacks::convert_price_back( Helpers::get_product_price( $product, null, 'cart' ) );
+			$amount = Engine::get_amount_after_percentage( $base, $amount );
 		}
 
 		return (float) $amount;
@@ -1218,6 +1263,8 @@ final class CartHandler {
 				if ( isset( $option['discount'] ) && $option['discount'] > 0 ) {
 					$option_price = (float) $option['discount'];
 				}
+
+				$option_price = self::unresolved_payload_amount( $option_price );
 			}
 
 			$option_price = apply_filters( 'ppom_option_price', $option_price );

--- a/src/WooCommerce/Cart/CartHandler.php
+++ b/src/WooCommerce/Cart/CartHandler.php
@@ -830,7 +830,7 @@ final class CartHandler {
 		$discount = self::saved_option_discount( $field_meta, $option['option_id'] );
 		if ( null !== $discount ) {
 			return false !== strpos( $discount, '%' )
-				? (float) Engine::get_amount_after_percentage( $product->get_price(), $discount )
+				? (float) Engine::get_amount_after_percentage( Helpers::get_product_price( $product, null, 'cart' ), $discount )
 				: (float) $discount;
 		}
 
@@ -873,7 +873,98 @@ final class CartHandler {
 	}
 
 	/**
+	 * Server-resolved fixed-fee total for a row that carries no option id.
+	 *
+	 * @param string               $data_name       Field data name carried by the row.
+	 * @param \WC_Product          $product         Pristine product of the cart line.
+	 * @param int[]                $attached_ids    Group ids confirmed attached to the product.
+	 * @param array<string, mixed> $selected_fields Field values submitted for the line.
+	 * @param array<string, bool>  $counted_fields  Fields already totalled for this line.
+	 *
+	 * @return float|null Canonical total, or null when the field prices outside its option list.
+	 */
+	private static function resolved_onetime_field_total( $data_name, $product, array $attached_ids, array $selected_fields, array &$counted_fields ) {
+		if ( empty( $attached_ids ) ) {
+			return 0.0;
+		}
+
+		$field_meta = Helpers::get_field_meta_by_dataname( 0, sanitize_key( (string) $data_name ), implode( ',', $attached_ids ) );
+
+		if ( empty( $field_meta ) || ! is_array( $field_meta ) ) {
+			return 0.0;
+		}
+
+		if ( ! isset( $field_meta['onetime'] ) || 'on' !== $field_meta['onetime'] ) {
+			return 0.0;
+		}
+
+		$saved_rows = self::saved_option_rows( $field_meta );
+
+		if ( empty( $saved_rows ) ) {
+			return null;
+		}
+
+		$key = isset( $field_meta['data_name'] ) ? (string) $field_meta['data_name'] : (string) $data_name;
+
+		if ( isset( $counted_fields[ $key ] ) ) {
+			return 0.0;
+		}
+
+		$counted_fields[ $key ] = true;
+
+		if ( ! isset( $selected_fields[ $key ] ) ) {
+			return 0.0;
+		}
+
+		$submitted = self::submitted_option_tokens( $selected_fields[ $key ] );
+
+		if ( empty( $submitted ) ) {
+			return 0.0;
+		}
+
+		$total = 0.0;
+
+		foreach ( $saved_rows as $saved_option ) {
+			if ( self::saved_option_matches_submission( $saved_option, $submitted ) ) {
+				$total += self::saved_option_amount( $field_meta, $saved_option, $product );
+			}
+		}
+
+		return $total;
+	}
+
+	/**
+	 * Canonical amount of one saved option, discount first as the pricing engine does.
+	 *
+	 * @param array<string, mixed> $field_meta   Saved field definition.
+	 * @param array<string, mixed> $saved_option Saved option row.
+	 * @param \WC_Product          $product      Pristine product of the cart line.
+	 *
+	 * @return float
+	 */
+	private static function saved_option_amount( array $field_meta, array $saved_option, $product ) {
+		$amount = '';
+
+		if ( isset( $saved_option['discount'] ) && is_scalar( $saved_option['discount'] ) && (float) $saved_option['discount'] > 0 ) {
+			$amount = (string) $saved_option['discount'];
+		} elseif ( isset( $saved_option['price'] ) && is_scalar( $saved_option['price'] ) ) {
+			$amount = (string) $saved_option['price'];
+		}
+
+		if ( '' === $amount ) {
+			return 0.0;
+		}
+
+		return false !== strpos( $amount, '%' )
+			? (float) Engine::get_amount_after_percentage( Helpers::get_product_price( $product, null, 'cart' ), $amount )
+			: (float) $amount;
+	}
+
+	/**
 	 * Whether an option id belongs to the values submitted for its field.
+	 *
+	 * Cart payloads are untrusted, so rows are only honoured when the submitted values still
+	 * evidence the option selection.
 	 *
 	 * @param array<string, mixed> $field_meta      Saved field definition.
 	 * @param string               $option_id       Option id carried by the cart row.
@@ -882,38 +973,133 @@ final class CartHandler {
 	 * @return bool
 	 */
 	private static function option_is_selected( array $field_meta, $option_id, array $selected_fields ) {
-		$data_name  = isset( $field_meta['data_name'] ) ? $field_meta['data_name'] : '';
-		$field_type = isset( $field_meta['type'] ) ? $field_meta['type'] : '';
+		$data_name = isset( $field_meta['data_name'] ) ? (string) $field_meta['data_name'] : '';
 
 		if ( '' === $data_name || ! isset( $selected_fields[ $data_name ] ) ) {
-			return true;
+			return false;
 		}
 
-		if ( 'image' === $field_type || empty( $field_meta['options'] ) || ! is_array( $field_meta['options'] ) ) {
-			return true;
+		$submitted = self::submitted_option_tokens( $selected_fields[ $data_name ] );
+
+		if ( empty( $submitted ) ) {
+			return false;
 		}
 
-		$selected = array_map( 'strval', array_filter( (array) $selected_fields[ $data_name ], 'is_scalar' ) );
-		$ids      = array();
+		$option_id  = (string) $option_id;
+		$candidates = array();
 
-		foreach ( $field_meta['options'] as $saved_option ) {
-			if ( ! is_array( $saved_option ) ) {
+		foreach ( $submitted as $token ) {
+			$candidates[] = $token;
+			$candidates[] = sanitize_key( $data_name . '_' . $token );
+			$candidates[] = $data_name . '-' . $token;
+		}
+
+		foreach ( self::saved_option_rows( $field_meta ) as $saved_option ) {
+			if ( ! self::saved_option_matches_submission( $saved_option, $submitted ) ) {
 				continue;
 			}
 
-			$label = isset( $saved_option['option'] ) ? $saved_option['option'] : '';
-			if ( ! is_scalar( $label ) || ! in_array( (string) $label, $selected, true ) ) {
+			$candidates[] = (string) Helpers::get_option_id( $saved_option, $field_meta );
+
+			if ( isset( $saved_option['id'] ) && is_scalar( $saved_option['id'] ) ) {
+				$candidates[] = (string) $saved_option['id'];
+				$candidates[] = $data_name . '-' . $saved_option['id'];
+			}
+		}
+
+		return in_array( $option_id, $candidates, true );
+	}
+
+	/**
+	 * Flattens a submitted field value into comparable option tokens.
+	 *
+	 * @param mixed $value Submitted value for one field.
+	 *
+	 * @return string[]
+	 */
+	private static function submitted_option_tokens( $value ) {
+		$tokens = array();
+
+		foreach ( (array) $value as $entry ) {
+			if ( is_array( $entry ) ) {
+				$tokens = array_merge( $tokens, self::submitted_option_tokens( $entry ) );
 				continue;
 			}
 
-			$ids[] = (string) Helpers::get_option_id( $saved_option, $field_meta );
+			if ( ! is_scalar( $entry ) ) {
+				continue;
+			}
+
+			$entry    = (string) $entry;
+			$tokens[] = $entry;
+
+			$decoded = json_decode( stripslashes( $entry ), true );
+			if ( ! is_array( $decoded ) ) {
+				continue;
+			}
+
+			foreach ( array( 'option_id', 'image_id', 'id' ) as $key ) {
+				if ( isset( $decoded[ $key ] ) && is_scalar( $decoded[ $key ] ) ) {
+					$tokens[] = (string) $decoded[ $key ];
+				}
+			}
 		}
 
-		if ( empty( $ids ) ) {
-			return true;
+		return array_values( array_unique( $tokens ) );
+	}
+
+	/**
+	 * Saved option rows of a field, whichever key its type keeps them under.
+	 *
+	 * @param array<string, mixed> $field_meta Saved field definition.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function saved_option_rows( array $field_meta ) {
+		$rows = array();
+
+		foreach ( array( 'options', 'images', 'audio' ) as $key ) {
+			if ( empty( $field_meta[ $key ] ) || ! is_array( $field_meta[ $key ] ) ) {
+				continue;
+			}
+
+			foreach ( $field_meta[ $key ] as $row ) {
+				if ( is_array( $row ) ) {
+					$rows[] = $row;
+				}
+			}
 		}
 
-		return in_array( (string) $option_id, $ids, true );
+		return $rows;
+	}
+
+	/**
+	 * Whether a saved option row is named by the submitted tokens.
+	 *
+	 * @param array<string, mixed> $saved_option Saved option row.
+	 * @param string[]             $submitted    Tokens submitted for the field.
+	 *
+	 * @return bool
+	 */
+	private static function saved_option_matches_submission( array $saved_option, array $submitted ) {
+		foreach ( array( 'option', 'title' ) as $key ) {
+			if ( ! isset( $saved_option[ $key ] ) || ! is_scalar( $saved_option[ $key ] ) ) {
+				continue;
+			}
+
+			$label = (string) $saved_option[ $key ];
+
+			if ( in_array( $label, $submitted, true ) ) {
+				return true;
+			}
+
+			$translated = Helpers::wpml_translate( $label, 'PPOM' );
+			if ( is_scalar( $translated ) && in_array( (string) $translated, $submitted, true ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	// Control subtotal when quantities input used.
@@ -935,10 +1121,13 @@ final class CartHandler {
 		$product_data = new \WC_Product( $product_id );
 
 		// Resolve amounts against saved field meta, like the authoritative pricing path.
-		$line_product    = isset( $cart_item['data'] ) && $cart_item['data'] instanceof \WC_Product ? $cart_item['data'] : $product_data;
+		$variation_id    = isset( $cart_item['variation_id'] ) ? absint( $cart_item['variation_id'] ) : 0;
+		$pristine        = wc_get_product( $variation_id ? $variation_id : $product_id );
+		$line_product    = $pristine instanceof \WC_Product ? $pristine : $product_data;
 		$ppom_meta_ids   = isset( $cart_item['ppom']['fields']['id'] ) ? $cart_item['ppom']['fields']['id'] : '';
 		$selected_fields = isset( $cart_item['ppom']['fields'] ) && is_array( $cart_item['ppom']['fields'] ) ? $cart_item['ppom']['fields'] : array();
 		$attached_ids    = null;
+		$counted_fields  = array();
 
 		$price = 0.0;
 		foreach ( $option_prices as $option ) {
@@ -953,12 +1142,22 @@ final class CartHandler {
 
 			$option_price = isset( $option['price'] ) ? (float) $option['price'] : 0.0;
 
-			if ( ! empty( $ppom_meta_ids ) && isset( $option['data_name'], $option['option_id'] ) ) {
+			if ( ! empty( $ppom_meta_ids ) && isset( $option['data_name'] ) ) {
 				if ( null === $attached_ids ) {
 					$attached_ids = self::attached_meta_ids( $product_id, $ppom_meta_ids );
 				}
 
-				$option_price = self::resolved_onetime_option_price( $option, $line_product, $attached_ids, $selected_fields );
+				if ( isset( $option['option_id'] ) ) {
+					$option_price = self::resolved_onetime_option_price( $option, $line_product, $attached_ids, $selected_fields );
+				} else {
+					$field_total = self::resolved_onetime_field_total( $option['data_name'], $line_product, $attached_ids, $selected_fields, $counted_fields );
+
+					if ( null !== $field_total ) {
+						$option_price = $field_total;
+					} elseif ( isset( $option['discount'] ) && $option['discount'] > 0 ) {
+						$option_price = (float) $option['discount'];
+					}
+				}
 			} elseif ( isset( $option['discount'] ) && $option['discount'] > 0 ) {
 				$option_price = (float) $option['discount'];
 			}

--- a/src/WooCommerce/Cart/CartHandler.php
+++ b/src/WooCommerce/Cart/CartHandler.php
@@ -774,6 +774,148 @@ final class CartHandler {
 		return $quantity;
 	}
 
+	/**
+	 * Narrows payload-supplied PPOM group ids to those actually attached to the product.
+	 *
+	 * @param int                     $product_id    Product the cart line refers to.
+	 * @param string|array<int, mixed> $ppom_meta_ids Group ids carried by the cart payload.
+	 *
+	 * @return int[] Attached group ids; empty when none of the requested ids belong to the product.
+	 */
+	private static function attached_meta_ids( $product_id, $ppom_meta_ids ) {
+		$requested = is_array( $ppom_meta_ids ) ? $ppom_meta_ids : explode( ',', (string) $ppom_meta_ids );
+		$requested = array_filter( array_map( 'absint', $requested ) );
+
+		if ( empty( $requested ) ) {
+			return array();
+		}
+
+		$ppom    = new \PPOM_Meta( $product_id );
+		$allowed = $ppom->get_meta_id( $product_id );
+		$allowed = array_filter( array_map( 'absint', is_array( $allowed ) ? $allowed : array( $allowed ) ) );
+
+		return array_values( array_intersect( $requested, $allowed ) );
+	}
+
+	/**
+	 * Server-resolved fixed-fee amount for one `ppom_option_price` row.
+	 *
+	 * @param array<string, mixed> $option          Single decoded option row.
+	 * @param \WC_Product          $product         Product of the cart line; percentage prices need it.
+	 * @param int[]                $attached_ids    Group ids confirmed attached to the product.
+	 * @param array<string, mixed> $selected_fields Field values submitted for the line.
+	 *
+	 * @return float
+	 */
+	private static function resolved_onetime_option_price( array $option, $product, array $attached_ids, array $selected_fields ) {
+		if ( empty( $attached_ids ) ) {
+			return 0.0;
+		}
+
+		$meta_ids   = implode( ',', $attached_ids );
+		$field_meta = Helpers::get_field_meta_by_dataname( 0, sanitize_key( (string) $option['data_name'] ), $meta_ids );
+
+		if ( empty( $field_meta ) || ! is_array( $field_meta ) ) {
+			return 0.0;
+		}
+
+		if ( ! isset( $field_meta['onetime'] ) || 'on' !== $field_meta['onetime'] ) {
+			return 0.0;
+		}
+
+		if ( ! self::option_is_selected( $field_meta, $option['option_id'], $selected_fields ) ) {
+			return 0.0;
+		}
+
+		$discount = self::saved_option_discount( $field_meta, $option['option_id'] );
+		if ( null !== $discount ) {
+			return false !== strpos( $discount, '%' )
+				? (float) Engine::get_amount_after_percentage( $product->get_price(), $discount )
+				: (float) $discount;
+		}
+
+		return (float) Helpers::get_field_option_price_by_id( $option, $product, $meta_ids );
+	}
+
+	/**
+	 * Saved discounted amount for an option, when the admin configured one.
+	 *
+	 * @param array<string, mixed> $field_meta Saved field definition.
+	 * @param string               $option_id  Option id carried by the cart row.
+	 *
+	 * @return string|null Discounted amount, or null when the option has no discount.
+	 */
+	private static function saved_option_discount( array $field_meta, $option_id ) {
+		if ( empty( $field_meta['options'] ) || ! is_array( $field_meta['options'] ) ) {
+			return null;
+		}
+
+		foreach ( $field_meta['options'] as $saved_option ) {
+			if ( ! is_array( $saved_option ) || ! isset( $saved_option['discount'] ) || ! is_scalar( $saved_option['discount'] ) ) {
+				continue;
+			}
+
+			$ids = array( (string) Helpers::get_option_id( $saved_option, $field_meta ) );
+			if ( isset( $saved_option['id'] ) && is_scalar( $saved_option['id'] ) ) {
+				$ids[] = (string) $saved_option['id'];
+			}
+
+			if ( ! in_array( (string) $option_id, $ids, true ) ) {
+				continue;
+			}
+
+			$discount = (string) $saved_option['discount'];
+
+			return (float) $discount > 0 ? $discount : null;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Whether an option id belongs to the values submitted for its field.
+	 *
+	 * @param array<string, mixed> $field_meta      Saved field definition.
+	 * @param string               $option_id       Option id carried by the cart row.
+	 * @param array<string, mixed> $selected_fields Field values submitted for the line.
+	 *
+	 * @return bool
+	 */
+	private static function option_is_selected( array $field_meta, $option_id, array $selected_fields ) {
+		$data_name  = isset( $field_meta['data_name'] ) ? $field_meta['data_name'] : '';
+		$field_type = isset( $field_meta['type'] ) ? $field_meta['type'] : '';
+
+		if ( '' === $data_name || ! isset( $selected_fields[ $data_name ] ) ) {
+			return true;
+		}
+
+		if ( 'image' === $field_type || empty( $field_meta['options'] ) || ! is_array( $field_meta['options'] ) ) {
+			return true;
+		}
+
+		$selected = array_map( 'strval', array_filter( (array) $selected_fields[ $data_name ], 'is_scalar' ) );
+		$ids      = array();
+
+		foreach ( $field_meta['options'] as $saved_option ) {
+			if ( ! is_array( $saved_option ) ) {
+				continue;
+			}
+
+			$label = isset( $saved_option['option'] ) ? $saved_option['option'] : '';
+			if ( ! is_scalar( $label ) || ! in_array( (string) $label, $selected, true ) ) {
+				continue;
+			}
+
+			$ids[] = (string) Helpers::get_option_id( $saved_option, $field_meta );
+		}
+
+		if ( empty( $ids ) ) {
+			return true;
+		}
+
+		return in_array( (string) $option_id, $ids, true );
+	}
+
 	// Control subtotal when quantities input used.
 	public static function item_subtotal( $item_subtotal, $cart_item, $cart_item_key ) {
 
@@ -793,8 +935,10 @@ final class CartHandler {
 		$product_data = new \WC_Product( $product_id );
 
 		// Resolve amounts against saved field meta, like the authoritative pricing path.
-		$line_product  = isset( $cart_item['data'] ) && $cart_item['data'] instanceof \WC_Product ? $cart_item['data'] : $product_data;
-		$ppom_meta_ids = isset( $cart_item['ppom']['fields']['id'] ) ? $cart_item['ppom']['fields']['id'] : '';
+		$line_product    = isset( $cart_item['data'] ) && $cart_item['data'] instanceof \WC_Product ? $cart_item['data'] : $product_data;
+		$ppom_meta_ids   = isset( $cart_item['ppom']['fields']['id'] ) ? $cart_item['ppom']['fields']['id'] : '';
+		$selected_fields = isset( $cart_item['ppom']['fields'] ) && is_array( $cart_item['ppom']['fields'] ) ? $cart_item['ppom']['fields'] : array();
+		$attached_ids    = null;
 
 		$price = 0.0;
 		foreach ( $option_prices as $option ) {
@@ -802,14 +946,19 @@ final class CartHandler {
 				continue;
 			}
 
-			$option       = Helpers::translation_options( $option );
-			$option_price = isset( $option['price'] ) ? (float) $option['price'] : 0.0;
-			if ( 0.0 === $option_price || ( ! isset( $option['apply'] ) || 'onetime' !== $option['apply'] ) ) {
+			$option = Helpers::translation_options( $option );
+			if ( ! isset( $option['apply'] ) || 'onetime' !== $option['apply'] ) {
 				continue;
 			}
 
+			$option_price = isset( $option['price'] ) ? (float) $option['price'] : 0.0;
+
 			if ( ! empty( $ppom_meta_ids ) && isset( $option['data_name'], $option['option_id'] ) ) {
-				$option_price = (float) Helpers::get_field_option_price_by_id( $option, $line_product, $ppom_meta_ids );
+				if ( null === $attached_ids ) {
+					$attached_ids = self::attached_meta_ids( $product_id, $ppom_meta_ids );
+				}
+
+				$option_price = self::resolved_onetime_option_price( $option, $line_product, $attached_ids, $selected_fields );
 			} elseif ( isset( $option['discount'] ) && $option['discount'] > 0 ) {
 				$option_price = (float) $option['discount'];
 			}

--- a/src/WooCommerce/Cart/CartHandler.php
+++ b/src/WooCommerce/Cart/CartHandler.php
@@ -1177,12 +1177,11 @@ final class CartHandler {
 
 		$product_id   = $cart_item['product_id'];
 		$quantity     = $cart_item['quantity'];
-		$product_data = new \WC_Product( $product_id );
+		$variation_id = isset( $cart_item['variation_id'] ) ? absint( $cart_item['variation_id'] ) : 0;
 
-		// Resolve amounts against saved field meta, like the authoritative pricing path.
-		$variation_id    = isset( $cart_item['variation_id'] ) ? absint( $cart_item['variation_id'] ) : 0;
+		// The selected variation prices the line, and its pristine copy resolves addons.
 		$pristine        = wc_get_product( $variation_id ? $variation_id : $product_id );
-		$line_product    = $pristine instanceof \WC_Product ? $pristine : $product_data;
+		$line_product    = $pristine instanceof \WC_Product ? $pristine : new \WC_Product( $product_id );
 		$ppom_meta_ids   = isset( $cart_item['ppom']['fields']['id'] ) ? $cart_item['ppom']['fields']['id'] : '';
 		$selected_fields = isset( $cart_item['ppom']['fields'] ) && is_array( $cart_item['ppom']['fields'] ) ? $cart_item['ppom']['fields'] : array();
 		$attached_ids    = null;
@@ -1242,7 +1241,7 @@ final class CartHandler {
 		if ( 0.0 === $price ) {
 			return $item_subtotal;
 		}
-		$product_price = floatval( $product_data->get_price() ) * $quantity;
+		$product_price = floatval( $line_product->get_price() ) * $quantity;
 		$item_subtotal = $product_price + $price;
 		return Helpers::price( $item_subtotal );
 	}

--- a/src/WooCommerce/Cart/CartHandler.php
+++ b/src/WooCommerce/Cart/CartHandler.php
@@ -578,13 +578,13 @@ final class CartHandler {
 					}
 
 					// Charge the saved amount, never the payload's, so the line subtotal agrees.
+					$resolved = null;
+
 					if ( $pristine instanceof \WC_Product && ! empty( $ppom_meta_ids ) ) {
 						$resolved = self::canonical_onetime_price( $fee, $pristine, $attached_ids, $selected_fields, $counted_fields );
-
-						if ( null !== $resolved ) {
-							$fee_price = $resolved;
-						}
 					}
+
+					$fee_price = null !== $resolved ? $resolved : (float) $fee_price;
 
 					// if(  'incl' === get_option( 'woocommerce_tax_display_shop' ) ) {
 					// $taxable = false;
@@ -979,8 +979,8 @@ final class CartHandler {
 	/**
 	 * Turns a saved amount into the figure the cart shows.
 	 *
-	 * Mirrors `Helpers::get_ppom_options()`: percentages resolve against the product base
-	 * price, then `ppom_option_price_vat` adjusts for the store's tax display.
+	 * Percentages resolve against the product base price. The amount stays net, because
+	 * the tax display transformation belongs to the display path alone.
 	 *
 	 * @param mixed       $amount  Saved amount, possibly a percentage.
 	 * @param \WC_Product $product Pristine product of the cart line.
@@ -998,7 +998,7 @@ final class CartHandler {
 			$amount = Engine::get_amount_after_percentage( Helpers::get_product_price( $product, null, 'cart' ), $amount );
 		}
 
-		return (float) apply_filters( 'ppom_option_price_vat', $amount, $product );
+		return (float) $amount;
 	}
 
 	/**
@@ -1188,7 +1188,9 @@ final class CartHandler {
 		$attached_ids    = null;
 		$counted_fields  = array();
 
-		$price = 0.0;
+		$price          = 0.0;
+		$resolved_price = 0.0;
+
 		foreach ( $option_prices as $option ) {
 			if ( ! is_array( $option ) ) {
 				continue;
@@ -1213,15 +1215,29 @@ final class CartHandler {
 
 			if ( null !== $resolved ) {
 				$option_price = $resolved;
-			} elseif ( isset( $option['discount'] ) && $option['discount'] > 0 ) {
-				$option_price = (float) $option['discount'];
+			} else {
+				if ( isset( $option['discount'] ) && $option['discount'] > 0 ) {
+					$option_price = (float) $option['discount'];
+				}
 			}
 
 			$option_price = apply_filters( 'ppom_option_price', $option_price );
+			$option_price = floatval( wp_strip_all_tags( (string) $option_price ) );
 
 			// Accumulate every fixed-fee option on the line, not just the last one.
-			$price += floatval( wp_strip_all_tags( (string) $option_price ) );
+			if ( null !== $resolved ) {
+				$resolved_price += $option_price;
+			} else {
+				$price += $option_price;
+			}
 		}
+
+		// Saved amounts are net, so only they take the store's tax display treatment.
+		if ( $resolved_price > 0 ) {
+			$resolved_price = (float) apply_filters( 'ppom_option_price_vat', $resolved_price, $line_product );
+		}
+
+		$price += $resolved_price;
 
 		if ( 0.0 === $price ) {
 			return $item_subtotal;

--- a/src/WooCommerce/Cart/CartHandler.php
+++ b/src/WooCommerce/Cart/CartHandler.php
@@ -552,9 +552,17 @@ final class CartHandler {
 			$option_prices = json_decode( wp_unslash( $item['ppom']['ppom_option_price'] ), true );
 
 			if ( $option_prices ) {
+				$product_id      = isset( $item['product_id'] ) ? absint( $item['product_id'] ) : 0;
+				$variation_id    = isset( $item['variation_id'] ) ? absint( $item['variation_id'] ) : 0;
+				$pristine        = wc_get_product( $variation_id ? $variation_id : $product_id );
+				$selected_fields = isset( $item['ppom']['fields'] ) && is_array( $item['ppom']['fields'] ) ? $item['ppom']['fields'] : array();
+				$ppom_meta_ids   = isset( $selected_fields['id'] ) ? $selected_fields['id'] : '';
+				$attached_ids    = empty( $ppom_meta_ids ) ? array() : self::attached_meta_ids( $product_id, $ppom_meta_ids );
+				$counted_fields  = array();
+
 				foreach ( $option_prices as $fee ) {
 
-					if ( $fee['apply'] != 'onetime' ) {
+					if ( ! is_array( $fee ) || ! isset( $fee['apply'] ) || $fee['apply'] != 'onetime' ) {
 						continue;
 					}
 
@@ -567,6 +575,15 @@ final class CartHandler {
 
 					if ( ! empty( $fee['without_tax'] ) ) {
 						$fee_price = $fee['without_tax'];
+					}
+
+					// Charge the saved amount, never the payload's, so the line subtotal agrees.
+					if ( $pristine instanceof \WC_Product && ! empty( $ppom_meta_ids ) ) {
+						$resolved = self::canonical_onetime_price( $fee, $pristine, $attached_ids, $selected_fields, $counted_fields );
+
+						if ( null !== $resolved ) {
+							$fee_price = $resolved;
+						}
 					}
 
 					// if(  'incl' === get_option( 'woocommerce_tax_display_shop' ) ) {
@@ -775,6 +792,30 @@ final class CartHandler {
 	}
 
 	/**
+	 * Canonical fixed-fee amount for one `ppom_option_price` row, or null when the row
+	 * cannot be resolved from saved meta at all.
+	 *
+	 * @param array<string, mixed> $option          Single decoded option row.
+	 * @param \WC_Product          $product         Pristine product of the cart line.
+	 * @param int[]                $attached_ids    Group ids confirmed attached to the product.
+	 * @param array<string, mixed> $selected_fields Field values submitted for the line.
+	 * @param array<string, bool>  $counted_fields  Fields already totalled for this line.
+	 *
+	 * @return float|null
+	 */
+	public static function canonical_onetime_price( array $option, $product, array $attached_ids, array $selected_fields, array &$counted_fields ) {
+		if ( ! isset( $option['data_name'] ) ) {
+			return null;
+		}
+
+		if ( isset( $option['option_id'] ) ) {
+			return self::resolved_onetime_option_price( $option, $product, $attached_ids, $selected_fields );
+		}
+
+		return self::resolved_onetime_field_total( $option['data_name'], $product, $attached_ids, $selected_fields, $counted_fields );
+	}
+
+	/**
 	 * Narrows payload-supplied PPOM group ids to those actually attached to the product.
 	 *
 	 * @param int                     $product_id    Product the cart line refers to.
@@ -827,49 +868,15 @@ final class CartHandler {
 			return 0.0;
 		}
 
-		$discount = self::saved_option_discount( $field_meta, $option['option_id'] );
-		if ( null !== $discount ) {
-			return false !== strpos( $discount, '%' )
-				? (float) Engine::get_amount_after_percentage( Helpers::get_product_price( $product, null, 'cart' ), $discount )
-				: (float) $discount;
+		$option_id = (string) $option['option_id'];
+
+		foreach ( self::saved_option_rows( $field_meta ) as $saved_option ) {
+			if ( in_array( $option_id, self::saved_option_ids( $saved_option, $field_meta ), true ) ) {
+				return self::saved_option_amount( $field_meta, $saved_option, $product );
+			}
 		}
 
-		return (float) Helpers::get_field_option_price_by_id( $option, $product, $meta_ids );
-	}
-
-	/**
-	 * Saved discounted amount for an option, when the admin configured one.
-	 *
-	 * @param array<string, mixed> $field_meta Saved field definition.
-	 * @param string               $option_id  Option id carried by the cart row.
-	 *
-	 * @return string|null Discounted amount, or null when the option has no discount.
-	 */
-	private static function saved_option_discount( array $field_meta, $option_id ) {
-		if ( empty( $field_meta['options'] ) || ! is_array( $field_meta['options'] ) ) {
-			return null;
-		}
-
-		foreach ( $field_meta['options'] as $saved_option ) {
-			if ( ! is_array( $saved_option ) || ! isset( $saved_option['discount'] ) || ! is_scalar( $saved_option['discount'] ) ) {
-				continue;
-			}
-
-			$ids = array( (string) Helpers::get_option_id( $saved_option, $field_meta ) );
-			if ( isset( $saved_option['id'] ) && is_scalar( $saved_option['id'] ) ) {
-				$ids[] = (string) $saved_option['id'];
-			}
-
-			if ( ! in_array( (string) $option_id, $ids, true ) ) {
-				continue;
-			}
-
-			$discount = (string) $saved_option['discount'];
-
-			return (float) $discount > 0 ? $discount : null;
-		}
-
-		return null;
+		return self::canonical_amount( Helpers::get_field_option_price_by_id( $option, $product, $meta_ids ), $product );
 	}
 
 	/**
@@ -901,7 +908,22 @@ final class CartHandler {
 		$saved_rows = self::saved_option_rows( $field_meta );
 
 		if ( empty( $saved_rows ) ) {
-			return null;
+			// Text-like fields price the field itself; anything else prices outside saved meta.
+			if ( ! isset( $field_meta['price'] ) || ! is_scalar( $field_meta['price'] ) || '' === (string) $field_meta['price'] ) {
+				return null;
+			}
+
+			$key = isset( $field_meta['data_name'] ) ? (string) $field_meta['data_name'] : (string) $data_name;
+
+			if ( isset( $counted_fields[ $key ] ) ) {
+				return 0.0;
+			}
+
+			$counted_fields[ $key ] = true;
+
+			return empty( self::submitted_option_tokens( isset( $selected_fields[ $key ] ) ? $selected_fields[ $key ] : '' ) )
+				? 0.0
+				: self::canonical_amount( $field_meta['price'], $product );
 		}
 
 		$key = isset( $field_meta['data_name'] ) ? (string) $field_meta['data_name'] : (string) $data_name;
@@ -951,13 +973,55 @@ final class CartHandler {
 			$amount = (string) $saved_option['price'];
 		}
 
-		if ( '' === $amount ) {
+		return self::canonical_amount( $amount, $product );
+	}
+
+	/**
+	 * Turns a saved amount into the figure the cart shows.
+	 *
+	 * Mirrors `Helpers::get_ppom_options()`: percentages resolve against the product base
+	 * price, then `ppom_option_price_vat` adjusts for the store's tax display.
+	 *
+	 * @param mixed       $amount  Saved amount, possibly a percentage.
+	 * @param \WC_Product $product Pristine product of the cart line.
+	 *
+	 * @return float
+	 */
+	private static function canonical_amount( $amount, $product ) {
+		if ( ! is_scalar( $amount ) || '' === (string) $amount ) {
 			return 0.0;
 		}
 
-		return false !== strpos( $amount, '%' )
-			? (float) Engine::get_amount_after_percentage( Helpers::get_product_price( $product, null, 'cart' ), $amount )
-			: (float) $amount;
+		$amount = (string) $amount;
+
+		if ( false !== strpos( $amount, '%' ) ) {
+			$amount = Engine::get_amount_after_percentage( Helpers::get_product_price( $product, null, 'cart' ), $amount );
+		}
+
+		return (float) apply_filters( 'ppom_option_price_vat', $amount, $product );
+	}
+
+	/**
+	 * Every id shape a saved option row can be referenced by.
+	 *
+	 * Image rows are addressed as `<data_name>-<id>`, while other types use the id
+	 * `Helpers::get_option_id()` generates.
+	 *
+	 * @param array<string, mixed> $saved_option Saved option row.
+	 * @param array<string, mixed> $field_meta   Saved field definition.
+	 *
+	 * @return string[]
+	 */
+	private static function saved_option_ids( array $saved_option, array $field_meta ) {
+		$data_name = isset( $field_meta['data_name'] ) ? (string) $field_meta['data_name'] : '';
+		$ids       = array( (string) Helpers::get_option_id( $saved_option, $field_meta ) );
+
+		if ( isset( $saved_option['id'] ) && is_scalar( $saved_option['id'] ) ) {
+			$ids[] = (string) $saved_option['id'];
+			$ids[] = $data_name . '-' . $saved_option['id'];
+		}
+
+		return array_values( array_unique( $ids ) );
 	}
 
 	/**
@@ -999,12 +1063,7 @@ final class CartHandler {
 				continue;
 			}
 
-			$candidates[] = (string) Helpers::get_option_id( $saved_option, $field_meta );
-
-			if ( isset( $saved_option['id'] ) && is_scalar( $saved_option['id'] ) ) {
-				$candidates[] = (string) $saved_option['id'];
-				$candidates[] = $data_name . '-' . $saved_option['id'];
-			}
+			$candidates = array_merge( $candidates, self::saved_option_ids( $saved_option, $field_meta ) );
 		}
 
 		return in_array( $option_id, $candidates, true );
@@ -1142,22 +1201,18 @@ final class CartHandler {
 
 			$option_price = isset( $option['price'] ) ? (float) $option['price'] : 0.0;
 
-			if ( ! empty( $ppom_meta_ids ) && isset( $option['data_name'] ) ) {
+			$resolved = null;
+
+			if ( ! empty( $ppom_meta_ids ) ) {
 				if ( null === $attached_ids ) {
 					$attached_ids = self::attached_meta_ids( $product_id, $ppom_meta_ids );
 				}
 
-				if ( isset( $option['option_id'] ) ) {
-					$option_price = self::resolved_onetime_option_price( $option, $line_product, $attached_ids, $selected_fields );
-				} else {
-					$field_total = self::resolved_onetime_field_total( $option['data_name'], $line_product, $attached_ids, $selected_fields, $counted_fields );
+				$resolved = self::canonical_onetime_price( $option, $line_product, $attached_ids, $selected_fields, $counted_fields );
+			}
 
-					if ( null !== $field_total ) {
-						$option_price = $field_total;
-					} elseif ( isset( $option['discount'] ) && $option['discount'] > 0 ) {
-						$option_price = (float) $option['discount'];
-					}
-				}
+			if ( null !== $resolved ) {
+				$option_price = $resolved;
 			} elseif ( isset( $option['discount'] ) && $option['discount'] > 0 ) {
 				$option_price = (float) $option['discount'];
 			}

--- a/tests/unit/src/WooCommerce/test-cart-handler.php
+++ b/tests/unit/src/WooCommerce/test-cart-handler.php
@@ -1046,10 +1046,204 @@ class Test_Cart_Handler extends PPOM_Test_Case {
 			)
 		);
 
-		$cart_item['ppom']['fields'] = array( 'id' => (string) $meta_id );
+		$cart_item['ppom']['fields'] = array(
+			'id'     => (string) $meta_id,
+			'extras' => array( 'Gift wrap', 'Candles' ),
+		);
 
 		$subtotal = CartHandler::item_subtotal( 'original', $cart_item, 'cart-key' );
 
 		$this->assertSame( Helpers::price( 18 ), $subtotal );
+	}
+
+	/**
+	 * Regression: a group that is not attached to this product must not price its line,
+	 * even though the group id travels in the cart payload.
+	 *
+	 * @return void
+	 */
+	public function test_item_subtotal_ignores_field_group_not_attached_to_the_product() {
+		$product     = $this->create_simple_product( array( 'regular_price' => '10' ) );
+		$other_group = $this->insert_ppom_meta(
+			array(
+				$this->build_checkbox_field(
+					'extras',
+					'Extras',
+					array( array( 'option' => 'Gold leaf', 'price' => '500', 'id' => 'gold_leaf' ) ),
+					array( 'onetime' => 'on' )
+				),
+			)
+		);
+
+		$cart_item = $this->option_price_cart_item(
+			$product->get_id(),
+			array(
+				array( 'price' => '500', 'apply' => 'onetime', 'data_name' => 'extras', 'option_id' => 'gold_leaf' ),
+			)
+		);
+
+		$cart_item['ppom']['fields'] = array(
+			'id'     => (string) $other_group,
+			'extras' => array( 'Gold leaf' ),
+		);
+
+		$this->assertSame( 'original', CartHandler::item_subtotal( 'original', $cart_item, 'cart-key' ) );
+	}
+
+	/**
+	 * Regression: `apply` on the row cannot promote a field the admin never configured
+	 * as a fixed fee.
+	 *
+	 * @return void
+	 */
+	public function test_item_subtotal_ignores_option_whose_field_is_not_a_fixed_fee() {
+		$product    = $this->create_simple_product( array( 'regular_price' => '10' ) );
+		$product_id = $product->get_id();
+
+		$meta_id = $this->insert_ppom_meta(
+			array(
+				$this->build_checkbox_field(
+					'extras',
+					'Extras',
+					array( array( 'option' => 'Gift wrap', 'price' => '3', 'id' => 'gift_wrap' ) )
+				),
+			),
+			$product_id
+		);
+
+		$cart_item = $this->option_price_cart_item(
+			$product_id,
+			array(
+				array( 'price' => '3', 'apply' => 'onetime', 'data_name' => 'extras', 'option_id' => 'gift_wrap' ),
+			)
+		);
+
+		$cart_item['ppom']['fields'] = array(
+			'id'     => (string) $meta_id,
+			'extras' => array( 'Gift wrap' ),
+		);
+
+		$this->assertSame( 'original', CartHandler::item_subtotal( 'original', $cart_item, 'cart-key' ) );
+	}
+
+	/**
+	 * Regression: only options the shopper actually selected may be charged into the
+	 * displayed subtotal.
+	 *
+	 * @return void
+	 */
+	public function test_item_subtotal_ignores_option_the_shopper_did_not_select() {
+		$product    = $this->create_simple_product( array( 'regular_price' => '10' ) );
+		$product_id = $product->get_id();
+
+		$meta_id = $this->insert_ppom_meta(
+			array(
+				$this->build_checkbox_field(
+					'extras',
+					'Extras',
+					array(
+						array( 'option' => 'Gift wrap', 'price' => '3', 'id' => 'gift_wrap' ),
+						array( 'option' => 'Gold leaf', 'price' => '500', 'id' => 'gold_leaf' ),
+					),
+					array( 'onetime' => 'on' )
+				),
+			),
+			$product_id
+		);
+
+		$cart_item = $this->option_price_cart_item(
+			$product_id,
+			array(
+				array( 'price' => '3', 'apply' => 'onetime', 'data_name' => 'extras', 'option_id' => 'gift_wrap' ),
+				array( 'price' => '3', 'apply' => 'onetime', 'data_name' => 'extras', 'option_id' => 'gold_leaf' ),
+			)
+		);
+
+		$cart_item['ppom']['fields'] = array(
+			'id'     => (string) $meta_id,
+			'extras' => array( 'Gift wrap' ),
+		);
+
+		$subtotal = CartHandler::item_subtotal( 'original', $cart_item, 'cart-key' );
+
+		$this->assertSame( Helpers::price( 13 ), $subtotal );
+	}
+
+	/**
+	 * Regression: a configured per-option discount is the amount the product page
+	 * charges, so the cart line has to show it too.
+	 *
+	 * @return void
+	 */
+	public function test_item_subtotal_uses_saved_discount_for_resolved_option() {
+		$product    = $this->create_simple_product( array( 'regular_price' => '10' ) );
+		$product_id = $product->get_id();
+
+		$meta_id = $this->insert_ppom_meta(
+			array(
+				$this->build_checkbox_field(
+					'extras',
+					'Extras',
+					array( array( 'option' => 'Gift wrap', 'price' => '5', 'discount' => '2', 'id' => 'gift_wrap' ) ),
+					array( 'onetime' => 'on' )
+				),
+			),
+			$product_id
+		);
+
+		$cart_item = $this->option_price_cart_item(
+			$product_id,
+			array(
+				array( 'price' => '2', 'apply' => 'onetime', 'data_name' => 'extras', 'option_id' => 'gift_wrap' ),
+			)
+		);
+
+		$cart_item['ppom']['fields'] = array(
+			'id'     => (string) $meta_id,
+			'extras' => array( 'Gift wrap' ),
+		);
+
+		$subtotal = CartHandler::item_subtotal( 'original', $cart_item, 'cart-key' );
+
+		$this->assertSame( Helpers::price( 12 ), $subtotal );
+	}
+
+	/**
+	 * Regression: zeroing the payload amount must not hide a configured fixed fee from
+	 * the displayed subtotal.
+	 *
+	 * @return void
+	 */
+	public function test_item_subtotal_resolves_fee_even_when_payload_amount_is_zero() {
+		$product    = $this->create_simple_product( array( 'regular_price' => '10' ) );
+		$product_id = $product->get_id();
+
+		$meta_id = $this->insert_ppom_meta(
+			array(
+				$this->build_checkbox_field(
+					'extras',
+					'Extras',
+					array( array( 'option' => 'Gift wrap', 'price' => '3', 'id' => 'gift_wrap' ) ),
+					array( 'onetime' => 'on' )
+				),
+			),
+			$product_id
+		);
+
+		$cart_item = $this->option_price_cart_item(
+			$product_id,
+			array(
+				array( 'price' => '0', 'apply' => 'onetime', 'data_name' => 'extras', 'option_id' => 'gift_wrap' ),
+			)
+		);
+
+		$cart_item['ppom']['fields'] = array(
+			'id'     => (string) $meta_id,
+			'extras' => array( 'Gift wrap' ),
+		);
+
+		$subtotal = CartHandler::item_subtotal( 'original', $cart_item, 'cart-key' );
+
+		$this->assertSame( Helpers::price( 13 ), $subtotal );
 	}
 }

--- a/tests/unit/src/WooCommerce/test-cart-handler.php
+++ b/tests/unit/src/WooCommerce/test-cart-handler.php
@@ -5,6 +5,7 @@
  * @package ppom-pro
  */
 
+use PPOM\Support\Helpers;
 use PPOM\WooCommerce\Cart\CartHandler;
 
 /**
@@ -905,5 +906,107 @@ class Test_Cart_Handler extends PPOM_Test_Case {
 		$result = CartHandler::update_cart_fees( $cart_items, $values );
 
 		$this->assertSame( 15.0, (float) $result['data']->get_price() );
+	}
+
+	/**
+	 * Builds a cart item carrying legacy `ppom_option_price` rows.
+	 *
+	 * @param int   $product_id Product the line refers to.
+	 * @param array $options    Option price rows.
+	 * @param int   $quantity   Cart line quantity.
+	 *
+	 * @return array
+	 */
+	private function option_price_cart_item( $product_id, array $options, $quantity = 1 ) {
+		return array(
+			'product_id' => $product_id,
+			'quantity'   => $quantity,
+			'ppom'       => array(
+				'ppom_option_price' => wp_json_encode( $options ),
+			),
+		);
+	}
+
+	/**
+	 * Regression: every selected fixed-fee option must be added to the cart line
+	 * subtotal, not just the last one.
+	 *
+	 * @return void
+	 */
+	public function test_item_subtotal_sums_every_onetime_option_price() {
+		$product    = $this->create_simple_product( array( 'regular_price' => '10' ) );
+		$product_id = $product->get_id();
+
+		$cart_item = $this->option_price_cart_item(
+			$product_id,
+			array(
+				array( 'price' => '3', 'apply' => 'onetime' ),
+				array( 'price' => '5', 'apply' => 'onetime' ),
+				array( 'price' => '9', 'apply' => 'onetime' ),
+			)
+		);
+
+		$subtotal = CartHandler::item_subtotal( 'original', $cart_item, 'cart-key' );
+
+		$this->assertSame( Helpers::price( 27 ), $subtotal );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_item_subtotal_prefers_discount_over_price_per_onetime_option() {
+		$product    = $this->create_simple_product( array( 'regular_price' => '10' ) );
+		$product_id = $product->get_id();
+
+		$cart_item = $this->option_price_cart_item(
+			$product_id,
+			array(
+				array( 'price' => '5', 'discount' => '2', 'apply' => 'onetime' ),
+				array( 'price' => '3', 'apply' => 'onetime' ),
+			)
+		);
+
+		$subtotal = CartHandler::item_subtotal( 'original', $cart_item, 'cart-key' );
+
+		$this->assertSame( Helpers::price( 15 ), $subtotal );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_item_subtotal_multiplies_only_the_base_price_by_quantity() {
+		$product    = $this->create_simple_product( array( 'regular_price' => '10' ) );
+		$product_id = $product->get_id();
+
+		$cart_item = $this->option_price_cart_item(
+			$product_id,
+			array(
+				array( 'price' => '3', 'apply' => 'onetime' ),
+				array( 'price' => '5', 'apply' => 'onetime' ),
+			),
+			2
+		);
+
+		$subtotal = CartHandler::item_subtotal( 'original', $cart_item, 'cart-key' );
+
+		$this->assertSame( Helpers::price( 28 ), $subtotal );
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_item_subtotal_left_untouched_when_no_onetime_option_selected() {
+		$product    = $this->create_simple_product( array( 'regular_price' => '10' ) );
+		$product_id = $product->get_id();
+
+		$cart_item = $this->option_price_cart_item(
+			$product_id,
+			array(
+				array( 'price' => '3', 'apply' => 'variable' ),
+				array( 'price' => '5', 'apply' => 'quantities' ),
+			)
+		);
+
+		$this->assertSame( 'original', CartHandler::item_subtotal( 'original', $cart_item, 'cart-key' ) );
 	}
 }

--- a/tests/unit/src/WooCommerce/test-cart-handler.php
+++ b/tests/unit/src/WooCommerce/test-cart-handler.php
@@ -952,9 +952,12 @@ class Test_Cart_Handler extends PPOM_Test_Case {
 	}
 
 	/**
+	 * Rows with no `data_name`/`option_id` cannot be resolved server-side, so they
+	 * keep the legacy behaviour of trusting the payload amount.
+	 *
 	 * @return void
 	 */
-	public function test_item_subtotal_prefers_discount_over_price_per_onetime_option() {
+	public function test_item_subtotal_prefers_discount_over_price_for_unresolvable_option() {
 		$product    = $this->create_simple_product( array( 'regular_price' => '10' ) );
 		$product_id = $product->get_id();
 
@@ -1008,5 +1011,45 @@ class Test_Cart_Handler extends PPOM_Test_Case {
 		);
 
 		$this->assertSame( 'original', CartHandler::item_subtotal( 'original', $cart_item, 'cart-key' ) );
+	}
+
+	/**
+	 * Regression: a tampered cart payload must not inflate the displayed subtotal —
+	 * fixed-fee amounts are re-read from the saved field meta.
+	 *
+	 * @return void
+	 */
+	public function test_item_subtotal_ignores_payload_amount_when_option_resolves_from_field_meta() {
+		$product    = $this->create_simple_product( array( 'regular_price' => '10' ) );
+		$product_id = $product->get_id();
+
+		$meta_id = $this->insert_ppom_meta(
+			array(
+				$this->build_checkbox_field(
+					'extras',
+					'Extras',
+					array(
+						array( 'option' => 'Gift wrap', 'price' => '3', 'id' => 'gift_wrap' ),
+						array( 'option' => 'Candles', 'price' => '5', 'id' => 'candles' ),
+					),
+					array( 'onetime' => 'on' )
+				),
+			),
+			$product_id
+		);
+
+		$cart_item = $this->option_price_cart_item(
+			$product_id,
+			array(
+				array( 'price' => '9999', 'apply' => 'onetime', 'data_name' => 'extras', 'option_id' => 'gift_wrap' ),
+				array( 'price' => '9999', 'apply' => 'onetime', 'data_name' => 'extras', 'option_id' => 'candles' ),
+			)
+		);
+
+		$cart_item['ppom']['fields'] = array( 'id' => (string) $meta_id );
+
+		$subtotal = CartHandler::item_subtotal( 'original', $cart_item, 'cart-key' );
+
+		$this->assertSame( Helpers::price( 18 ), $subtotal );
 	}
 }


### PR DESCRIPTION
### Summary
Verify correct handling of fixed-fee ("onetime") option pricing, including summing multiple options, resolving amounts from field meta, handling discounts, and ensuring only valid and selected options affect the subtotal.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/706