### PR TITLE
fix: label paired option identifiers as Option ID

### DIFF
--- a/packages/admin/field-modal/src/components/paired-options/PairedOptionRowItem.tsx
+++ b/packages/admin/field-modal/src/components/paired-options/PairedOptionRowItem.tsx
@@ -214,11 +214,7 @@ export function PairedOptionRowItem( {
 					flex="1 1 0"
 					minW={ 0 }
 					w="auto"
-					placeholder={
-						showSwitcherExtras
-							? i18n.pairedOptionId || 'Option ID'
-							: i18n.pairedOptionImageId || 'Image ID'
-					}
+					placeholder={ i18n.pairedOptionId || 'Option ID' }
 					value={ String( row.id ?? row.images ?? '' ) }
 					onChange={ ( e ) =>
 						onPatch( index, { id: e.target.value } )


### PR DESCRIPTION
Select, radio, and checkbox option rows label the editable option identifier as “Image ID” (#736). The control stores the unique option identifier, not an attachment, so the placeholder now reads “Option ID” for every paired-option variant.

## What changed

- **Paired option rows** (select, radio, checkbox) use the same “Option ID” placeholder the switcher variant already used.

- **Switcher rows** keep their separate “Image ID” input for the actual image property.

## QA

1. In WP Admin → PPOM Fields, edit a field group using the new field modal. Open a Select, Radio, or Checkbox field.

   **Expect:** the identifier input on each option row displays “Option ID” when empty.

2. Enter an identifier, save the field group, and reopen the field.

   **Expect:** the identifier is preserved.

3. Open a Switcher field.

   **Expect:** each option row shows both an “Option ID” input and an “Image ID” input.
