### PR TITLE
Passed product context to rendering inputs

### DIFF
--- a/classes/form.class.php
+++ b/classes/form.class.php
@@ -202,7 +202,7 @@ class PPOM_Form {
 			}
 
 			do_action( 'ppom_rendering_inputs', $meta, $data_name, $fm->input_classes_array(), $fm->field_label(), $fm->options() );
-			do_action( "ppom_rendering_inputs_{$type}", $meta, $default_value );
+			do_action( "ppom_rendering_inputs_{$type}", $meta, $default_value, $this->product );
 
 			$field_html .= ob_get_clean();
 


### PR DESCRIPTION
### Summary
Added product context to render the input fields.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Part of https://github.com/Codeinwp/ppom-pro/pull/772

## Why no test cases
Just added product context to the input field renderer. No new functionality was added, so no new test cases were needed.