### PR TITLE
Fix: allow SVG uploads through the File upload field

### DIFF
--- a/src/Files/Handler.php
+++ b/src/Files/Handler.php
@@ -266,7 +266,8 @@ final class Handler {
 			array(
 				'ai'  => 'application/postscript',
 				'eps' => 'application/postscript',
-			) 
+				'svg' => 'image/svg+xml',
+			)
 		);
 
 		$allowed_mime_types = array_merge( get_allowed_mime_types(), $additional_mime_types );
@@ -394,6 +395,22 @@ final class Handler {
 			rename( $chunk_file_path, $unique_file_path );
 			$file_path = $unique_file_path;
 
+			// The type check above only compared the declared extension against the
+			// allow-list, because the destination didn't exist yet to sniff — that's
+			// harmless for jpg/pdf/zip, but SVG is markup a browser will execute, so
+			// its actual content has to be checked now that the bytes are on disk.
+			if ( 'svg' === $file_ext && ! self::sanitize_svg_file( $file_path ) ) {
+				@unlink( $file_path );
+
+				$response ['status']  = 'error';
+				$response ['message'] = sprintf(
+				// translators: %s: the name of the extension.
+					__( 'File type not valid - %s', 'woocommerce-product-addon' ),
+					$file_ext
+				);
+				wp_send_json( $response );
+			}
+
 			$product_id = intval( $_REQUEST['product_id'] );
 			$data_name  = sanitize_key( $_REQUEST['data_name'] );
 			$file_meta  = Helpers::get_field_meta_by_dataname( $product_id, $data_name );
@@ -455,6 +472,62 @@ final class Handler {
 		// Return JSON-RPC response
 		// die ( '{"jsonrpc" : "2.0", "result" : '. json_encode($response) .', "id" : "id"}' );
 		die( json_encode( apply_filters( 'ppom_file_upload', $response, $file_type, $file_dir_path, $file_name ) ) );
+	}
+
+	/**
+	 * Strips script-capable content from an uploaded SVG, in place.
+	 *
+	 * SVG is XML the browser will execute inline, so — unlike the other types
+	 * this endpoint accepts — its content has to be checked, not just its
+	 * extension. Rejects anything that isn't parseable XML rooted at <svg>;
+	 * otherwise strips <script>/<foreignObject>/event-driven tags, "on*"
+	 * attributes, and javascript: URIs, then rewrites the file.
+	 *
+	 * ponytail: denylist of the well-known SVG XSS vectors via DOMDocument,
+	 * not a full allowlist sanitizer. Swap for enshrined/svg-sanitize if this
+	 * endpoint ever needs to withstand adversarial (not just careless) input.
+	 *
+	 * @param string $file_path Path to the file to sanitize.
+	 *
+	 * @return bool True if the file is safe to keep, false if it was rejected.
+	 */
+	private static function sanitize_svg_file( $file_path ) {
+
+		$content = file_get_contents( $file_path );
+		if ( false === $content ) {
+			return false;
+		}
+
+		$previous_setting = libxml_use_internal_errors( true );
+		$doc              = new \DOMDocument();
+		// No DTD flags: external entities are not resolved.
+		$loaded = $doc->loadXML( $content, LIBXML_NONET | LIBXML_NOBLANKS );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous_setting );
+
+		if ( ! $loaded || ! $doc->documentElement || 'svg' !== strtolower( $doc->documentElement->localName ) ) {
+			return false;
+		}
+
+		$dangerous_tags = array( 'script', 'foreignobject', 'iframe', 'embed', 'object', 'animate', 'animatetransform', 'set' );
+		foreach ( $dangerous_tags as $tag ) {
+			foreach ( iterator_to_array( $doc->getElementsByTagName( $tag ) ) as $node ) {
+				$node->parentNode->removeChild( $node );
+			}
+		}
+
+		foreach ( iterator_to_array( ( new \DOMXPath( $doc ) )->query( '//*' ) ) as $element ) {
+			foreach ( iterator_to_array( $element->attributes ) as $attr ) {
+				$is_event_handler = 0 === stripos( $attr->nodeName, 'on' );
+				$is_script_uri    = preg_match( '/^\s*javascript:/i', $attr->nodeValue );
+
+				if ( $is_event_handler || $is_script_uri ) {
+					$element->removeAttribute( $attr->nodeName );
+				}
+			}
+		}
+
+		return false !== file_put_contents( $file_path, $doc->saveXML() );
 	}
 
 	/**

--- a/src/Files/Handler.php
+++ b/src/Files/Handler.php
@@ -548,6 +548,16 @@ final class Handler {
 		libxml_clear_errors();
 		libxml_use_internal_errors( $previous_setting );
 
+		// A DOCTYPE can declare an internal entity whose expansion never becomes
+		// an inspectable element node without LIBXML_NOENT, so the tag/attribute
+		// removal below never sees it — yet saveXML() below writes the
+		// declaration and reference back unchanged, and a browser rendering the
+		// file expands and runs it. SVGs have no legitimate use for a DOCTYPE;
+		// reject the file outright rather than try to sanitize around one.
+		if ( $loaded && null !== $doc->doctype ) {
+			return false;
+		}
+
 		$root_name = $loaded && $doc->documentElement ? $doc->documentElement->localName : null;
 
 		if ( null === $root_name || 'svg' !== strtolower( $root_name ) ) {

--- a/src/Files/Handler.php
+++ b/src/Files/Handler.php
@@ -251,6 +251,29 @@ final class Handler {
 			wp_send_json( $response );
 		}
 
+		// multipart_params sends product_id/data_name with every chunk (not just
+		// the last), so the field can — and should — be resolved up front: the
+		// mime allow-list below is shared by every upload-capable field, and
+		// without this, a field left at its default "jpg,pdf,zip" (or a cropper,
+		// which only ever wants images) would accept any type the *broadest*
+		// field on the site allows, like the svg entry that list now carries.
+		$product_id = intval( $_REQUEST['product_id'] );
+		$data_name  = sanitize_key( $_REQUEST['data_name'] );
+		$file_meta  = Helpers::get_field_meta_by_dataname( $product_id, $data_name );
+
+		// The upload nonce is public, so the posted product and field are not
+		// necessarily a pair the form could have produced. Keeping a file no
+		// form references only leaves something to clean up later.
+		//
+		// Same wording as the nonce failure above on purpose: saying which
+		// field names exist, and which of them accept uploads, would let the
+		// endpoint be probed to map a product's fields.
+		if ( ! self::field_accepts_uploads( $file_meta ) ) {
+			$response ['status']  = 'error';
+			$response ['message'] = __( 'You cannot upload the file at this time, please refresh the page and try again. Note that your current option choices will be reset.', 'woocommerce-product-addon' );
+			wp_send_json( $response );
+		}
+
 		$file_name = '';
 
 		if ( isset( $_REQUEST['name'] ) && $_REQUEST['name'] != '' ) {
@@ -281,7 +304,7 @@ final class Handler {
 		$restricted_type    = Helpers::get_option( 'ppom_restricted_file_type', $default_restricted );
 		$restricted_type    = explode( ',', $restricted_type );
 
-		if ( empty( $extension ) || in_array( strtolower( $extension ), $restricted_type ) ) {
+		if ( empty( $extension ) || in_array( strtolower( $extension ), $restricted_type ) || ! self::field_allows_extension( $file_meta, $extension ) ) {
 			$response ['status']  = 'error';
 			$response ['message'] = sprintf(
 			// translators: %s: the name of the extension.
@@ -411,25 +434,8 @@ final class Handler {
 				wp_send_json( $response );
 			}
 
-			$product_id = intval( $_REQUEST['product_id'] );
-			$data_name  = sanitize_key( $_REQUEST['data_name'] );
-			$file_meta  = Helpers::get_field_meta_by_dataname( $product_id, $data_name );
-
-			// The upload nonce is public, so the posted product and field are not
-			// necessarily a pair the form could have produced. Keeping a file no
-			// form references only leaves something to clean up later.
-			//
-			// Same wording as the nonce failure above on purpose: saying which
-			// field names exist, and which of them accept uploads, would let the
-			// endpoint be probed to map a product's fields.
-			if ( ! self::field_accepts_uploads( $file_meta ) ) {
-				@unlink( $file_path );
-
-				$response ['status']  = 'error';
-				$response ['message'] = __( 'You cannot upload the file at this time, please refresh the page and try again. Note that your current option choices will be reset.', 'woocommerce-product-addon' );
-				wp_send_json( $response );
-			}
-
+			// $file_meta was already resolved and validated up front, since the
+			// mime/extension gate above needs it too.
 			self::remember_uploaded_file( $file_name );
 
 			// making thumb if images
@@ -475,6 +481,35 @@ final class Handler {
 	}
 
 	/**
+	 * Whether a field's own "File types" setting allows the given extension.
+	 *
+	 * The mime/extension allow-list earlier in upload_file() is shared by every
+	 * upload-capable field on the site, so on its own it would let a field
+	 * accept anything any other field's setting allows — including a cropper
+	 * (images only) or a file field a store owner left at its default
+	 * "jpg,pdf,zip". Each field's own list is the actual authorization.
+	 *
+	 * @param mixed  $file_meta Field definition resolved from the posted data name.
+	 * @param string $extension Extension resolved from the upload request.
+	 *
+	 * @return bool
+	 */
+	private static function field_allows_extension( $file_meta, $extension ) {
+
+		$type = is_array( $file_meta ) && isset( $file_meta['type'] ) ? $file_meta['type'] : '';
+
+		$default_types = 'cropper' === $type ? 'jpg,png' : 'jpg,pdf,zip';
+
+		$configured = is_array( $file_meta ) && ! empty( $file_meta['file_types'] )
+			? $file_meta['file_types']
+			: $default_types;
+
+		$allowed = array_map( 'strtolower', array_map( 'trim', explode( ',', $configured ) ) );
+
+		return in_array( strtolower( $extension ), $allowed, true );
+	}
+
+	/**
 	 * Strips script-capable content from an uploaded SVG, in place.
 	 *
 	 * SVG is XML the browser will execute inline, so — unlike the other types
@@ -493,8 +528,16 @@ final class Handler {
 	 */
 	private static function sanitize_svg_file( $file_path ) {
 
+		// The dom extension is bundled by default but is still optional; without
+		// it, `new DOMDocument()` below is a fatal error, not a catchable one.
+		if ( ! class_exists( '\\DOMDocument' ) || ! class_exists( '\\DOMXPath' ) ) {
+			return false;
+		}
+
 		$content = file_get_contents( $file_path );
-		if ( false === $content ) {
+		// On PHP 8+, DOMDocument::loadXML('') throws instead of returning false,
+		// so an empty upload has to be rejected before it ever reaches loadXML.
+		if ( empty( $content ) ) {
 			return false;
 		}
 
@@ -511,7 +554,10 @@ final class Handler {
 			return false;
 		}
 
-		$dangerous_tags = array( 'script', 'foreignobject', 'iframe', 'embed', 'object', 'animate', 'animatetransform', 'set' );
+		// XML tag names are case-sensitive — a real <foreignObject> or
+		// <animateTransform> only matches this exact casing, and a renderer
+		// treating the file as SVG would honor it the same way.
+		$dangerous_tags = array( 'script', 'foreignObject', 'iframe', 'embed', 'object', 'animate', 'animateTransform', 'set' );
 		foreach ( $dangerous_tags as $tag ) {
 			foreach ( iterator_to_array( $doc->getElementsByTagName( $tag ) ) as $node ) {
 				if ( $node->parentNode ) {
@@ -530,8 +576,15 @@ final class Handler {
 			}
 
 			foreach ( iterator_to_array( $element->attributes ) as $attr ) {
+				// A URL's scheme is matched after stripping tab/newline/CR
+				// wherever they occur, not just at the ends — that's how a
+				// browser reads the same value, so java&#x09;script: has to be
+				// normalized the same way before the javascript: check below,
+				// or the literal tab hides the scheme from a naive prefix match.
+				$normalized_value = null !== $attr->nodeValue ? preg_replace( '/[\t\r\n]/', '', $attr->nodeValue ) : null;
+
 				$is_event_handler = 0 === stripos( $attr->nodeName, 'on' );
-				$is_script_uri    = null !== $attr->nodeValue && preg_match( '/^\s*javascript:/i', $attr->nodeValue );
+				$is_script_uri    = null !== $normalized_value && preg_match( '/^\s*javascript:/i', $normalized_value );
 
 				if ( $is_event_handler || $is_script_uri ) {
 					$element->removeAttribute( $attr->nodeName );

--- a/src/Files/Handler.php
+++ b/src/Files/Handler.php
@@ -505,21 +505,33 @@ final class Handler {
 		libxml_clear_errors();
 		libxml_use_internal_errors( $previous_setting );
 
-		if ( ! $loaded || ! $doc->documentElement || 'svg' !== strtolower( $doc->documentElement->localName ) ) {
+		$root_name = $loaded && $doc->documentElement ? $doc->documentElement->localName : null;
+
+		if ( null === $root_name || 'svg' !== strtolower( $root_name ) ) {
 			return false;
 		}
 
 		$dangerous_tags = array( 'script', 'foreignobject', 'iframe', 'embed', 'object', 'animate', 'animatetransform', 'set' );
 		foreach ( $dangerous_tags as $tag ) {
 			foreach ( iterator_to_array( $doc->getElementsByTagName( $tag ) ) as $node ) {
-				$node->parentNode->removeChild( $node );
+				if ( $node->parentNode ) {
+					$node->parentNode->removeChild( $node );
+				}
 			}
 		}
 
-		foreach ( iterator_to_array( ( new \DOMXPath( $doc ) )->query( '//*' ) ) as $element ) {
+		$elements = ( new \DOMXPath( $doc ) )->query( '//*' );
+		foreach ( $elements ? iterator_to_array( $elements ) : array() as $element ) {
+			// The '//*' xpath only ever matches element nodes, but DOMXPath::query()
+			// is typed to allow namespace nodes too — narrow it before using
+			// element-only members like ->attributes and ->removeAttribute().
+			if ( ! $element instanceof \DOMElement ) {
+				continue;
+			}
+
 			foreach ( iterator_to_array( $element->attributes ) as $attr ) {
 				$is_event_handler = 0 === stripos( $attr->nodeName, 'on' );
-				$is_script_uri    = preg_match( '/^\s*javascript:/i', $attr->nodeValue );
+				$is_script_uri    = null !== $attr->nodeValue && preg_match( '/^\s*javascript:/i', $attr->nodeValue );
 
 				if ( $is_event_handler || $is_script_uri ) {
 					$element->removeAttribute( $attr->nodeName );

--- a/tests/unit/src/Files/test-svg-field-authorization.php
+++ b/tests/unit/src/Files/test-svg-field-authorization.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Regression tests for a Copilot review finding on PR #741 (Codeinwp/ppom-pro#505):
+ * the mime/extension allow-list in Handler::upload_file() is shared by every
+ * upload-capable field on a site, so adding "svg" to it for one field's sake
+ * let *every* field accept an SVG — including a field still left at its
+ * default "jpg,pdf,zip", or an image-only cropper field. Each field's own
+ * "File types" setting is the actual authorization and has to be checked too.
+ *
+ * @package ppom-pro
+ */
+
+use PPOM\Files\Handler;
+
+/**
+ * @covers \PPOM\Files\Handler::field_allows_extension
+ */
+class Test_Svg_Field_Authorization extends WP_UnitTestCase {
+
+	/**
+	 * @param mixed  $file_meta Field definition.
+	 * @param string $extension Extension to check.
+	 *
+	 * @return bool
+	 */
+	private function allows( $file_meta, $extension ) {
+
+		$method = new ReflectionMethod( Handler::class, 'field_allows_extension' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $file_meta, $extension );
+	}
+
+	/**
+	 * A file field left at its default setting must not suddenly accept svg
+	 * just because the shared mime allow-list now permits the extension.
+	 */
+	public function test_file_field_without_explicit_file_types_rejects_svg() {
+
+		$file_meta = array( 'type' => 'file' );
+
+		$this->assertFalse( $this->allows( $file_meta, 'svg' ) );
+		$this->assertTrue( $this->allows( $file_meta, 'jpg' ) );
+	}
+
+	/**
+	 * A cropper field only ever wants images; it must not accept svg either.
+	 */
+	public function test_cropper_field_without_explicit_file_types_rejects_svg() {
+
+		$file_meta = array( 'type' => 'cropper' );
+
+		$this->assertFalse( $this->allows( $file_meta, 'svg' ) );
+		$this->assertTrue( $this->allows( $file_meta, 'png' ) );
+	}
+
+	/**
+	 * A store owner who explicitly adds svg to a field's "File types" setting
+	 * must still be able to accept it — that's the bug this PR fixes.
+	 */
+	public function test_field_with_svg_in_its_own_file_types_allows_it() {
+
+		$file_meta = array(
+			'type'       => 'file',
+			'file_types' => 'jpg, svg, pdf',
+		);
+
+		$this->assertTrue( $this->allows( $file_meta, 'svg' ) );
+	}
+
+	/**
+	 * Matching must be case- and whitespace-insensitive, since that's how the
+	 * setting is free-typed by a store owner.
+	 */
+	public function test_matching_is_case_and_whitespace_insensitive() {
+
+		$file_meta = array(
+			'type'       => 'file',
+			'file_types' => ' JPG , SVG ',
+		);
+
+		$this->assertTrue( $this->allows( $file_meta, 'SVG' ) );
+	}
+}

--- a/tests/unit/src/Files/test-svg-upload-sanitization.php
+++ b/tests/unit/src/Files/test-svg-upload-sanitization.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Regression tests for Codeinwp/ppom-pro#505 — SVG uploads through the File
+ * upload field were always rejected, because wp_check_filetype_and_ext()
+ * only compares extensions/mimes (it never sniffs content when the
+ * destination file doesn't exist yet, which is the case at that point in
+ * the chunked-upload flow) and SVG isn't in WordPress's default allowed
+ * mime list. Once the extension is allowed, the endpoint has to validate
+ * the actual bytes instead, since SVG — unlike jpg/pdf/zip — is markup a
+ * browser will execute.
+ *
+ * @package ppom-pro
+ */
+
+use PPOM\Files\Handler;
+
+/**
+ * @covers \PPOM\Files\Handler::sanitize_svg_file
+ */
+class Test_Svg_Upload_Sanitization extends WP_UnitTestCase {
+
+	/**
+	 * @param string $file_path Path to the file to sanitize.
+	 *
+	 * @return bool
+	 */
+	private function sanitize( $file_path ) {
+
+		$method = new ReflectionMethod( Handler::class, 'sanitize_svg_file' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null, $file_path );
+	}
+
+	/**
+	 * A benign SVG must still be accepted — this is the bug in #505.
+	 */
+	public function test_accepts_a_clean_svg() {
+
+		$file = tempnam( sys_get_temp_dir(), 'svg' );
+		file_put_contents( $file, '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><circle cx="5" cy="5" r="4"/></svg>' );
+
+		$this->assertTrue( $this->sanitize( $file ) );
+
+		$content = file_get_contents( $file );
+		$this->assertStringContainsString( '<circle', $content );
+
+		unlink( $file );
+	}
+
+	/**
+	 * Allowing the extension through means the content is the only thing left
+	 * guarding this endpoint, so a <script> tag must not survive.
+	 */
+	public function test_strips_script_tag() {
+
+		$file = tempnam( sys_get_temp_dir(), 'svg' );
+		file_put_contents( $file, '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script><rect width="10" height="10"/></svg>' );
+
+		$this->assertTrue( $this->sanitize( $file ) );
+
+		$content = file_get_contents( $file );
+		$this->assertStringNotContainsString( '<script', $content );
+		$this->assertStringContainsString( '<rect', $content );
+
+		unlink( $file );
+	}
+
+	/**
+	 * Event-handler attributes are as executable as a <script> tag.
+	 */
+	public function test_strips_event_handler_attribute() {
+
+		$file = tempnam( sys_get_temp_dir(), 'svg' );
+		file_put_contents( $file, '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"><rect width="10" height="10"/></svg>' );
+
+		$this->assertTrue( $this->sanitize( $file ) );
+
+		$content = file_get_contents( $file );
+		$this->assertStringNotContainsString( 'onload', $content );
+
+		unlink( $file );
+	}
+
+	/**
+	 * A javascript: URI is another route to script execution from a link/href.
+	 */
+	public function test_strips_javascript_uri() {
+
+		$file = tempnam( sys_get_temp_dir(), 'svg' );
+		file_put_contents( $file, '<svg xmlns="http://www.w3.org/2000/svg"><a xlink:href="javascript:alert(1)"><rect width="10" height="10"/></a></svg>' );
+
+		$this->assertTrue( $this->sanitize( $file ) );
+
+		$content = file_get_contents( $file );
+		$this->assertStringNotContainsString( 'javascript:', $content );
+
+		unlink( $file );
+	}
+
+	/**
+	 * Renaming an arbitrary file to .svg must not be enough to pass, now that
+	 * the extension alone is allowed through the mime allow-list.
+	 */
+	public function test_rejects_non_xml_content() {
+
+		$file = tempnam( sys_get_temp_dir(), 'svg' );
+		file_put_contents( $file, "\xFF\xD8\xFF\xE0not really xml" );
+
+		$this->assertFalse( $this->sanitize( $file ) );
+
+		unlink( $file );
+	}
+
+	/**
+	 * Valid XML that isn't SVG (e.g. some other renamed XML document) must
+	 * also be rejected — the root element has to be <svg>.
+	 */
+	public function test_rejects_xml_with_wrong_root_element() {
+
+		$file = tempnam( sys_get_temp_dir(), 'svg' );
+		file_put_contents( $file, '<html><body>hi</body></html>' );
+
+		$this->assertFalse( $this->sanitize( $file ) );
+
+		unlink( $file );
+	}
+}

--- a/tests/unit/src/Files/test-svg-upload-sanitization.php
+++ b/tests/unit/src/Files/test-svg-upload-sanitization.php
@@ -125,4 +125,75 @@ class Test_Svg_Upload_Sanitization extends WP_UnitTestCase {
 
 		unlink( $file );
 	}
+
+	/**
+	 * On PHP 8+, DOMDocument::loadXML('') throws a ValueError rather than
+	 * returning false, so a zero-byte .svg has to be rejected before that
+	 * call — otherwise the public upload endpoint would fatal instead of
+	 * returning its normal invalid-file JSON response.
+	 */
+	public function test_rejects_empty_file() {
+
+		$file = tempnam( sys_get_temp_dir(), 'svg' );
+		file_put_contents( $file, '' );
+
+		$this->assertFalse( $this->sanitize( $file ) );
+
+		unlink( $file );
+	}
+
+	/**
+	 * XML tag names are case-sensitive, so a denylist entry of "foreignobject"
+	 * never matches the real element name and the embedded-HTML attack
+	 * surface it exists to close survives untouched.
+	 */
+	public function test_strips_foreignobject_in_canonical_case() {
+
+		$file = tempnam( sys_get_temp_dir(), 'svg' );
+		file_put_contents( $file, '<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><div xmlns="http://www.w3.org/1999/xhtml">hi</div></foreignObject><rect width="10" height="10"/></svg>' );
+
+		$this->assertTrue( $this->sanitize( $file ) );
+
+		$content = file_get_contents( $file );
+		$this->assertStringNotContainsString( 'foreignObject', $content );
+		$this->assertStringContainsString( '<rect', $content );
+
+		unlink( $file );
+	}
+
+	/**
+	 * Same case-sensitivity gap for <animateTransform>.
+	 */
+	public function test_strips_animatetransform_in_canonical_case() {
+
+		$file = tempnam( sys_get_temp_dir(), 'svg' );
+		file_put_contents( $file, '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"><animateTransform attributeName="transform" type="rotate"/></rect></svg>' );
+
+		$this->assertTrue( $this->sanitize( $file ) );
+
+		$content = file_get_contents( $file );
+		$this->assertStringNotContainsString( 'animateTransform', $content );
+
+		unlink( $file );
+	}
+
+	/**
+	 * A browser strips tab/newline/CR from anywhere in a URL before reading
+	 * its scheme, so "java&#x09;script:" (an embedded tab, not leading
+	 * whitespace) still executes as javascript: once opened — even though a
+	 * naive `^\s*javascript:` match against the raw decoded value misses it.
+	 */
+	public function test_strips_javascript_uri_obfuscated_with_a_tab() {
+
+		$file = tempnam( sys_get_temp_dir(), 'svg' );
+		file_put_contents( $file, "<svg xmlns=\"http://www.w3.org/2000/svg\"><a xlink:href=\"java\tscript:alert(1)\"><rect width=\"10\" height=\"10\"/></a></svg>" );
+
+		$this->assertTrue( $this->sanitize( $file ) );
+
+		$content = file_get_contents( $file );
+		$this->assertStringNotContainsString( 'javascript:', $content );
+		$this->assertStringNotContainsString( "java\tscript", $content );
+
+		unlink( $file );
+	}
 }

--- a/tests/unit/src/Files/test-svg-upload-sanitization.php
+++ b/tests/unit/src/Files/test-svg-upload-sanitization.php
@@ -196,4 +196,36 @@ class Test_Svg_Upload_Sanitization extends WP_UnitTestCase {
 
 		unlink( $file );
 	}
+
+	/**
+	 * A DOCTYPE can declare an internal entity whose expansion is never an
+	 * inspectable element node without LIBXML_NOENT, so the <script> denylist
+	 * above never sees it — yet saveXML() writes the declaration and
+	 * reference back unchanged, and a browser rendering the file expands and
+	 * runs it. The whole file has to be rejected, not sanitized around.
+	 */
+	public function test_rejects_svg_with_doctype_entity_smuggling_script() {
+
+		$file = tempnam( sys_get_temp_dir(), 'svg' );
+		file_put_contents( $file, '<?xml version="1.0"?><!DOCTYPE svg [ <!ENTITY xss "<script>alert(1)</script>"> ]><svg xmlns="http://www.w3.org/2000/svg">&xss;<rect width="10" height="10"/></svg>' );
+
+		$this->assertFalse( $this->sanitize( $file ) );
+
+		unlink( $file );
+	}
+
+	/**
+	 * Even a DOCTYPE with no custom entity is rejected — SVGs have no
+	 * legitimate need for one, so there's no reason to parse further to
+	 * check whether a given DOCTYPE happens to be harmless.
+	 */
+	public function test_rejects_svg_with_benign_doctype() {
+
+		$file = tempnam( sys_get_temp_dir(), 'svg' );
+		file_put_contents( $file, '<?xml version="1.0"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>' );
+
+		$this->assertFalse( $this->sanitize( $file ) );
+
+		unlink( $file );
+	}
 }


### PR DESCRIPTION
## Summary

Fixes Codeinwp/ppom-pro#505 — uploading an `.svg` file through a "File upload" field always failed with `File type not valid - svg`, even after adding `svg` to the field's "File types" setting.

**Root cause**: `wp_check_filetype_and_ext()` only does a real content sniff when the target path already exists on disk. In `Handler::upload_file()` that check runs against the not-yet-written destination path (chunked upload, assembled later), so it always falls back to a pure extension/mime lookup. That lookup used `get_allowed_mime_types()` (WordPress core's default list) plus a tiny extra filter that only added `ai`/`eps` — SVG was never in that list, so it was rejected before a single byte was inspected. This is independent of the field's own "File types" setting, which is only ever used client-side to filter the OS file picker.

**Fix**: add `svg => image/svg+xml` to the allow-list so the extension passes, and — because that removes the only check SVG had — validate the actual content once the file is fully assembled on disk. SVG is markup a browser will execute, unlike the other types this endpoint accepts, so letting it through on extension alone would trade one bug for a stored-XSS hole. The new `Handler::sanitize_svg_file()`:
- rejects anything that isn't parseable XML rooted at `<svg>` (so a renamed non-SVG file is still rejected, same error message as before)
- otherwise strips `<script>`/`<foreignObject>`/other event-driven tags, any `on*` attribute, and `javascript:` URIs, then rewrites the file in place

This is a denylist over the well-known SVG XSS vectors via `DOMDocument`, not a full allowlist sanitizer — good enough for a product-options upload field; flagging in case this endpoint ever needs to withstand more adversarial input, at which point `enshrined/svg-sanitize` would be the next step.

## Test plan

- [x] Unit tests added: `tests/unit/src/Files/test-svg-upload-sanitization.php` (clean SVG accepted, `<script>`/`onload`/`javascript:` stripped, non-XML and wrong-root-element rejected) — covered by `test-php.yml` CI on this PR.
- [x] Manually verified end-to-end on a live install: File upload field with `svg` added to "File types", uploaded as a **logged-out** guest on the product page (this is the case in the original report, and the reason `Safe SVG` didn't fully solve it — it gates on a login/capability check) — upload succeeds, file appears under `wp-content/uploads/ppom_files/`.
- [ ] Please also re-check: existing `jpg`/`pdf`/`zip` uploads on the same field still work (no regression to the allow-list merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
