### PR TITLE
Handled missing endpoints in bulk quantity pricing

### DIFF
--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -600,14 +600,11 @@ function ppom_bq_parse_range_endpoint( value ) {
 
 	const trimmed = String( value ).trim();
 
-	// PHP's numeric-string grammar: optional sign, digits with an optional
-	// fraction, optional exponent. Hex and trailing garbage are not numeric.
-	if ( ! /^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$/.test( trimmed ) ) {
+	if ( ! /^[0-9]{1,15}$/.test( trimmed ) ) {
 		return null;
 	}
 
-	// Matches PHP's intval(): truncate toward zero.
-	return Math.trunc( Number( trimmed ) );
+	return Number( trimmed );
 }
 
 // Resolve the active bulkquantity row into price/base-price attributes expected

--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -623,9 +623,21 @@ function ppom_bulkquantity_price_manager( quantity, data_name ) {
 	jQuery.each(
 		JSON.parse( ppom_bulkquantity_meta[ data_name ] ),
 		function ( idx, obj ) {
-			const qty_range = String( obj[ 'Quantity Range' ] || '' ).split(
-				'-'
-			);
+			if ( typeof obj !== 'object' || obj === null ) {
+				return;
+			}
+
+			const raw_range = obj[ 'Quantity Range' ];
+
+			if (
+				typeof raw_range !== 'string' &&
+				typeof raw_range !== 'number' &&
+				typeof raw_range !== 'boolean'
+			) {
+				return;
+			}
+
+			const qty_range = String( raw_range ).split( '-' );
 			const qty_range_from = ppom_bq_parse_range_endpoint(
 				qty_range[ 0 ]
 			);

--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -587,22 +587,53 @@ function ppom_bq_qty_changed( qty, data_name, context ) {
 	ppom_bulkquantity_price_manager( qty, data_name );
 }
 
+/**
+ * Parse one endpoint of a `Quantity Range` the way the server does.
+ *
+ * @param {*} value Raw endpoint from the stored matrix.
+ * @return {number|null} Integer value, or null when the server would skip it.
+ */
+function ppom_bq_parse_range_endpoint( value ) {
+	if ( typeof value !== 'string' && typeof value !== 'number' ) {
+		return null;
+	}
+
+	const trimmed = String( value ).trim();
+
+	// PHP's numeric-string grammar: optional sign, digits with an optional
+	// fraction, optional exponent. Hex and trailing garbage are not numeric.
+	if ( ! /^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$/.test( trimmed ) ) {
+		return null;
+	}
+
+	// Matches PHP's intval(): truncate toward zero.
+	return Math.trunc( Number( trimmed ) );
+}
+
 // Resolve the active bulkquantity row into price/base-price attributes expected
 // by the legacy and modern price preview engines.
 function ppom_bulkquantity_price_manager( quantity, data_name ) {
 	let ppom_base_price = 0;
+	const selected_option = jQuery(
+		`.ppom-bulkquantity-options.${ data_name } option:selected`
+	);
+	selected_option.attr( 'data-baseprice', 0 );
+	selected_option.attr( 'data-price', 0 );
+
 	jQuery.each(
 		JSON.parse( ppom_bulkquantity_meta[ data_name ] ),
 		function ( idx, obj ) {
 			const qty_range = String( obj[ 'Quantity Range' ] || '' ).split(
 				'-'
 			);
-			const qty_range_from = parseInt( qty_range[ 0 ], 10 );
-			const qty_range_to = parseInt( qty_range[ 1 ], 10 );
+			const qty_range_from = ppom_bq_parse_range_endpoint(
+				qty_range[ 0 ]
+			);
+			const qty_range_to = ppom_bq_parse_range_endpoint( qty_range[ 1 ] );
 
-			// A tier missing an endpoint can never be priced. Skip it explicitly
-			// rather than leaning on a NaN comparison to fall through.
-			if ( isNaN( qty_range_from ) || isNaN( qty_range_to ) ) {
+			// A tier the server would skip must be skipped here too, or the
+			// preview prices a row checkout ignores.
+			if ( qty_range_from === null || qty_range_to === null ) {
 				return;
 			}
 
@@ -613,16 +644,12 @@ function ppom_bulkquantity_price_manager( quantity, data_name ) {
 					obj[ 'Base Price' ] == ''
 						? 0
 						: obj[ 'Base Price' ];
-				jQuery(
-					`.ppom-bulkquantity-options.${ data_name } option:selected`
-				).attr( 'data-baseprice', ppom_base_price );
+				selected_option.attr( 'data-baseprice', ppom_base_price );
 
 				// Taking selected variation price
 				const variation = jQuery( '.ppom-bulkquantity-options' ).val();
 				const var_price = obj[ variation ];
-				jQuery(
-					`.ppom-bulkquantity-options.${ data_name } option:selected`
-				).attr( 'data-price', var_price );
+				selected_option.attr( 'data-price', var_price );
 
 				return false;
 			}

--- a/js/ppom.inputs.js
+++ b/js/ppom.inputs.js
@@ -594,14 +594,19 @@ function ppom_bulkquantity_price_manager( quantity, data_name ) {
 	jQuery.each(
 		JSON.parse( ppom_bulkquantity_meta[ data_name ] ),
 		function ( idx, obj ) {
-			const qty_range = obj[ 'Quantity Range' ].split( '-' );
-			const qty_range_from = qty_range[ 0 ];
-			const qty_range_to = qty_range[ 1 ];
+			const qty_range = String( obj[ 'Quantity Range' ] || '' ).split(
+				'-'
+			);
+			const qty_range_from = parseInt( qty_range[ 0 ], 10 );
+			const qty_range_to = parseInt( qty_range[ 1 ], 10 );
 
-			if (
-				quantity >= parseInt( qty_range_from ) &&
-				quantity <= parseInt( qty_range_to )
-			) {
+			// A tier missing an endpoint can never be priced. Skip it explicitly
+			// rather than leaning on a NaN comparison to fall through.
+			if ( isNaN( qty_range_from ) || isNaN( qty_range_to ) ) {
+				return;
+			}
+
+			if ( quantity >= qty_range_from && quantity <= qty_range_to ) {
 				// Setting Initial Price to 0 and taking base price
 				ppom_base_price =
 					obj[ 'Base Price' ] == undefined ||

--- a/src/Pricing/Engine.php
+++ b/src/Pricing/Engine.php
@@ -1371,6 +1371,27 @@ final class Engine {
 		return apply_filters( 'ppom_price_matrix_chunk_cart', $matrix_found, $product, $pm_applied );
 	}
 
+	/**
+	 * Parse one endpoint of a bulk-quantity `Quantity Range`.
+	 *
+	 * @param mixed $value Raw endpoint from the stored matrix.
+	 * @return int|null Integer value, or null when the endpoint is unusable.
+	 */
+	private static function parse_range_endpoint( $value ) {
+
+		if ( ! is_scalar( $value ) ) {
+			return null;
+		}
+
+		$trimmed = trim( (string) $value );
+
+		if ( ! preg_match( '/^[0-9]{1,15}$/', $trimmed ) ) {
+			return null;
+		}
+
+		return intval( $trimmed );
+	}
+
 	// If Bulkquantity add-on is used, get it's chunk
 	public static function price_bulkquantity_chunk( $product, $bulkquantity_options, $product_quantity ) {
 
@@ -1387,12 +1408,12 @@ final class Engine {
 				$range       = isset( $bq['Quantity Range'] ) && is_scalar( $bq['Quantity Range'] ) ? (string) $bq['Quantity Range'] : '';
 				$range_array = explode( '-', $range );
 
-				if ( ! isset( $range_array[1] ) || ! is_numeric( trim( $range_array[0] ) ) || ! is_numeric( trim( $range_array[1] ) ) ) {
+				$range_start = self::parse_range_endpoint( $range_array[0] );
+				$range_end   = isset( $range_array[1] ) ? self::parse_range_endpoint( $range_array[1] ) : null;
+
+				if ( null === $range_start || null === $range_end ) {
 					continue;
 				}
-
-				$range_start = intval( $range_array[0] );
-				$range_end   = intval( $range_array[1] );
 
 				// var_dump($bq);
 				$quantity = intval( $product_quantity );

--- a/src/Pricing/Engine.php
+++ b/src/Pricing/Engine.php
@@ -1380,9 +1380,13 @@ final class Engine {
 
 			foreach ( $bulkquantity_options as $bq ) {
 
-				// ppom_pa($bq);
-				$range       = $bq['Quantity Range'];
-				$range_array = explode( '-', $range );
+				$range       = isset( $bq['Quantity Range'] ) ? $bq['Quantity Range'] : '';
+				$range_array = explode( '-', (string) $range );
+
+				if ( ! isset( $range_array[1] ) || ! is_numeric( trim( $range_array[0] ) ) || ! is_numeric( trim( $range_array[1] ) ) ) {
+					continue;
+				}
+
 				$range_start = intval( $range_array[0] );
 				$range_end   = intval( $range_array[1] );
 

--- a/src/Pricing/Engine.php
+++ b/src/Pricing/Engine.php
@@ -1376,7 +1376,7 @@ final class Engine {
 
 		$bq_found = array();
 
-		if ( count( $bulkquantity_options ) > 0 ) {
+		if ( is_array( $bulkquantity_options ) ) {
 
 			foreach ( $bulkquantity_options as $bq ) {
 

--- a/src/Pricing/Engine.php
+++ b/src/Pricing/Engine.php
@@ -1380,8 +1380,12 @@ final class Engine {
 
 			foreach ( $bulkquantity_options as $bq ) {
 
-				$range       = isset( $bq['Quantity Range'] ) ? $bq['Quantity Range'] : '';
-				$range_array = explode( '-', (string) $range );
+				if ( ! is_array( $bq ) ) {
+					continue;
+				}
+
+				$range       = isset( $bq['Quantity Range'] ) && is_scalar( $bq['Quantity Range'] ) ? (string) $bq['Quantity Range'] : '';
+				$range_array = explode( '-', $range );
 
 				if ( ! isset( $range_array[1] ) || ! is_numeric( trim( $range_array[0] ) ) || ! is_numeric( trim( $range_array[1] ) ) ) {
 					continue;

--- a/tests/unit/src/Pricing/test-engine-gaps.php
+++ b/tests/unit/src/Pricing/test-engine-gaps.php
@@ -260,6 +260,19 @@ class Test_Pricing_Engine_Gaps extends PPOM_Test_Case {
 				'Base Price'     => '20',
 				'ID'             => 'b',
 			),
+			// Stored JSON can decode a range into an array; casting one would
+			// raise a conversion notice before any endpoint check ran.
+			array(
+				'Quantity Range' => array( '10', '20' ),
+				'Base Price'     => '30',
+				'ID'             => 'c',
+			),
+			// A numeric prefix is not numeric to PHP, so this row is skipped too.
+			array(
+				'Quantity Range' => '10-20x',
+				'Base Price'     => '40',
+				'ID'             => 'd',
+			),
 		);
 
 		$errors = array();
@@ -274,17 +287,16 @@ class Test_Pricing_Engine_Gaps extends PPOM_Test_Case {
 		try {
 			$this->assertSame( $rows[0], Engine::price_bulkquantity_chunk( $product, $rows, 5 ) );
 			$this->assertSame( array(), Engine::price_bulkquantity_chunk( $product, $rows, 10 ) );
+			$this->assertSame( array(), Engine::price_bulkquantity_chunk( $product, $rows, 15 ) );
 		} finally {
 			restore_error_handler();
 		}
 
-		foreach ( $errors as $error ) {
-			$this->assertStringNotContainsString(
-				'Undefined array key',
-				$error,
-				'A row missing an endpoint must be skipped, not read.'
-			);
-		}
+		$this->assertSame(
+			array(),
+			$errors,
+			'A row missing an endpoint must be skipped, not read. Raised: ' . implode( ' | ', $errors )
+		);
 	}
 	/**
 	 * price_has_discount_matrix returns false when the product has no pricematrix field.

--- a/tests/unit/src/Pricing/test-engine-gaps.php
+++ b/tests/unit/src/Pricing/test-engine-gaps.php
@@ -241,6 +241,52 @@ class Test_Pricing_Engine_Gaps extends PPOM_Test_Case {
 	}
 
 	/**
+	 * A bulk-quantity row whose `Quantity Range` has no second endpoint cannot
+	 * be matched against a quantity.
+	 *
+	 * @return void
+	 */
+	public function test_price_bulkquantity_chunk_skips_rows_missing_an_endpoint() {
+		$product = $this->create_simple_product();
+
+		$rows = array(
+			array(
+				'Quantity Range' => '1-9',
+				'Base Price'     => '10',
+				'ID'             => 'a',
+			),
+			array(
+				'Quantity Range' => '10+',
+				'Base Price'     => '20',
+				'ID'             => 'b',
+			),
+		);
+
+		$errors = array();
+		set_error_handler(
+			function ( $errno, $errstr ) use ( &$errors ) {
+				$errors[] = $errstr;
+				return true;
+			},
+			E_ALL
+		);
+
+		try {
+			$this->assertSame( $rows[0], Engine::price_bulkquantity_chunk( $product, $rows, 5 ) );
+			$this->assertSame( array(), Engine::price_bulkquantity_chunk( $product, $rows, 10 ) );
+		} finally {
+			restore_error_handler();
+		}
+
+		foreach ( $errors as $error ) {
+			$this->assertStringNotContainsString(
+				'Undefined array key',
+				$error,
+				'A row missing an endpoint must be skipped, not read.'
+			);
+		}
+	}
+	/**
 	 * price_has_discount_matrix returns false when the product has no pricematrix field.
 	 *
 	 * @return void

--- a/tests/unit/src/Pricing/test-engine-gaps.php
+++ b/tests/unit/src/Pricing/test-engine-gaps.php
@@ -275,6 +275,16 @@ class Test_Pricing_Engine_Gaps extends PPOM_Test_Case {
 			),
 			// A row can decode to null outright.
 			null,
+			array(
+				'Quantity Range' => '1-1e309',
+				'Base Price'     => '50',
+				'ID'             => 'e',
+			),
+			array(
+				'Quantity Range' => '1-99999999999999999999',
+				'Base Price'     => '60',
+				'ID'             => 'f',
+			),
 		);
 
 		$errors = array();
@@ -290,6 +300,7 @@ class Test_Pricing_Engine_Gaps extends PPOM_Test_Case {
 			$this->assertSame( $rows[0], Engine::price_bulkquantity_chunk( $product, $rows, 5 ) );
 			$this->assertSame( array(), Engine::price_bulkquantity_chunk( $product, $rows, 10 ) );
 			$this->assertSame( array(), Engine::price_bulkquantity_chunk( $product, $rows, 15 ) );
+			$this->assertSame( array(), Engine::price_bulkquantity_chunk( $product, $rows, 1000 ) );
 		} finally {
 			restore_error_handler();
 		}

--- a/tests/unit/src/Pricing/test-engine-gaps.php
+++ b/tests/unit/src/Pricing/test-engine-gaps.php
@@ -273,6 +273,8 @@ class Test_Pricing_Engine_Gaps extends PPOM_Test_Case {
 				'Base Price'     => '40',
 				'ID'             => 'd',
 			),
+			// A row can decode to null outright.
+			null,
 		);
 
 		$errors = array();


### PR DESCRIPTION
### Summary
Improves the handling of bulk quantity pricing tiers that are missing a valid range endpoint, ensuring that such incomplete tiers are safely skipped during price calculations.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Part of https://github.com/Codeinwp/ppom-pro/pull/771